### PR TITLE
check token is still unspent after locking

### DIFF
--- a/integration/token/fungible/views/transfer.go
+++ b/integration/token/fungible/views/transfer.go
@@ -284,6 +284,7 @@ func (t *TransferWithSelectorView) Call(context view.Context) (any, error) {
 				if t.Retry {
 					time.Sleep(10 * time.Second)
 				}
+
 				continue
 			}
 
@@ -293,6 +294,7 @@ func (t *TransferWithSelectorView) Call(context view.Context) (any, error) {
 			// If an error occurs and retry has been asked, then wait first a bit
 			if err != nil && t.Retry {
 				time.Sleep(10 * time.Second)
+				
 				continue
 			}
 

--- a/integration/token/fungible/views/transfer.go
+++ b/integration/token/fungible/views/transfer.go
@@ -290,11 +290,11 @@ func (t *TransferWithSelectorView) Call(context view.Context) (any, error) {
 
 			// Select the request amount of tokens of the given type
 			ids, sum, err = selector.Select(context.Context(), ttx.GetWallet(context, t.Wallet), amount.Decimal(), t.Type)
-			
+
 			// If an error occurs and retry has been asked, then wait first a bit
 			if err != nil && t.Retry {
 				time.Sleep(10 * time.Second)
-				
+
 				continue
 			}
 

--- a/integration/token/fungible/views/transfer.go
+++ b/integration/token/fungible/views/transfer.go
@@ -260,33 +260,51 @@ func (t *TransferWithSelectorView) Call(context view.Context) (any, error) {
 	assert.NoError(err, "failed to convert to quantity")
 
 	if len(t.TokenIDs) == 0 {
-		// The sender uses the default token selector each transaction comes equipped with
-		selector, err := tx.Selector()
-		defer func() {
-			if err := tx.CloseSelector(); err != nil {
-				logger.Errorf("failed closing selector [%s]", err)
-			}
-		}()
-		assert.NoError(err, "failed getting token selector")
-
 		// The sender tries to select the requested amount of tokens of the passed type.
 		// If a failure happens, the sender retries up to 5 times, waiting 10 seconds after each failure.
 		// This is just an example, any other policy can be implemented.
 		var ids []*token.ID
 		var sum token.Quantity
 
-		for range 5 {
-			// Select the request amount of tokens of the given type
-			ids, sum, err = selector.Select(context.Context(), ttx.GetWallet(context, t.Wallet), amount.Decimal(), t.Type)
-			// If an error occurs and retry has been asked, then wait first a bit
-			if err != nil && t.Retry {
-				time.Sleep(10 * time.Second)
+		for i := range 5 {
+			// Close previous selector before creating a new one (except on first iteration)
+			if i > 0 {
+				if err := tx.CloseSelector(); err != nil {
+					logger.Warnf("failed closing selector on retry %d: %s", i, err)
+				}
+			}
 
+			// Get a fresh selector for each retry attempt to avoid stale lock state
+			selector, err := tx.Selector()
+			if err != nil {
+				logger.Errorf("failed getting token selector on attempt %d: %s", i+1, err)
+				if i == 4 { // Last attempt
+					assert.NoError(err, "failed getting token selector")
+				}
+				if t.Retry {
+					time.Sleep(10 * time.Second)
+				}
 				continue
 			}
 
+			// Select the request amount of tokens of the given type
+			ids, sum, err = selector.Select(context.Context(), ttx.GetWallet(context, t.Wallet), amount.Decimal(), t.Type)
+			
+			// If an error occurs and retry has been asked, then wait first a bit
+			if err != nil && t.Retry {
+				time.Sleep(10 * time.Second)
+				continue
+			}
+
+			// Success or non-retryable error - break out
 			break
 		}
+
+		// Always close the selector when done with all attempts
+		if closeErr := tx.CloseSelector(); closeErr != nil {
+			logger.Warnf("failed closing selector after all attempts: %s", closeErr)
+		}
+
 		if err != nil {
 			// If finally not enough tokens were available, the sender can check what was the cause of the error:
 			switch {

--- a/token/services/selector/sherdlock/selector.go
+++ b/token/services/selector/sherdlock/selector.go
@@ -197,6 +197,50 @@ func (s *Selector) selectInternal(ctx context.Context, owner token.OwnerFilter, 
 			tokensLockedByOthersExist = true
 		} else {
 			s.logger.DebugfContext(ctx, "Got the lock on token [%v]", t)
+			
+			// Verify token still exists and is unspent after acquiring lock
+			found := false
+			verifyIter, err := s.fetcher.UnspentTokensIteratorBy(ctx, owner.ID(), tokenType)
+			if err != nil {
+				return nil, nil, immediateRetries, errors.Wrapf(err, "failed to verify token after lock [%s:%s]", owner.ID(), tokenType)
+			}
+			
+			// Search for our locked token in the fresh iterator
+			for {
+				tok, err := verifyIter.Next()
+				if err != nil {
+					verifyIter.Close()
+					return nil, nil, immediateRetries, errors.Wrapf(err, "error iterating tokens during verification")
+				}
+				if tok == nil {
+					break
+				}
+				if tok.Id.TxId == t.Id.TxId && tok.Id.Index == t.Id.Index {
+					found = true
+					break
+				}
+			}
+			verifyIter.Close()
+			
+			if !found {
+				// Token was spent before lock completed - unlock and continue searching
+				s.logger.DebugfContext(ctx, "Token [%v] was spent before lock completed, unlocking and continuing", t.Id)
+				if unlockErr := s.locker.UnlockAll(ctx); unlockErr != nil {
+					s.logger.Warnf("failed to unlock after detecting spent token: %v", unlockErr)
+				}
+				tokensLockedByOthersExist = true
+				// Reset cache to continue iteration
+				if s.cache, err = s.fetcher.UnspentTokensIteratorBy(ctx, owner.ID(), tokenType); err != nil {
+					return nil, nil, immediateRetries, errors.Wrapf(err, "failed to reset cache after spent token detection")
+				}
+				continue
+			}
+			
+			// Token verified as unspent - reset cache for next iteration
+			if s.cache, err = s.fetcher.UnspentTokensIteratorBy(ctx, owner.ID(), tokenType); err != nil {
+				return nil, nil, immediateRetries, errors.Wrapf(err, "failed to reset cache after verification")
+			}
+
 			q, err := token2.ToQuantity(t.Quantity, s.precision)
 			if err != nil {
 				return nil, nil, immediateRetries, errors.Wrapf(err, "invalid token [%s] found", t.Id)

--- a/token/services/selector/sherdlock/selector.go
+++ b/token/services/selector/sherdlock/selector.go
@@ -197,14 +197,14 @@ func (s *Selector) selectInternal(ctx context.Context, owner token.OwnerFilter, 
 			tokensLockedByOthersExist = true
 		} else {
 			s.logger.DebugfContext(ctx, "Got the lock on token [%v]", t)
-			
+
 			// Verify token still exists and is unspent after acquiring lock
 			found := false
 			verifyIter, err := s.fetcher.UnspentTokensIteratorBy(ctx, owner.ID(), tokenType)
 			if err != nil {
 				return nil, nil, immediateRetries, errors.Wrapf(err, "failed to verify token after lock [%s:%s]", owner.ID(), tokenType)
 			}
-			
+
 			// Search for our locked token in the fresh iterator
 			for {
 				tok, err := verifyIter.Next()
@@ -224,7 +224,7 @@ func (s *Selector) selectInternal(ctx context.Context, owner token.OwnerFilter, 
 				}
 			}
 			verifyIter.Close()
-			
+
 			if !found {
 				// Token was spent before lock completed - unlock and continue searching
 				s.logger.DebugfContext(ctx, "Token [%v] was spent before lock completed, unlocking and continuing", t.Id)
@@ -239,7 +239,7 @@ func (s *Selector) selectInternal(ctx context.Context, owner token.OwnerFilter, 
 
 				continue
 			}
-			
+
 			// Token verified as unspent - reset cache for next iteration
 			if s.cache, err = s.fetcher.UnspentTokensIteratorBy(ctx, owner.ID(), tokenType); err != nil {
 				return nil, nil, immediateRetries, errors.Wrapf(err, "failed to reset cache after verification")

--- a/token/services/selector/sherdlock/selector.go
+++ b/token/services/selector/sherdlock/selector.go
@@ -210,13 +210,16 @@ func (s *Selector) selectInternal(ctx context.Context, owner token.OwnerFilter, 
 				tok, err := verifyIter.Next()
 				if err != nil {
 					verifyIter.Close()
+
 					return nil, nil, immediateRetries, errors.Wrapf(err, "error iterating tokens during verification")
 				}
+
 				if tok == nil {
 					break
 				}
 				if tok.Id.TxId == t.Id.TxId && tok.Id.Index == t.Id.Index {
 					found = true
+
 					break
 				}
 			}
@@ -233,6 +236,7 @@ func (s *Selector) selectInternal(ctx context.Context, owner token.OwnerFilter, 
 				if s.cache, err = s.fetcher.UnspentTokensIteratorBy(ctx, owner.ID(), tokenType); err != nil {
 					return nil, nil, immediateRetries, errors.Wrapf(err, "failed to reset cache after spent token detection")
 				}
+
 				continue
 			}
 			

--- a/token/services/selector/sherdlock/selector.go
+++ b/token/services/selector/sherdlock/selector.go
@@ -59,6 +59,7 @@ type StubbornSelector struct {
 
 func (m *StubbornSelector) Select(ctx context.Context, ownerFilter token.OwnerFilter, q string, tokenType token2.Type) ([]*token2.ID, token2.Quantity, error) {
 	start := time.Now()
+	var lastErr error
 	for retriesAfterBackoff := 0; retriesAfterBackoff <= m.maxRetriesAfterBackoff; retriesAfterBackoff++ {
 		if tokens, quantity, err := m.selectWithoutMetrics(ctx, ownerFilter, q, tokenType); err == nil || !errors.Is(err, token.SelectorSufficientButLockedFunds) {
 			m.metrics.SelectionDuration.Observe(time.Since(start).Seconds())
@@ -71,6 +72,8 @@ func (m *StubbornSelector) Select(ctx context.Context, ownerFilter token.OwnerFi
 			}
 
 			return tokens, quantity, err
+		} else {
+			lastErr = err
 		}
 		var backoffDuration time.Duration
 		if m.backoffInterval > 0 {
@@ -94,6 +97,11 @@ func (m *StubbornSelector) Select(ctx context.Context, ownerFilter token.OwnerFi
 	m.metrics.SelectionDuration.Observe(time.Since(start).Seconds())
 	m.metrics.SelectionOutcome.With(outcomeLabel, "locked_funds").Add(1)
 
+	// Preserve the detailed error message from the last attempt
+	if lastErr != nil {
+		
+		return nil, nil, errors.Wrapf(lastErr, "aborted too many times and no other process unlocked or added tokens")
+	}
 	return nil, nil, errors.Wrapf(token.SelectorInsufficientFunds, "aborted too many times and no other process unlocked or added tokens")
 }
 

--- a/token/services/selector/sherdlock/selector.go
+++ b/token/services/selector/sherdlock/selector.go
@@ -99,9 +99,9 @@ func (m *StubbornSelector) Select(ctx context.Context, ownerFilter token.OwnerFi
 
 	// Preserve the detailed error message from the last attempt
 	if lastErr != nil {
-		
 		return nil, nil, errors.Wrapf(lastErr, "aborted too many times and no other process unlocked or added tokens")
 	}
+
 	return nil, nil, errors.Wrapf(token.SelectorInsufficientFunds, "aborted too many times and no other process unlocked or added tokens")
 }
 

--- a/token/services/selector/sherdlock/selector_test.go
+++ b/token/services/selector/sherdlock/selector_test.go
@@ -27,15 +27,18 @@ func TestSelectorUnit(t *testing.T) {
 		mockLocker := &mocks.FakeTokenLocker{}
 		s := sherdlock.NewSelector(sherdlock.Logger(), mockFetcher, mockLocker, 64, metrics)
 
-		mockIt := &mocks.FakeIterator[*token2.UnspentTokenInWallet]{}
-		mockIt.NextReturnsOnCall(0, &token2.UnspentTokenInWallet{
-			Id:       token2.ID{TxId: "tx1", Index: 0},
-			Type:     "ABC",
-			Quantity: "100",
-		}, nil)
-		mockIt.NextReturnsOnCall(1, nil, nil)
-
-		mockFetcher.UnspentTokensIteratorByReturns(mockIt, nil)
+		// Use a stub to return fresh iterators on each call
+		mockFetcher.UnspentTokensIteratorByStub = func(ctx context.Context, walletID string, tokenType token2.Type) (sherdlock.Iterator[*token2.UnspentTokenInWallet], error) {
+			mockIt := &mocks.FakeIterator[*token2.UnspentTokenInWallet]{}
+			mockIt.NextReturnsOnCall(0, &token2.UnspentTokenInWallet{
+				Id:       token2.ID{TxId: "tx1", Index: 0},
+				Type:     "ABC",
+				Quantity: "100",
+			}, nil)
+			mockIt.NextReturnsOnCall(1, nil, nil)
+			
+			return mockIt, nil
+		}
 		mockLocker.TryLockReturns(true)
 
 		tokens, sum, err := s.Select(t.Context(), &unitTestMockOwnerFilter{id: "alice"}, "50", "ABC")

--- a/token/services/selector/sherdlock/selector_test.go
+++ b/token/services/selector/sherdlock/selector_test.go
@@ -36,7 +36,7 @@ func TestSelectorUnit(t *testing.T) {
 				Quantity: "100",
 			}, nil)
 			mockIt.NextReturnsOnCall(1, nil, nil)
-			
+
 			return mockIt, nil
 		}
 		mockLocker.TryLockReturns(true)

--- a/token/services/selector/simple/selector.go
+++ b/token/services/selector/simple/selector.go
@@ -198,7 +198,7 @@ func (s *selector) selectByID(ctx context.Context, ownerFilter token.OwnerFilter
 
 			return nil, nil, errors.WithMessagef(
 				token.SelectorInsufficientFunds,
-				"token selection failed: insufficient funds, only [%s] tokens of type [%s] are available", sum.Decimal(), tokenType,
+				"token selection failed: insufficient funds, only [%s] tokens of type [%s] are available, but [%s] were requested", sum.Decimal(), tokenType, target.Decimal(),
 			)
 		}
 


### PR DESCRIPTION
When dealing with a transaction a token is checked for being unspent and then is locked for the transaction.
This PR checks the token is still unspent after the lock to catch a case where the token was spent in the time window between checking it was unspent and locking it.
Addresses issue #1632 
