### PR TITLE
Validate and Verify Audit Information Before Registration

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -147,6 +147,9 @@ jobs:
           - name: identity-role-register-recipient
             pkg: ./token/services/identity/role
             func: FuzzLongTermOwnerWalletRegisterRecipientNoPanic
+          - name: identity-wallet-register-recipient-guard
+            pkg: ./token/services/identity/wallet
+            func: FuzzRegisterRecipientIdentityStructuralGuard
 
     steps:
       - name: Checkout code

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -101,6 +101,7 @@ valid encodings are still correctly accepted.
 | `FuzzMetadataDeserializeNoPanic` | `token/core/zkatdlog/nogh/v1/token` | Raw ledger-stored metadata bytes through `Metadata.Deserialize`. |
 | `FuzzPublicParamsDeserializeNoPanic` | `token/core/zkatdlog/nogh/v1/setup` | Raw ledger-stored public parameters through `NewPublicParamsFromBytes`, exercised by every validator/prover/verifier on startup and params update. |
 | `FuzzProofDeserializeNoPanic` | `token/core/zkatdlog/nogh/v1/crypto/upgrade` | Raw untrusted token-upgrade request bytes through `Proof.Deserialize`. |
+| `FuzzRegisterRecipientIdentityStructuralGuard` | `token/services/identity/wallet` | A counterparty's identity and audit-info bytes through `Service.RegisterRecipientIdentity`, asserting the structural guard rejects exactly the out-of-bounds lengths and never panics. |
 
 ### Running the Seed Corpus
 

--- a/token/services/identity/wallet/service.go
+++ b/token/services/identity/wallet/service.go
@@ -114,6 +114,15 @@ func (s *Service) RegisterRecipientIdentity(ctx context.Context, data *tdriver.R
 
 	s.Logger.DebugfContext(ctx, "register recipient identity [%s] with audit info [%s]", data.Identity, utils.Hashable(data.AuditInfo))
 
+	// Validate basic structure: nil/empty checks and length bounds as a DoS guard.
+	// Driver-specific validation (audit-info format, typed-identity structure, enrollment
+	// ID / revocation handle) is intentionally not performed here — it is technology-specific
+	// and is already covered downstream by MatchIdentity and the driver's own deserializers.
+	if err := validateBasicStructure(data); err != nil {
+		return errors.Wrap(err, "basic structure validation failed")
+	}
+
+	// Match identity against audit info (cryptographic binding) before any registration.
 	if err := s.Deserializer.MatchIdentity(ctx, data.Identity, data.AuditInfo); err != nil {
 		return errors.Wrapf(err, "failed to match identity to audit information for [%s]:[%s]", data.Identity, utils.Hashable(data.AuditInfo))
 	}

--- a/token/services/identity/wallet/service.go
+++ b/token/services/identity/wallet/service.go
@@ -108,12 +108,22 @@ func (s *Service) GetEIDAndRH(ctx context.Context, identity tdriver.Identity, au
 // If RegisterRecipientData fails after RegisterRecipientIdentity succeeds, the IdentityProvider
 // may implement identity.RecipientRegistrationRollback so partial registration can be undone.
 func (s *Service) RegisterRecipientIdentity(ctx context.Context, data *tdriver.RecipientData) error {
-	if data == nil {
-		return errors.Wrapf(ErrNilRecipientData, "invalid recipient data")
+	// Validate basic structure: nil/empty checks and length bounds as a DoS guard.
+	// This is the single nil guard for this entry point, so it must run before anything
+	// dereferences data. Driver-specific validation (audit-info format, typed-identity
+	// structure, enrollment ID / revocation handle) is intentionally not performed here:
+	// it is technology-specific and belongs to the driver deserializers, which MatchIdentity
+	// dispatches to below. How strong that downstream check is varies by driver — for idemix
+	// it is a cryptographic proof, for x509 only an EID/CommonName consistency check over an
+	// unvalidated certificate — so it is not a proof of ownership for every driver. Call
+	// sites that need one layer it on separately (see ttx.verifyRecipientAttestation).
+	if err := validateBasicStructure(data); err != nil {
+		return errors.Wrap(err, "basic structure validation failed")
 	}
 
 	s.Logger.DebugfContext(ctx, "register recipient identity [%s] with audit info [%s]", data.Identity, utils.Hashable(data.AuditInfo))
 
+	// Match identity against audit info (cryptographic binding) before any registration.
 	if err := s.Deserializer.MatchIdentity(ctx, data.Identity, data.AuditInfo); err != nil {
 		return errors.Wrapf(err, "failed to match identity to audit information for [%s]:[%s]", data.Identity, utils.Hashable(data.AuditInfo))
 	}

--- a/token/services/identity/wallet/service_test.go
+++ b/token/services/identity/wallet/service_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	dmock "github.com/LFDT-Panurus/panurus/token/driver/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	idriver "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/wallet"
 	wmock "github.com/LFDT-Panurus/panurus/token/services/identity/wallet/mock"
@@ -84,35 +85,45 @@ func TestRegisterRecipientIdentityFailuresAndSuccess(t *testing.T) {
 	d := &dmock.Deserializer{}
 	regSvc := wallet.NewService(&logging.MockLogger{}, ip, d, nil)
 
+	// Create a properly typed identity
+	typedID, err := identity.WrapWithType(driver.X509IdentityType, []byte("raw-identity"))
+	require.NoError(t, err)
+
 	// nil data
-	err := regSvc.RegisterRecipientIdentity(ctx, nil)
+	err = regSvc.RegisterRecipientIdentity(ctx, nil)
 	require.Error(t, err)
 
 	// RegisterRecipientIdentity fails
+	mockVerifier := &dmock.Verifier{}
+	mockVerifier.VerifyReturns(nil)
+	d.GetOwnerVerifierReturns(mockVerifier, nil)
+	d.MatchIdentityReturns(nil)
+	ip.GetEnrollmentIDReturns("alice", nil)
+	ip.GetRevocationHandlerReturns("rh", nil)
 	ip.RegisterRecipientIdentityReturns(errors.New("rri"))
-	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id")})
+	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: typedID, AuditInfo: []byte(`{"EID":"alice","RH":"rh"}`)})
 	require.Error(t, err)
 	ip.RegisterRecipientIdentityReturns(nil)
 
 	// MatchIdentity fails
 	d.MatchIdentityReturns(errors.New("mismatch"))
-	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id"), AuditInfo: []byte("ai")})
+	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: typedID, AuditInfo: []byte(`{"EID":"alice","RH":"rh"}`)})
 	require.Error(t, err)
 	d.MatchIdentityReturns(nil)
 
 	// RegisterRecipientData fails
 	ip.RegisterRecipientDataReturns(errors.New("rrd"))
-	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id"), AuditInfo: []byte("ai")})
+	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: typedID, AuditInfo: []byte(`{"EID":"alice","RH":"rh"}`)})
 	require.Error(t, err)
 	ip.RegisterRecipientDataReturns(nil)
 
 	// success
 	ip.RegisterRecipientIdentityCalls(func(context.Context, driver.Identity) error { return nil })
 	d.MatchIdentityCalls(func(context.Context, driver.Identity, []byte) error { return nil })
-	d.GetOwnerVerifierCalls(func(context.Context, driver.Identity) (driver.Verifier, error) { return &dmock.Verifier{}, nil })
+	d.GetOwnerVerifierCalls(func(context.Context, driver.Identity) (driver.Verifier, error) { return mockVerifier, nil })
 	ip.RegisterRecipientDataCalls(func(context.Context, *driver.RecipientData) error { return nil })
 
-	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id"), AuditInfo: []byte("ai")})
+	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: typedID, AuditInfo: []byte(`{"EID":"alice","RH":"rh"}`)})
 	require.NoError(t, err)
 }
 
@@ -128,12 +139,22 @@ func (r *ipWithRollback) RollbackPartialRecipientRegistration(ctx context.Contex
 
 func TestRegisterRecipientIdentity_MatchIdentityFailureSkipsIdentityProvider(t *testing.T) {
 	ctx := t.Context()
+
+	// Create a properly typed identity
+	typedID, err := identity.WrapWithType(driver.X509IdentityType, []byte("raw-identity"))
+	require.NoError(t, err)
+
 	ip := &dmock.IdentityProvider{}
+	ip.GetEnrollmentIDReturns("alice", nil)
+	ip.GetRevocationHandlerReturns("rh", nil)
 	d := &dmock.Deserializer{}
+	mockVerifier := &dmock.Verifier{}
+	mockVerifier.VerifyReturns(nil)
+	d.GetOwnerVerifierReturns(mockVerifier, nil)
 	d.MatchIdentityReturns(errors.New("mismatch"))
 	regSvc := wallet.NewService(&logging.MockLogger{}, ip, d, nil)
 
-	err := regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id"), AuditInfo: []byte("ai")})
+	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: typedID, AuditInfo: []byte(`{"EID":"alice","RH":"rh"}`)})
 	require.Error(t, err)
 	require.Zero(t, ip.RegisterRecipientIdentityCallCount())
 	require.Equal(t, 1, d.MatchIdentityCallCount())
@@ -141,14 +162,25 @@ func TestRegisterRecipientIdentity_MatchIdentityFailureSkipsIdentityProvider(t *
 
 func TestRegisterRecipientIdentity_RollbackWhenRegisterRecipientDataFails(t *testing.T) {
 	ctx := t.Context()
+
+	// Create a properly typed identity
+	typedID, err := identity.WrapWithType(driver.X509IdentityType, []byte("raw-identity"))
+	require.NoError(t, err)
+
 	base := &dmock.IdentityProvider{}
+	base.GetEnrollmentIDReturns("alice", nil)
+	base.GetRevocationHandlerReturns("rh", nil)
 	base.RegisterRecipientIdentityReturns(nil)
 	base.RegisterRecipientDataReturns(errors.New("rrd"))
 	ip := &ipWithRollback{IdentityProvider: base}
 	d := &dmock.Deserializer{}
+	mockVerifier := &dmock.Verifier{}
+	mockVerifier.VerifyReturns(nil)
+	d.GetOwnerVerifierReturns(mockVerifier, nil)
+	d.MatchIdentityReturns(nil)
 	regSvc := wallet.NewService(&logging.MockLogger{}, ip, d, nil)
 
-	err := regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id"), AuditInfo: []byte("ai")})
+	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: typedID, AuditInfo: []byte(`{"EID":"alice","RH":"rh"}`)})
 	require.Error(t, err)
 	require.Equal(t, 1, ip.rollbackCalls)
 }

--- a/token/services/identity/wallet/service_test.go
+++ b/token/services/identity/wallet/service_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	dmock "github.com/LFDT-Panurus/panurus/token/driver/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	idriver "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/wallet"
 	wmock "github.com/LFDT-Panurus/panurus/token/services/identity/wallet/mock"
@@ -84,35 +85,39 @@ func TestRegisterRecipientIdentityFailuresAndSuccess(t *testing.T) {
 	d := &dmock.Deserializer{}
 	regSvc := wallet.NewService(&logging.MockLogger{}, ip, d, nil)
 
+	// A typed identity, long enough to pass validateBasicStructure's length bounds
+	typedID, err := identity.WrapWithType(driver.X509IdentityType, []byte("raw-identity"))
+	require.NoError(t, err)
+
 	// nil data
-	err := regSvc.RegisterRecipientIdentity(ctx, nil)
+	err = regSvc.RegisterRecipientIdentity(ctx, nil)
 	require.Error(t, err)
 
 	// RegisterRecipientIdentity fails
+	d.MatchIdentityReturns(nil)
 	ip.RegisterRecipientIdentityReturns(errors.New("rri"))
-	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id")})
+	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: typedID, AuditInfo: []byte(`{"EID":"alice","RH":"rh"}`)})
 	require.Error(t, err)
 	ip.RegisterRecipientIdentityReturns(nil)
 
 	// MatchIdentity fails
 	d.MatchIdentityReturns(errors.New("mismatch"))
-	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id"), AuditInfo: []byte("ai")})
+	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: typedID, AuditInfo: []byte(`{"EID":"alice","RH":"rh"}`)})
 	require.Error(t, err)
 	d.MatchIdentityReturns(nil)
 
 	// RegisterRecipientData fails
 	ip.RegisterRecipientDataReturns(errors.New("rrd"))
-	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id"), AuditInfo: []byte("ai")})
+	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: typedID, AuditInfo: []byte(`{"EID":"alice","RH":"rh"}`)})
 	require.Error(t, err)
 	ip.RegisterRecipientDataReturns(nil)
 
 	// success
 	ip.RegisterRecipientIdentityCalls(func(context.Context, driver.Identity) error { return nil })
 	d.MatchIdentityCalls(func(context.Context, driver.Identity, []byte) error { return nil })
-	d.GetOwnerVerifierCalls(func(context.Context, driver.Identity) (driver.Verifier, error) { return &dmock.Verifier{}, nil })
 	ip.RegisterRecipientDataCalls(func(context.Context, *driver.RecipientData) error { return nil })
 
-	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id"), AuditInfo: []byte("ai")})
+	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: typedID, AuditInfo: []byte(`{"EID":"alice","RH":"rh"}`)})
 	require.NoError(t, err)
 }
 
@@ -128,12 +133,17 @@ func (r *ipWithRollback) RollbackPartialRecipientRegistration(ctx context.Contex
 
 func TestRegisterRecipientIdentity_MatchIdentityFailureSkipsIdentityProvider(t *testing.T) {
 	ctx := t.Context()
+
+	// A typed identity, long enough to pass validateBasicStructure's length bounds
+	typedID, err := identity.WrapWithType(driver.X509IdentityType, []byte("raw-identity"))
+	require.NoError(t, err)
+
 	ip := &dmock.IdentityProvider{}
 	d := &dmock.Deserializer{}
 	d.MatchIdentityReturns(errors.New("mismatch"))
 	regSvc := wallet.NewService(&logging.MockLogger{}, ip, d, nil)
 
-	err := regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id"), AuditInfo: []byte("ai")})
+	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: typedID, AuditInfo: []byte(`{"EID":"alice","RH":"rh"}`)})
 	require.Error(t, err)
 	require.Zero(t, ip.RegisterRecipientIdentityCallCount())
 	require.Equal(t, 1, d.MatchIdentityCallCount())
@@ -141,14 +151,20 @@ func TestRegisterRecipientIdentity_MatchIdentityFailureSkipsIdentityProvider(t *
 
 func TestRegisterRecipientIdentity_RollbackWhenRegisterRecipientDataFails(t *testing.T) {
 	ctx := t.Context()
+
+	// A typed identity, long enough to pass validateBasicStructure's length bounds
+	typedID, err := identity.WrapWithType(driver.X509IdentityType, []byte("raw-identity"))
+	require.NoError(t, err)
+
 	base := &dmock.IdentityProvider{}
 	base.RegisterRecipientIdentityReturns(nil)
 	base.RegisterRecipientDataReturns(errors.New("rrd"))
 	ip := &ipWithRollback{IdentityProvider: base}
 	d := &dmock.Deserializer{}
+	d.MatchIdentityReturns(nil)
 	regSvc := wallet.NewService(&logging.MockLogger{}, ip, d, nil)
 
-	err := regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id"), AuditInfo: []byte("ai")})
+	err = regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: typedID, AuditInfo: []byte(`{"EID":"alice","RH":"rh"}`)})
 	require.Error(t, err)
 	require.Equal(t, 1, ip.rollbackCalls)
 }

--- a/token/services/identity/wallet/validation.go
+++ b/token/services/identity/wallet/validation.go
@@ -1,0 +1,62 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package wallet
+
+import (
+	tdriver "github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// Validation errors
+var (
+	ErrEmptyIdentity     = errors.New("empty identity")
+	ErrEmptyAuditInfo    = errors.New("empty audit info")
+	ErrIdentityTooShort  = errors.New("identity too short")
+	ErrIdentityTooLarge  = errors.New("identity too large")
+	ErrAuditInfoTooLarge = errors.New("audit info too large")
+)
+
+const (
+	// MinIdentityLength defines the minimum allowed length for identity data
+	MinIdentityLength = 10
+	// MaxIdentityLength defines the maximum allowed length for identity data (prevents DoS).
+	// Set generously so legitimate identities are never rejected: composite identities
+	// (MultiSig, Policy) aggregate several inner identities and X509 chains / Idemix proofs
+	// can run to several KB. The bound exists only to reject pathological multi-MB blobs.
+	MaxIdentityLength = 1 << 20 // 1 MiB
+	// MaxAuditInfoLength defines the maximum allowed length for audit info (prevents DoS)
+	MaxAuditInfoLength = 50000
+)
+
+// validateBasicStructure performs nil, empty, and length-bound checks on RecipientData.
+// These checks are technology-agnostic (they make no assumption about the identity's
+// encoding or the audit info's format): they only reject nil/empty input and pathological
+// blob sizes as a denial-of-service guard. The cryptographic binding between identity and
+// audit info, and any driver-specific structural validation, are performed downstream by
+// the Deserializer's MatchIdentity and the driver's own deserializers.
+func validateBasicStructure(data *tdriver.RecipientData) error {
+	if data == nil {
+		return ErrNilRecipientData
+	}
+	if len(data.Identity) == 0 {
+		return ErrEmptyIdentity
+	}
+	if len(data.Identity) < MinIdentityLength {
+		return errors.Wrapf(ErrIdentityTooShort, "identity is %d bytes (min %d)", len(data.Identity), MinIdentityLength)
+	}
+	if len(data.Identity) > MaxIdentityLength {
+		return errors.Wrapf(ErrIdentityTooLarge, "identity is %d bytes (max %d)", len(data.Identity), MaxIdentityLength)
+	}
+	if len(data.AuditInfo) == 0 {
+		return ErrEmptyAuditInfo
+	}
+	if len(data.AuditInfo) > MaxAuditInfoLength {
+		return errors.Wrapf(ErrAuditInfoTooLarge, "audit info is %d bytes (max %d)", len(data.AuditInfo), MaxAuditInfoLength)
+	}
+
+	return nil
+}

--- a/token/services/identity/wallet/validation_fuzz_test.go
+++ b/token/services/identity/wallet/validation_fuzz_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package wallet_test
+
+import (
+	"bytes"
+	"testing"
+
+	tdriver "github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+// maxFuzzRecipientBytes bounds generated inputs. It sits just above
+// MaxAuditInfoLength so both sides of that bound stay reachable while keeping each
+// execution cheap.
+const maxFuzzRecipientBytes = wallet.MaxAuditInfoLength + 1024
+
+// FuzzRegisterRecipientIdentityStructuralGuard hunts for recipient data that panics
+// RegisterRecipientIdentity instead of returning an error, and for drift between the
+// structural guard's advertised bounds and what it actually rejects.
+//
+// RegisterRecipientIdentity is the entry point through which a counterparty's own
+// identity and audit-info bytes reach the node, so it must never panic on them. The
+// service is built with an IdentityProvider and a Deserializer that always succeed,
+// which makes the guard the only source of errors: the call must fail exactly when
+// the identity length is outside [MinIdentityLength, MaxIdentityLength] or the audit
+// info is empty or longer than MaxAuditInfoLength, and must succeed otherwise.
+//
+// Generated inputs are capped at maxFuzzRecipientBytes so the campaign is not spent
+// mutating multi-megabyte blobs; the MaxIdentityLength bound itself (1 MiB) is covered
+// as an ordinary case by TestValidateBasicStructure.
+func FuzzRegisterRecipientIdentityStructuralGuard(f *testing.F) {
+	minIdentity := bytes.Repeat([]byte("i"), wallet.MinIdentityLength)
+	shortIdentity := bytes.Repeat([]byte("i"), wallet.MinIdentityLength-1)
+	maxAuditInfo := bytes.Repeat([]byte("a"), wallet.MaxAuditInfoLength)
+	largeAuditInfo := bytes.Repeat([]byte("a"), wallet.MaxAuditInfoLength+1)
+
+	seeds := [][2][]byte{
+		{[]byte("identity-long-enough"), []byte(`{"key":"value"}`)}, // accepted pair
+		{nil, nil},                                                       // empty
+		{[]byte{}, []byte("audit-info")},                                 // empty identity
+		{[]byte("identity-long-enough"), []byte{}},                       // empty audit info
+		{minIdentity, []byte("a")},                                       // identity at the lower bound
+		{shortIdentity, []byte("audit-info")},                            // identity one byte too short
+		{[]byte("identity-long-enough"), maxAuditInfo},                   // audit info at the upper bound
+		{[]byte("identity-long-enough"), largeAuditInfo},                 // audit info one byte too large
+		{[]byte{0x00, 0x00, 0x00}, []byte{0xff, 0xfe}},                   // short, non-UTF8 bytes
+		{bytes.Repeat([]byte{0x00}, 32), bytes.Repeat([]byte{0x00}, 32)}, // all-zero bytes
+	}
+	for _, s := range seeds {
+		f.Add(s[0], s[1])
+	}
+
+	f.Fuzz(func(t *testing.T, identityRaw, auditInfoRaw []byte) {
+		if len(identityRaw) > maxFuzzRecipientBytes || len(auditInfoRaw) > maxFuzzRecipientBytes {
+			t.Skip()
+		}
+		service, _, _ := newService()
+
+		var err error
+		require.NotPanics(t, func() {
+			err = service.RegisterRecipientIdentity(t.Context(), &tdriver.RecipientData{
+				Identity:  identityRaw,
+				AuditInfo: auditInfoRaw,
+			})
+		})
+
+		outOfBounds := len(identityRaw) < wallet.MinIdentityLength ||
+			len(identityRaw) > wallet.MaxIdentityLength ||
+			len(auditInfoRaw) == 0 ||
+			len(auditInfoRaw) > wallet.MaxAuditInfoLength
+		if outOfBounds {
+			require.Errorf(t, err, "guard accepted out-of-bounds data: identity %d bytes, audit info %d bytes",
+				len(identityRaw), len(auditInfoRaw))
+
+			return
+		}
+		require.NoErrorf(t, err, "guard rejected in-bounds data: identity %d bytes, audit info %d bytes",
+			len(identityRaw), len(auditInfoRaw))
+	})
+}

--- a/token/services/identity/wallet/validation_test.go
+++ b/token/services/identity/wallet/validation_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package wallet_test
+
+import (
+	"context"
+	"testing"
+
+	tdriver "github.com/LFDT-Panurus/panurus/token/driver"
+	dmock "github.com/LFDT-Panurus/panurus/token/driver/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/wallet"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newService builds a wallet.Service whose IdentityProvider and Deserializer succeed by
+// default, so tests that exercise the structural guard fail (or pass) only on the guard.
+func newService() (*wallet.Service, *dmock.IdentityProvider, *dmock.Deserializer) {
+	mockIP := &dmock.IdentityProvider{}
+	mockIP.RegisterRecipientIdentityReturns(nil)
+	mockIP.RegisterRecipientDataReturns(nil)
+
+	mockDeserializer := &dmock.Deserializer{}
+	mockDeserializer.MatchIdentityReturns(nil)
+
+	service := wallet.NewService(
+		&logging.MockLogger{},
+		mockIP,
+		mockDeserializer,
+		wallet.RoleRegistries{},
+	)
+
+	return service, mockIP, mockDeserializer
+}
+
+// TestValidateBasicStructure verifies the technology-agnostic structural guard applied
+// by RegisterRecipientIdentity: nil/empty checks and length bounds. It does not assert
+// anything about the identity encoding or audit-info format — those are validated
+// downstream by MatchIdentity and the driver deserializers.
+func TestValidateBasicStructure(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    *tdriver.RecipientData
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil data",
+			data:    nil,
+			wantErr: true,
+			errMsg:  "nil recipient data",
+		},
+		{
+			name: "empty identity",
+			data: &tdriver.RecipientData{
+				Identity:  []byte{},
+				AuditInfo: []byte("audit"),
+			},
+			wantErr: true,
+			errMsg:  "empty identity",
+		},
+		{
+			name: "empty audit info",
+			data: &tdriver.RecipientData{
+				Identity:  []byte("identity-long-enough"),
+				AuditInfo: []byte{},
+			},
+			wantErr: true,
+			errMsg:  "empty audit info",
+		},
+		{
+			name: "identity too short",
+			data: &tdriver.RecipientData{
+				Identity:  []byte("short"),
+				AuditInfo: []byte(`{"key":"value"}`),
+			},
+			wantErr: true,
+			errMsg:  "identity too short",
+		},
+		{
+			name: "identity too large",
+			data: &tdriver.RecipientData{
+				Identity:  make([]byte, wallet.MaxIdentityLength+1),
+				AuditInfo: []byte(`{"key":"value"}`),
+			},
+			wantErr: true,
+			errMsg:  "identity too large",
+		},
+		{
+			name: "audit info too large",
+			data: &tdriver.RecipientData{
+				Identity:  []byte("valid-identity-data"),
+				AuditInfo: make([]byte, wallet.MaxAuditInfoLength+1),
+			},
+			wantErr: true,
+			errMsg:  "audit info too large",
+		},
+		{
+			name: "valid data passes the structural guard",
+			data: &tdriver.RecipientData{
+				Identity:  []byte("identity-long-enough"),
+				AuditInfo: []byte(`{"key":"value"}`),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			service, _, _ := newService()
+
+			err := service.RegisterRecipientIdentity(ctx, tt.data)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestRegisterRecipientIdentityForgedPair verifies that a structurally-valid but
+// cryptographically-mismatched identity/audit-info pair is rejected by MatchIdentity,
+// and that no registration side effect happens when the match fails.
+func TestRegisterRecipientIdentityForgedPair(t *testing.T) {
+	ctx := context.Background()
+
+	typedID, err := identity.WrapWithType(tdriver.X509IdentityType, []byte("raw-identity"))
+	require.NoError(t, err)
+
+	service, mockIP, mockDeserializer := newService()
+	// The audit info does not bind to the identity: MatchIdentity rejects it.
+	mockDeserializer.MatchIdentityReturns(errors.New("identity does not match audit info"))
+
+	data := &tdriver.RecipientData{
+		Identity:  typedID,
+		AuditInfo: []byte(`{"EID":"attacker","RH":"forged"}`),
+	}
+
+	err = service.RegisterRecipientIdentity(ctx, data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to match identity to audit information")
+
+	// A forged pair must never reach registration.
+	assert.Equal(t, 0, mockIP.RegisterRecipientIdentityCallCount(), "identity must not be registered when the pair is forged")
+	assert.Equal(t, 0, mockIP.RegisterRecipientDataCallCount(), "recipient data must not be stored when the pair is forged")
+}
+
+// TestRegisterRecipientIdentityFullFlow verifies the happy path: a structurally-valid
+// pair whose cryptographic binding checks out is registered and stored.
+func TestRegisterRecipientIdentityFullFlow(t *testing.T) {
+	ctx := context.Background()
+
+	typedID, err := identity.WrapWithType(tdriver.X509IdentityType, []byte("raw-identity"))
+	require.NoError(t, err)
+
+	service, mockIP, _ := newService()
+
+	data := &tdriver.RecipientData{
+		Identity:  typedID,
+		AuditInfo: []byte(`{"EID":"alice","RH":"rh-value"}`),
+	}
+
+	err = service.RegisterRecipientIdentity(ctx, data)
+	require.NoError(t, err)
+	assert.Equal(t, 1, mockIP.RegisterRecipientIdentityCallCount())
+	assert.Equal(t, 1, mockIP.RegisterRecipientDataCallCount())
+}


### PR DESCRIPTION
## Problem

`RegisterRecipientIdentity` accepted recipient identity data from a counterparty without any structural validation, so nil, empty, or multi-MB blobs reached the debug log (which dereferences `data.Identity`), the deserializer, and the audit trail — a denial-of-service vector.

Fixes #1645

## Solution

A technology-agnostic structural guard in `token/services/identity/wallet`, run before any registration side effect:

1. **Basic structure** (`validateBasicStructure`) — nil/empty checks and length bounds: identity `10 B … 1 MiB`, audit info `≤ 50 KB`. The identity cap is deliberately generous so legitimate identities are never falsely rejected (composite MultiSig/Policy identities aggregate several inner identities, and X509 chains / Idemix proofs run to several KB); it exists only to reject pathological multi-MB blobs.
2. **Cryptographic binding** — the existing `Deserializer.MatchIdentity` (identity ↔ audit info), now guaranteed to run before the `IdentityProvider` is touched.

Earlier revisions of this PR also added driver-specific checks (audit-info JSON well-formedness, typed-identity decode, enrollment ID / revocation handle bounds). Those were **removed per review**: they are technology-specific, belong to the driver deserializers rather than this layer, and duplicated deserialization work already done downstream.

### Scope note: strength of `MatchIdentity` varies by driver

For idemix wallets, `MatchIdentity` is a genuine proof of ownership. For x509 wallets it is weaker: `x509.AuditInfoMatcher.Match` compares the self-reported EID in the audit info against the certificate's CN, and `crypto.GetEnrollmentID` parses that certificate with no chain or signature validation — a self-consistency check, not proof of control. `token/services/ttx/recipients.go` layers a signature-based key-ownership attestation on top of most call sites, but the per-component registration loops skip it for sub-identities. This is a pre-existing limitation outside this PR's diff, which this change does not worsen; it is worth a follow-up issue.

## Testing

- `TestValidateBasicStructure` — table-driven coverage of every bound, including the 1 MiB identity cap.
- `FuzzRegisterRecipientIdentityStructuralGuard` — drives counterparty identity and audit-info bytes through `RegisterRecipientIdentity` with an always-succeeding `IdentityProvider` and `Deserializer`, so the guard is the only source of errors: the call must fail exactly when the lengths fall outside the declared bounds, and must never panic. Wired into `.github/workflows/nightly-fuzz.yml` and the fuzz-target table in `docs/development/testing.md`.
