### PR TITLE
feat(storage): service-wide, stackable guard layer for API limits (#1630)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -798,6 +798,42 @@ to `<params>_<short_code>` (params still apply when provided; short-code overrid
 
 ---
 
+### Optional: token.storage.maxPayloadSize
+
+Maximum serialised size, in bytes, accepted by a single storage-service write
+(applies across the transaction, token, endorser, identity, and wallet stores).
+Writes whose payload exceeds this size are rejected before reaching the database.
+A value of `0` disables the check. When the key is absent, the default (4 MiB) applies.
+
+```yaml
+token:
+  storage:
+    maxPayloadSize: 4194304   # 4 MiB
+```
+
+---
+
+### Optional: token.storage.maxPageSize
+
+Maximum page size a paginated storage-service read may request, so an unlimited scan
+cannot exhaust database resources. A query that asks for an unbounded page (`nil` or
+`pagination.None()`) or a page larger than this value is rejected; callers page
+through the full result set instead. When the key is absent, the default (1000)
+applies.
+
+```yaml
+token:
+  storage:
+    maxPageSize: 1000
+```
+
+This bounds the paginated reads only. Streaming iterator reads are deliberately not
+row-capped, because they accept no page size for the caller to comply with — see
+[Storage API Limits](services/storage.md#storage-api-limits) for the full list and
+the reasoning, including why movement/balance queries are never row-capped.
+
+---
+
 ### Optional: token.tms.<name>.services.storage.cleanup
 
 If not specified, the default configuration is:

--- a/docs/services/storage.md
+++ b/docs/services/storage.md
@@ -356,3 +356,64 @@ The cleanup service supports both PostgreSQL and SQLite backends, with different
 Cleanup behavior is controlled by the configuration section. See the [Configuration Guide](../configuration.md) for detailed parameter descriptions and tuning recommendations.
 
 See the [Configuration Guide](../configuration.md), Section `Optional: token.tms.<name>.services.network.fabric.recovery`, for detailed parameter descriptions and tuning recommendations.
+
+## Storage API Limits
+
+The storage service limits its writes and reads so one huge write or one runaway
+query can't exhaust the database (issue #1630, CWE-400 / CWE-770). The limits are
+enforced by a single, stackable **guard** decorator layer
+(`token/services/storage/db/guard/`) applied once at the multiplexed driver
+(`token/services/storage/db/multiplexed/driver.go`) as each store is created, so
+every backing driver (SQLite, PostgreSQL) and every store is covered by the same
+mechanism. The decorators embed the store interfaces and override only the methods
+that need a check, delegating everything else — new layers (metrics, tracing) can be
+stacked the same way, with the concrete SQL store at the bottom.
+
+A single `Policy` (`MaxPayloadSize`, `MaxPageSize`) drives every check. It is loaded
+once from configuration; absent keys fall back to the built-in defaults, and an
+explicit `0` disables that check.
+
+**Write size limit.** Writes whose serialised payload exceeds `maxPayloadSize`
+(default 4 MiB; `0` disables) are rejected before reaching the database. Covered
+writes include the transaction store's `AddTokenRequest` / `AddTransaction` /
+`AddMovement` / `AddTransactionEndorsementAck`, the token store's `StoreToken` /
+`StorePublicParams` / `StoreCertifications`, the endorser store's
+`AddValidationRecord`, the identity store's `StoreIdentityData` / `StoreSignerInfo` /
+`RegisterIdentityDescriptor` / `AddConfiguration`, and the wallet store's
+`StoreIdentity`.
+
+**Read size limit.** `maxPageSize` (default 1000) bounds the paginated reads —
+currently `QueryTransactions` on the owner and audit transaction stores. Those
+reads require a bounded page: `nil` and `pagination.None()` are rejected, as is a
+page size larger than `maxPageSize`. Callers page through the full result set.
+
+Rejecting the request is only a safe way to bound a read when the caller has a way
+to comply, so the cap is applied exactly to the reads that accept a pagination
+argument. Streaming iterator reads are **not** row-capped:
+
+- The token store's unspent/spendable/unsupported iterators, the endorser store's
+  `QueryValidations`, the transaction store's `QueryTokenRequests`, and the identity
+  store's `IteratorConfigurations` all take no page size or cursor, and their
+  consumers drain them in full — the selectors and integrity checks for the token
+  iterators, and `LocalMembership.storedIdentityConfigurations` on the identity
+  `Load` path for `IteratorConfigurations`. Capping any of them would turn a large
+  but legitimate dataset into a hard failure that the caller cannot page around.
+- `QueryMovements` is uncapped for a second reason: it feeds balance totals, so
+  dropping rows would quietly return wrong balances. It is already narrowed by its
+  required filters.
+
+You can override the limits in configuration (`token.storage.maxPayloadSize` /
+`token.storage.maxPageSize`) — see the [Configuration Guide](../configuration.md).
+
+**Not yet covered (tracked follow-up).** Two groups of reads cannot be bounded by a
+wrapper at all, and need query-level work instead:
+
+- The streaming iterators listed above. Bounding them requires a SQL-level `LIMIT`
+  on the query (with a defined order and documented truncation) or adding paging to
+  their signatures, so the caller can ask for the next page rather than fail.
+- Reads that materialise a full slice or map before returning (e.g.
+  `ListUnspentTokens`, `QueryTokenDetails`, `ConfigurationsByID`, `GetWalletIDs`) —
+  the SQL has already loaded everything by the time the decorator sees the result.
+
+The opaque `Keystore.Put` value and input-size caps for variadic id lists
+(`DeleteTokens`, `GetTokens`) are in the same follow-up.

--- a/integration/token/fungible/views/history.go
+++ b/integration/token/fungible/views/history.go
@@ -17,10 +17,49 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/services/ttx"
 	token2 "github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
+
+// historyPageSize is the number of rows fetched per page when listing all
+// transactions. It must stay <= the store's max page size.
+const historyPageSize = 100
+
+// collectAllTransactions pages through queryPage (one page per call) and returns
+// every record. queryPage runs the underlying query for the given pagination.
+//
+// The storage layer now rejects unlimited queries, so these trusted views can no
+// longer fetch everything in one call. This helper is only that adaptation: it
+// still accumulates the full result set in memory, so it is not itself a memory
+// safeguard. The actual DoS protection (rejecting unlimited scans, hard LIMITs)
+// lives in the storage layer; these views legitimately need the complete list.
+func collectAllTransactions(queryPage func(driver2.Pagination) (iterators.Iterator[*ttxdb.TransactionRecord], error)) ([]*ttxdb.TransactionRecord, error) {
+	var page driver2.Pagination
+	page, err := pagination.Offset(0, historyPageSize)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create pagination")
+	}
+	var all []*ttxdb.TransactionRecord
+	for {
+		items, err := queryPage(page)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed querying transactions")
+		}
+		records, err := iterators.ReadAllPointers(items)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed reading transactions")
+		}
+		all = append(all, records...)
+		if len(records) < historyPageSize {
+			return all, nil
+		}
+		if page, err = page.Next(); err != nil {
+			return nil, errors.Wrapf(err, "failed advancing pagination")
+		}
+	}
+}
 
 // ListIssuedTokens contains the input to query the list of issued tokens
 type ListIssuedTokens struct {
@@ -143,12 +182,14 @@ func (p *ListAuditedTransactionsView) Call(context view.Context) (any, error) {
 		return nil, errors.Wrapf(err, "failed to get auditor instance")
 	}
 
-	it, err := auditor.Transactions(context.Context(), ttxdb.QueryTransactionsParams{From: p.From, To: p.To, SearchDirection: p.SearchDirection}, pagination.None())
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed querying transactions")
-	}
+	return collectAllTransactions(func(page driver2.Pagination) (iterators.Iterator[*ttxdb.TransactionRecord], error) {
+		it, err := auditor.Transactions(context.Context(), ttxdb.QueryTransactionsParams{From: p.From, To: p.To, SearchDirection: p.SearchDirection}, page)
+		if err != nil {
+			return nil, err
+		}
 
-	return iterators.ReadAllPointers(it.Items)
+		return it.Items, nil
+	})
 }
 
 type ListAuditedTransactionsViewFactory struct{}
@@ -184,21 +225,24 @@ func (p *ListAcceptedTransactionsView) Call(context view.Context) (any, error) {
 	tms, err := token.GetManagementService(context, ServiceOpts(p.TMSID)...)
 	assert.NoError(err, "failed getting management service")
 	owner := ttx.NewOwner(context, tms)
-	it, err := owner.Transactions(context.Context(), ttxdb.QueryTransactionsParams{
-		SenderWallet:    p.SenderWallet,
-		RecipientWallet: p.RecipientWallet,
-		From:            p.From,
-		To:              p.To,
-		ActionTypes:     p.ActionTypes,
-		Statuses:        p.Statuses,
-		IDs:             p.IDs,
-		SearchDirection: p.SearchDirection,
-	}, pagination.None())
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed querying transactions")
-	}
 
-	return iterators.ReadAllPointers(it.Items)
+	return collectAllTransactions(func(page driver2.Pagination) (iterators.Iterator[*ttxdb.TransactionRecord], error) {
+		it, err := owner.Transactions(context.Context(), ttxdb.QueryTransactionsParams{
+			SenderWallet:    p.SenderWallet,
+			RecipientWallet: p.RecipientWallet,
+			From:            p.From,
+			To:              p.To,
+			ActionTypes:     p.ActionTypes,
+			Statuses:        p.Statuses,
+			IDs:             p.IDs,
+			SearchDirection: p.SearchDirection,
+		}, page)
+		if err != nil {
+			return nil, err
+		}
+
+		return it.Items, nil
+	})
 }
 
 type ListAcceptedTransactionsViewFactory struct{}

--- a/token/sdk/db/checks.go
+++ b/token/sdk/db/checks.go
@@ -22,6 +22,10 @@ type AuditorCheckServiceProvider struct {
 	tmsProvider     common.TokenManagementServiceProvider
 	networkProvider common.NetworkProvider
 	checkers        []common.NamedChecker
+	// MaxPageSize is the storage layer's configured max read page size, passed to
+	// the default checkers so they page within the guard layer's cap. 0 means the
+	// built-in default is used.
+	MaxPageSize int
 }
 
 // NewAuditorCheckServiceProvider creates a new auditor check service provider.
@@ -36,7 +40,7 @@ func NewAuditorCheckServiceProvider(tmsProvider common.TokenManagementServicePro
 // CheckService creates a check service for the given TMS ID and databases.
 // It combines default checkers with custom checkers provided during initialization.
 func (a *AuditorCheckServiceProvider) CheckService(id token.TMSID, adb *auditdb.StoreService, tdb *tokens.Service) (auditor.CheckService, error) {
-	return common.NewChecksService(append(common.NewDefaultCheckers(a.tmsProvider, a.networkProvider, adb, tdb, id), a.checkers...)), nil
+	return common.NewChecksService(append(common.NewDefaultCheckers(a.tmsProvider, a.networkProvider, adb, tdb, id, a.MaxPageSize), a.checkers...)), nil
 }
 
 // OwnerCheckServiceProvider creates check services for token owners.
@@ -45,6 +49,10 @@ type OwnerCheckServiceProvider struct {
 	tmsProvider     common.TokenManagementServiceProvider
 	networkProvider common.NetworkProvider
 	checkers        []common.NamedChecker
+	// MaxPageSize is the storage layer's configured max read page size, passed to
+	// the default checkers so they page within the guard layer's cap. 0 means the
+	// built-in default is used.
+	MaxPageSize int
 }
 
 // NewOwnerCheckServiceProvider creates a new owner check service provider.
@@ -59,5 +67,5 @@ func NewOwnerCheckServiceProvider(tmsProvider common.TokenManagementServiceProvi
 // CheckService creates a check service for the given TMS ID and databases.
 // It combines default checkers with custom checkers provided during initialization.
 func (a *OwnerCheckServiceProvider) CheckService(id token.TMSID, txdb *ttxdb.StoreService, tdb *tokens.Service) (ttx.CheckService, error) {
-	return common.NewChecksService(append(common.NewDefaultCheckers(a.tmsProvider, a.networkProvider, txdb, tdb, id), a.checkers...)), nil
+	return common.NewChecksService(append(common.NewDefaultCheckers(a.tmsProvider, a.networkProvider, txdb, tdb, id, a.MaxPageSize), a.checkers...)), nil
 }

--- a/token/sdk/dig/checks.go
+++ b/token/sdk/dig/checks.go
@@ -9,6 +9,7 @@ package sdk
 import (
 	"github.com/LFDT-Panurus/panurus/token/sdk/db"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/db/common"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/guard"
 	"go.uber.org/dig"
 )
 
@@ -19,8 +20,12 @@ func NewAuditorCheckServiceProvider(in struct {
 	TMSProvider     common.TokenManagementServiceProvider
 	NetworkProvider common.NetworkProvider
 	Checkers        []common.NamedChecker `group:"auditdb-checkers"`
+	Policy          guard.Policy
 }) *db.AuditorCheckServiceProvider {
-	return db.NewAuditorCheckServiceProvider(in.TMSProvider, in.NetworkProvider, in.Checkers)
+	provider := db.NewAuditorCheckServiceProvider(in.TMSProvider, in.NetworkProvider, in.Checkers)
+	provider.MaxPageSize = in.Policy.MaxPageSize
+
+	return provider
 }
 
 // NewOwnerCheckServiceProvider creates an owner check service provider using dependency injection.
@@ -30,6 +35,10 @@ func NewOwnerCheckServiceProvider(in struct {
 	TMSProvider     common.TokenManagementServiceProvider
 	NetworkProvider common.NetworkProvider
 	Checkers        []common.NamedChecker `group:"ttxdb-checkers"`
+	Policy          guard.Policy
 }) *db.OwnerCheckServiceProvider {
-	return db.NewOwnerCheckServiceProvider(in.TMSProvider, in.NetworkProvider, in.Checkers)
+	provider := db.NewOwnerCheckServiceProvider(in.TMSProvider, in.NetworkProvider, in.Checkers)
+	provider.MaxPageSize = in.Policy.MaxPageSize
+
+	return provider
 }

--- a/token/sdk/dig/checks_test.go
+++ b/token/sdk/dig/checks_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/sdk/db"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/db/common"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/db/common/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/guard"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/dig"
@@ -31,6 +32,7 @@ func TestNewAuditorCheckServiceProvider(t *testing.T) {
 		TMSProvider     common.TokenManagementServiceProvider
 		NetworkProvider common.NetworkProvider
 		Checkers        []common.NamedChecker `group:"auditdb-checkers"`
+		Policy          guard.Policy
 	}{
 		TMSProvider:     tmsProvider,
 		NetworkProvider: networkProvider,
@@ -52,6 +54,7 @@ func TestNewAuditorCheckServiceProvider_EmptyCheckers(t *testing.T) {
 		TMSProvider     common.TokenManagementServiceProvider
 		NetworkProvider common.NetworkProvider
 		Checkers        []common.NamedChecker `group:"auditdb-checkers"`
+		Policy          guard.Policy
 	}{
 		TMSProvider:     tmsProvider,
 		NetworkProvider: networkProvider,
@@ -78,6 +81,7 @@ func TestNewAuditorCheckServiceProvider_MultipleCheckers(t *testing.T) {
 		TMSProvider     common.TokenManagementServiceProvider
 		NetworkProvider common.NetworkProvider
 		Checkers        []common.NamedChecker `group:"auditdb-checkers"`
+		Policy          guard.Policy
 	}{
 		TMSProvider:     tmsProvider,
 		NetworkProvider: networkProvider,
@@ -103,6 +107,7 @@ func TestNewOwnerCheckServiceProvider(t *testing.T) {
 		TMSProvider     common.TokenManagementServiceProvider
 		NetworkProvider common.NetworkProvider
 		Checkers        []common.NamedChecker `group:"ttxdb-checkers"`
+		Policy          guard.Policy
 	}{
 		TMSProvider:     tmsProvider,
 		NetworkProvider: networkProvider,
@@ -124,6 +129,7 @@ func TestNewOwnerCheckServiceProvider_EmptyCheckers(t *testing.T) {
 		TMSProvider     common.TokenManagementServiceProvider
 		NetworkProvider common.NetworkProvider
 		Checkers        []common.NamedChecker `group:"ttxdb-checkers"`
+		Policy          guard.Policy
 	}{
 		TMSProvider:     tmsProvider,
 		NetworkProvider: networkProvider,
@@ -150,6 +156,7 @@ func TestNewOwnerCheckServiceProvider_MultipleCheckers(t *testing.T) {
 		TMSProvider     common.TokenManagementServiceProvider
 		NetworkProvider common.NetworkProvider
 		Checkers        []common.NamedChecker `group:"ttxdb-checkers"`
+		Policy          guard.Policy
 	}{
 		TMSProvider:     tmsProvider,
 		NetworkProvider: networkProvider,
@@ -172,6 +179,7 @@ func TestNewAuditorCheckServiceProvider_WithNilProviders(t *testing.T) {
 		TMSProvider     common.TokenManagementServiceProvider
 		NetworkProvider common.NetworkProvider
 		Checkers        []common.NamedChecker `group:"auditdb-checkers"`
+		Policy          guard.Policy
 	}{
 		TMSProvider:     nil,
 		NetworkProvider: nil,
@@ -194,6 +202,7 @@ func TestNewOwnerCheckServiceProvider_WithNilProviders(t *testing.T) {
 		TMSProvider     common.TokenManagementServiceProvider
 		NetworkProvider common.NetworkProvider
 		Checkers        []common.NamedChecker `group:"ttxdb-checkers"`
+		Policy          guard.Policy
 	}{
 		TMSProvider:     nil,
 		NetworkProvider: nil,

--- a/token/sdk/dig/providers.go
+++ b/token/sdk/dig/providers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/core"
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	dbdriver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/guard"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/db/multiplexed"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
@@ -25,6 +26,23 @@ func newMultiplexedDriver(in struct {
 },
 ) multiplexed.Driver {
 	return multiplexed.NewDriver(in.ConfigProvider, in.Drivers...)
+}
+
+// newStoragePolicy loads the storage guard policy from configuration. It is the
+// single source of the storage resource limits (max payload / max page size) so
+// consumers such as the integrity checkers page within the same cap the guard
+// layer enforces. Falls back to the built-in defaults if the config is unreadable.
+func newStoragePolicy(in struct {
+	dig.In
+	ConfigProvider driver2.ConfigService
+},
+) guard.Policy {
+	policy, err := guard.LoadPolicy(in.ConfigProvider)
+	if err != nil {
+		return guard.DefaultPolicy()
+	}
+
+	return policy
 }
 
 // newTokenDriverService creates a token driver service from registered token drivers.

--- a/token/sdk/dig/sdk.go
+++ b/token/sdk/dig/sdk.go
@@ -202,6 +202,7 @@ func (p *SDK) Install() error {
 		p.Container().Provide(postgres.NewNamedDriver, dig.Group("token-db-drivers")),
 		p.Container().Provide(memory.NewNamedDriver, dig.Group("token-db-drivers")),
 		p.Container().Provide(newMultiplexedDriver),
+		p.Container().Provide(newStoragePolicy),
 		p.Container().Provide(NewAuditorCheckServiceProvider),
 		p.Container().Provide(digutils.Identity[*db.AuditorCheckServiceProvider](), dig.As(new(auditor.CheckServiceProvider))),
 		p.Container().Provide(NewOwnerCheckServiceProvider),

--- a/token/services/storage/db/common/checks.go
+++ b/token/services/storage/db/common/checks.go
@@ -15,6 +15,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	"github.com/LFDT-Panurus/panurus/token/services/network"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query/pagination"
 	"github.com/LFDT-Panurus/panurus/token/services/tokens"
 	"github.com/LFDT-Panurus/panurus/token/services/utils"
 	token2 "github.com/LFDT-Panurus/panurus/token/token"
@@ -26,6 +27,13 @@ import (
 var (
 	logger = logging.MustGetLogger()
 )
+
+// transactionsCheckPageSize is the fallback page size used to iterate all
+// transactions during integrity checks when the storage layer's max page size
+// is disabled (0). When a cap is configured, that cap is used as the page size
+// instead (see DefaultCheckers.maxPageSize), so the checks always stay within
+// the bound the guard layer enforces.
+const transactionsCheckPageSize = 100
 
 type TokenTransactionDB interface {
 	GetTokenRequest(ctx context.Context, txID string) ([]byte, error)
@@ -76,10 +84,19 @@ type DefaultCheckers struct {
 	db              TokenTransactionDB
 	tokenDB         *tokens.Service
 	tmsID           token.TMSID
+	// maxPageSize is the storage layer's configured max read page size. It is used
+	// as the transaction-iteration page size so integrity checks read within the
+	// bound the guard layer enforces. A value <= 0 means the cap is disabled, in
+	// which case the built-in fallback (transactionsCheckPageSize) is used.
+	maxPageSize int
 }
 
-func NewDefaultCheckers(tmsProvider TokenManagementServiceProvider, networkProvider NetworkProvider, db TokenTransactionDB, tokenDB *tokens.Service, tmsID token.TMSID) []NamedChecker {
-	checkers := &DefaultCheckers{tmsProvider: tmsProvider, networkProvider: networkProvider, db: db, tokenDB: tokenDB, tmsID: tmsID}
+// NewDefaultCheckers builds the built-in integrity checkers for a TMS. maxPageSize
+// is the storage layer's configured max read page size; it is used as the page
+// size for iterating transactions so the checks stay within the guard layer's
+// cap. A value <= 0 means the cap is disabled and a built-in fallback is used.
+func NewDefaultCheckers(tmsProvider TokenManagementServiceProvider, networkProvider NetworkProvider, db TokenTransactionDB, tokenDB *tokens.Service, tmsID token.TMSID, maxPageSize int) []NamedChecker {
+	checkers := &DefaultCheckers{tmsProvider: tmsProvider, networkProvider: networkProvider, db: db, tokenDB: tokenDB, tmsID: tmsID, maxPageSize: maxPageSize}
 
 	return []NamedChecker{
 		{
@@ -115,52 +132,83 @@ func (a *DefaultCheckers) CheckTransactions(ctx context.Context) ([]string, erro
 		return nil, errors.WithMessagef(err, "failed to get ledger [%s]", tms.ID())
 	}
 
-	it, err := a.db.Transactions(ctx, driver.QueryTransactionsParams{}, nil)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed querying transactions [%s]", tms.ID())
+	// Iterate over transactions one limited page at a time. A single unlimited
+	// query is rejected by the storage layer, so we page through the whole set
+	// using offset pagination and stop once a page comes back short. We page at
+	// the configured max page size so reads stay within the cap the guard layer
+	// enforces; when the cap is disabled (0) we fall back to a built-in default.
+	pageSize := a.maxPageSize
+	if pageSize <= 0 {
+		pageSize = transactionsCheckPageSize
 	}
-	defer it.Items.Close()
+	var page driver2.Pagination
+	page, err = pagination.Offset(0, pageSize)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to create pagination [%s]", tms.ID())
+	}
 	for {
-		transactionRecord, err := it.Items.Next()
+		count, err := func() (int, error) {
+			it, err := a.db.Transactions(ctx, driver.QueryTransactionsParams{}, page)
+			if err != nil {
+				return 0, errors.WithMessagef(err, "failed querying transactions [%s]", tms.ID())
+			}
+			defer it.Items.Close()
+			count := 0
+			for {
+				transactionRecord, err := it.Items.Next()
+				if err != nil {
+					return 0, errors.WithMessagef(err, "failed querying transactions [%s]", tms.ID())
+				}
+				if transactionRecord == nil {
+					break
+				}
+				count++
+
+				tokenRequest, err := a.db.GetTokenRequest(ctx, transactionRecord.TxID)
+				if err != nil {
+					return 0, errors.WithMessagef(err, "failed getting token request [%s]", transactionRecord.TxID)
+				}
+				if tokenRequest == nil {
+					return 0, errors.Errorf("token request [%s] is nil", transactionRecord.TxID)
+				}
+
+				// check the ledger
+				lVC, _, err := l.Status(transactionRecord.TxID)
+				if err != nil {
+					lVC = network.Unknown
+				}
+				switch {
+				case transactionRecord.Status == driver.Confirmed && lVC != network.Valid:
+					if err != nil {
+						errorMessages = append(errorMessages, fmt.Sprintf("failed to get ledger transaction status for [%s]: [%s]", transactionRecord.TxID, err))
+					}
+					errorMessages = append(errorMessages, fmt.Sprintf("transaction record [%s] is valid for vault but not for the ledger [%d]", transactionRecord.TxID, lVC))
+				case transactionRecord.Status == driver.Deleted && lVC != network.Invalid:
+					if lVC != network.Unknown || transactionRecord.Status != driver.Deleted {
+						if err != nil {
+							errorMessages = append(errorMessages, fmt.Sprintf("failed to get ledger transaction status for [%s]: [%s]", transactionRecord.TxID, err))
+						}
+						errorMessages = append(errorMessages, fmt.Sprintf("transaction record [%s] is invalid for vault but not for the ledger [%d]", transactionRecord.TxID, lVC))
+					}
+				case transactionRecord.Status == driver.Unknown && lVC != network.Unknown:
+					errorMessages = append(errorMessages, fmt.Sprintf("transaction record [%s] is unknown for vault but not for the ledger [%d]", transactionRecord.TxID, lVC))
+				case transactionRecord.Status == driver.Pending && lVC == network.Busy:
+					// this is fine, let's continue
+				case transactionRecord.Status == driver.Pending && lVC != network.Unknown:
+					errorMessages = append(errorMessages, fmt.Sprintf("transaction record [%s] is busy for vault but not for the ledger [%d]", transactionRecord.TxID, lVC))
+				}
+			}
+
+			return count, nil
+		}()
 		if err != nil {
-			return nil, errors.WithMessagef(err, "failed querying transactions [%s]", tms.ID())
+			return nil, err
 		}
-		if transactionRecord == nil {
+		if count < pageSize {
 			break
 		}
-
-		tokenRequest, err := a.db.GetTokenRequest(ctx, transactionRecord.TxID)
-		if err != nil {
-			return nil, errors.WithMessagef(err, "failed getting token request [%s]", transactionRecord.TxID)
-		}
-		if tokenRequest == nil {
-			return nil, errors.Errorf("token request [%s] is nil", transactionRecord.TxID)
-		}
-
-		// check the ledger
-		lVC, _, err := l.Status(transactionRecord.TxID)
-		if err != nil {
-			lVC = network.Unknown
-		}
-		switch {
-		case transactionRecord.Status == driver.Confirmed && lVC != network.Valid:
-			if err != nil {
-				errorMessages = append(errorMessages, fmt.Sprintf("failed to get ledger transaction status for [%s]: [%s]", transactionRecord.TxID, err))
-			}
-			errorMessages = append(errorMessages, fmt.Sprintf("transaction record [%s] is valid for vault but not for the ledger [%d]", transactionRecord.TxID, lVC))
-		case transactionRecord.Status == driver.Deleted && lVC != network.Invalid:
-			if lVC != network.Unknown || transactionRecord.Status != driver.Deleted {
-				if err != nil {
-					errorMessages = append(errorMessages, fmt.Sprintf("failed to get ledger transaction status for [%s]: [%s]", transactionRecord.TxID, err))
-				}
-				errorMessages = append(errorMessages, fmt.Sprintf("transaction record [%s] is invalid for vault but not for the ledger [%d]", transactionRecord.TxID, lVC))
-			}
-		case transactionRecord.Status == driver.Unknown && lVC != network.Unknown:
-			errorMessages = append(errorMessages, fmt.Sprintf("transaction record [%s] is unknown for vault but not for the ledger [%d]", transactionRecord.TxID, lVC))
-		case transactionRecord.Status == driver.Pending && lVC == network.Busy:
-			// this is fine, let's continue
-		case transactionRecord.Status == driver.Pending && lVC != network.Unknown:
-			errorMessages = append(errorMessages, fmt.Sprintf("transaction record [%s] is busy for vault but not for the ledger [%d]", transactionRecord.TxID, lVC))
+		if page, err = page.Next(); err != nil {
+			return nil, errors.WithMessagef(err, "failed advancing pagination [%s]", tms.ID())
 		}
 	}
 

--- a/token/services/storage/db/dbtest/transactions.go
+++ b/token/services/storage/db/dbtest/transactions.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token"
 	driver2 "github.com/LFDT-Panurus/panurus/token/driver"
 	driver3 "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query/pagination"
 	"github.com/LFDT-Panurus/panurus/token/services/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
 	"github.com/stretchr/testify/assert"
@@ -309,7 +310,9 @@ func TTransaction(t *testing.T, db driver3.TokenTransactionStore) {
 
 	// get all except last year's
 	t1 := time.Now().Add(time.Second * 3)
-	it, err := db.QueryTransactions(ctx, driver3.QueryTransactionsParams{From: &t0, To: &t1, SearchDirection: driver3.FromBeginning}, nil)
+	page, err := pagination.Offset(0, 100)
+	require.NoError(t, err)
+	it, err := db.QueryTransactions(ctx, driver3.QueryTransactionsParams{From: &t0, To: &t1, SearchDirection: driver3.FromBeginning}, page)
 	require.NoError(t, err)
 	for _, exp := range txs {
 		act, err := it.Items.Next()
@@ -320,7 +323,9 @@ func TTransaction(t *testing.T, db driver3.TokenTransactionStore) {
 
 	// get all tx from before the first
 	yesterday := t0.AddDate(0, 0, -1).Local().UTC().Truncate(time.Second)
-	it, err = db.QueryTransactions(ctx, driver3.QueryTransactionsParams{To: &yesterday}, nil)
+	page, err = pagination.Offset(0, 100)
+	require.NoError(t, err)
+	it, err = db.QueryTransactions(ctx, driver3.QueryTransactionsParams{To: &yesterday}, page)
 	require.NoError(t, err)
 	defer it.Items.Close()
 
@@ -867,7 +872,9 @@ func TTransactionQueries(t *testing.T, db driver3.TokenTransactionStore) {
 
 func getTransactions(t *testing.T, db driver3.TokenTransactionStore, params driver3.QueryTransactionsParams) []*driver3.TransactionRecord {
 	t.Helper()
-	records, err := db.QueryTransactions(t.Context(), params, nil)
+	page, err := pagination.Offset(0, 100)
+	require.NoError(t, err)
+	records, err := db.QueryTransactions(t.Context(), params, page)
 	require.NoError(t, err)
 	txs, err := iterators.ReadAllPointers(records.Items)
 	require.NoError(t, err)

--- a/token/services/storage/db/guard/decorator_test.go
+++ b/token/services/storage/db/guard/decorator_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package guard_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	driver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/guard"
+	sqlcommon "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/common"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query/pagination"
+	"github.com/stretchr/testify/require"
+)
+
+func ownerStore(t *testing.T, db *sql.DB, p guard.Policy) driver.TokenTransactionStore {
+	t.Helper()
+	store, err := sqlcommon.NewOwnerTransactionStore(db, db, sqlcommon.TableNames{
+		Movements:             "MOVEMENTS",
+		Transactions:          "TRANSACTIONS",
+		Requests:              "REQUESTS",
+		TransactionEndorseAck: "TRANSACTION_ENDORSE_ACK",
+	}, nil, nil)
+	require.NoError(t, err)
+
+	return guard.WrapOwnerTransaction(store, p)
+}
+
+// TestGuardRejectsOversizeWrite verifies the guard rejects an oversize write
+// on the atomic transaction before it reaches the database.
+func TestGuardRejectsOversizeWrite(t *testing.T) {
+	db, mockDB, err := sqlmock.New()
+	require.NoError(t, err)
+
+	store := ownerStore(t, db, guard.Policy{MaxPayloadSize: 20, MaxPageSize: 1000})
+	mockDB.ExpectBegin()
+
+	w, err := store.NewTransactionStoreTransaction()
+	require.NoError(t, err)
+
+	err = w.AddTokenRequest(t.Context(), "tx", make([]byte, 100), nil, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum")
+	require.NoError(t, mockDB.ExpectationsWereMet())
+}
+
+// TestGuardDisabledWritePassesThrough verifies a zero payload limit disables
+// the check and the write proceeds to the database.
+func TestGuardDisabledWritePassesThrough(t *testing.T) {
+	db, mockDB, err := sqlmock.New()
+	require.NoError(t, err)
+
+	store := ownerStore(t, db, guard.Policy{MaxPayloadSize: 0, MaxPageSize: 1000})
+	mockDB.ExpectBegin()
+	mockDB.ExpectExec("INSERT INTO REQUESTS").WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w, err := store.NewTransactionStoreTransaction()
+	require.NoError(t, err)
+
+	require.NoError(t, w.AddTokenRequest(t.Context(), "tx", make([]byte, 100), nil, nil, nil))
+	require.NoError(t, mockDB.ExpectationsWereMet())
+}
+
+// TestGuardRejectsOversizeAddTransaction verifies the guard rejects an oversize
+// AddTransaction record before it reaches the database.
+func TestGuardRejectsOversizeAddTransaction(t *testing.T) {
+	db, mockDB, err := sqlmock.New()
+	require.NoError(t, err)
+
+	store := ownerStore(t, db, guard.Policy{MaxPayloadSize: 20, MaxPageSize: 1000})
+	mockDB.ExpectBegin()
+
+	w, err := store.NewTransactionStoreTransaction()
+	require.NoError(t, err)
+
+	err = w.AddTransaction(t.Context(), driver.TransactionRecord{TxID: "tx", SenderEID: string(make([]byte, 100))})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum")
+	require.NoError(t, mockDB.ExpectationsWereMet())
+}
+
+// TestGuardRejectsOversizeAddMovement verifies the guard rejects an oversize
+// AddMovement record before it reaches the database.
+func TestGuardRejectsOversizeAddMovement(t *testing.T) {
+	db, mockDB, err := sqlmock.New()
+	require.NoError(t, err)
+
+	store := ownerStore(t, db, guard.Policy{MaxPayloadSize: 20, MaxPageSize: 1000})
+	mockDB.ExpectBegin()
+
+	w, err := store.NewTransactionStoreTransaction()
+	require.NoError(t, err)
+
+	err = w.AddMovement(t.Context(), driver.MovementRecord{TxID: "tx", EnrollmentID: string(make([]byte, 100))})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum")
+	require.NoError(t, mockDB.ExpectationsWereMet())
+}
+
+// TestGuardRejectsUnlimitedQuery verifies the read guard rejects nil and
+// unlimited (None) pagination without querying the database.
+func TestGuardRejectsUnlimitedQuery(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+
+	store := ownerStore(t, db, guard.DefaultPolicy())
+
+	_, err = store.QueryTransactions(t.Context(), driver.QueryTransactionsParams{}, nil)
+	require.Error(t, err)
+
+	_, err = store.QueryTransactions(t.Context(), driver.QueryTransactionsParams{}, pagination.None())
+	require.Error(t, err)
+}

--- a/token/services/storage/db/guard/decorator_writes_test.go
+++ b/token/services/storage/db/guard/decorator_writes_test.go
@@ -1,0 +1,682 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package guard_test
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"testing"
+
+	token2 "github.com/LFDT-Panurus/panurus/token"
+	tokendriver "github.com/LFDT-Panurus/panurus/token/driver"
+	idriver "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
+	driver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/guard"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query/pagination"
+	"github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+	"github.com/stretchr/testify/require"
+)
+
+// This file covers the guard decorators whose size checks the SQL-backed tests in
+// decorator_test.go do not reach: the wallet, identity, endorser, token and audit
+// transaction stores.
+//
+// Each fake below embeds its driver store interface and leaves it nil, overriding
+// only the method under test. That makes two failure modes loud instead of silent:
+// a guard that stops intercepting delegates to the fake (so the expected rejection
+// never happens), and a guard that reaches for any other store method panics
+// rather than quietly passing.
+
+// --- boundary helper -------------------------------------------------------
+
+// callFn performs the guarded write under policy p and reports how many times it
+// reached the underlying store.
+type callFn func(t *testing.T, p guard.Policy) (delegated int, err error)
+
+// assertSizeBoundary pins a guarded write's size arithmetic from both sides: a
+// payload of wantSize bytes must be rejected when the limit is one byte below it
+// and must reach the store when the limit is exactly wantSize.
+//
+// Pinning both sides is what makes this a regression test rather than a
+// decoration. wantSize is stated independently of the implementation, so adding a
+// field to the guard's sum breaks the at-the-limit case and dropping one breaks
+// the over-the-limit case.
+func assertSizeBoundary(t *testing.T, op string, wantSize int, call callFn) {
+	t.Helper()
+
+	delegated, err := call(t, guard.Policy{MaxPayloadSize: wantSize - 1, MaxPageSize: guard.DefaultMaxPageSize})
+	require.Error(t, err, "%s: a %d-byte payload must be rejected under a %d-byte limit", op, wantSize, wantSize-1)
+	require.Contains(t, err.Error(), "exceeds maximum")
+	require.Contains(t, err.Error(), op, "the error must name the rejected operation")
+	require.Zero(t, delegated, "%s: a rejected write must not reach the store", op)
+
+	delegated, err = call(t, guard.Policy{MaxPayloadSize: wantSize, MaxPageSize: guard.DefaultMaxPageSize})
+	require.NoError(t, err, "%s: a payload of exactly %d bytes must be allowed", op, wantSize)
+	require.Equal(t, 1, delegated, "%s: an allowed write must reach the store exactly once", op)
+}
+
+// --- wallet store ----------------------------------------------------------
+
+type fakeWalletStore struct {
+	driver.WalletStore
+	calls int
+}
+
+func (f *fakeWalletStore) StoreIdentity(context.Context, token2.Identity, string, driver.WalletID, int, []byte, string) error {
+	f.calls++
+
+	return nil
+}
+
+// TestGuardBoundsStoreIdentity verifies the wallet-store guard sums the identity,
+// enrollment id, wallet id, metadata and configuration id of a StoreIdentity call.
+func TestGuardBoundsStoreIdentity(t *testing.T) {
+	assertSizeBoundary(t, "StoreIdentity", 4+5+6+7+8, func(t *testing.T, p guard.Policy) (int, error) {
+		t.Helper()
+		fake := &fakeWalletStore{}
+		err := guard.WrapWallet(fake, p).StoreIdentity(
+			t.Context(),
+			token2.Identity(make([]byte, 4)),
+			strings.Repeat("e", 5),
+			strings.Repeat("w", 6),
+			1,
+			make([]byte, 7),
+			strings.Repeat("c", 8),
+		)
+
+		return fake.calls, err
+	})
+}
+
+// TestWrapWalletPassesThroughNil verifies wrapping a nil store yields nil rather
+// than a decorator over nothing.
+func TestWrapWalletPassesThroughNil(t *testing.T) {
+	require.Nil(t, guard.WrapWallet(nil, guard.DefaultPolicy()))
+	require.Nil(t, guard.WrapIdentity(nil, guard.DefaultPolicy()))
+	require.Nil(t, guard.WrapEndorser(nil, guard.DefaultPolicy()))
+	require.Nil(t, guard.WrapToken(nil, guard.DefaultPolicy()))
+	require.Nil(t, guard.WrapOwnerTransaction(nil, guard.DefaultPolicy()))
+	require.Nil(t, guard.WrapAuditTransaction(nil, guard.DefaultPolicy()))
+}
+
+// --- identity store --------------------------------------------------------
+
+type fakeIdentityStore struct {
+	driver.IdentityStore
+	calls int
+}
+
+func (f *fakeIdentityStore) AddConfiguration(context.Context, idriver.IdentityConfiguration) error {
+	f.calls++
+
+	return nil
+}
+
+func (f *fakeIdentityStore) StoreIdentityData(context.Context, []byte, []byte, []byte, []byte) error {
+	f.calls++
+
+	return nil
+}
+
+func (f *fakeIdentityStore) StoreSignerInfo(context.Context, tokendriver.Identity, []byte) error {
+	f.calls++
+
+	return nil
+}
+
+func (f *fakeIdentityStore) RegisterIdentityDescriptor(context.Context, *idriver.IdentityDescriptor, tokendriver.Identity) error {
+	f.calls++
+
+	return nil
+}
+
+// TestGuardBoundsIdentityWrites verifies the size arithmetic of every guarded
+// identity-store write.
+func TestGuardBoundsIdentityWrites(t *testing.T) {
+	tests := []struct {
+		op       string
+		wantSize int
+		write    func(ctx context.Context, s driver.IdentityStore) error
+	}{
+		{
+			op:       "AddConfiguration",
+			wantSize: 2 + 4 + 3 + 5 + 6, // id + type + url + config + raw
+			write: func(ctx context.Context, s driver.IdentityStore) error {
+				return s.AddConfiguration(ctx, idriver.IdentityConfiguration{
+					ID:     strings.Repeat("i", 2),
+					Type:   strings.Repeat("t", 4),
+					URL:    strings.Repeat("u", 3),
+					Config: make([]byte, 5),
+					Raw:    make([]byte, 6),
+				})
+			},
+		},
+		{
+			op:       "StoreIdentityData",
+			wantSize: 2 + 3 + 4 + 5, // id + identity audit + token metadata + token metadata audit
+			write: func(ctx context.Context, s driver.IdentityStore) error {
+				return s.StoreIdentityData(ctx, make([]byte, 2), make([]byte, 3), make([]byte, 4), make([]byte, 5))
+			},
+		},
+		{
+			op:       "StoreSignerInfo",
+			wantSize: 3 + 4, // id + info
+			write: func(ctx context.Context, s driver.IdentityStore) error {
+				return s.StoreSignerInfo(ctx, tokendriver.Identity(make([]byte, 3)), make([]byte, 4))
+			},
+		},
+		{
+			op:       "RegisterIdentityDescriptor",
+			wantSize: 2 + 3 + 4 + 5, // alias + descriptor identity + audit info + signer info
+			write: func(ctx context.Context, s driver.IdentityStore) error {
+				return s.RegisterIdentityDescriptor(ctx, &idriver.IdentityDescriptor{
+					Identity:   idriver.Identity(make([]byte, 3)),
+					AuditInfo:  make([]byte, 4),
+					SignerInfo: make([]byte, 5),
+				}, tokendriver.Identity(make([]byte, 2)))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.op, func(t *testing.T) {
+			assertSizeBoundary(t, test.op, test.wantSize, func(t *testing.T, p guard.Policy) (int, error) {
+				t.Helper()
+				fake := &fakeIdentityStore{}
+				err := test.write(t.Context(), guard.WrapIdentity(fake, p))
+
+				return fake.calls, err
+			})
+		})
+	}
+}
+
+// TestGuardRejectsOversizeDescriptorAliasWithoutDescriptor verifies the
+// RegisterIdentityDescriptor guard sizes the alias on its own when the descriptor
+// is nil, instead of dereferencing it.
+func TestGuardRejectsOversizeDescriptorAliasWithoutDescriptor(t *testing.T) {
+	fake := &fakeIdentityStore{}
+	store := guard.WrapIdentity(fake, guard.Policy{MaxPayloadSize: 8, MaxPageSize: guard.DefaultMaxPageSize})
+
+	err := store.RegisterIdentityDescriptor(t.Context(), nil, tokendriver.Identity(make([]byte, 9)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum")
+	require.Zero(t, fake.calls)
+}
+
+// --- endorser store --------------------------------------------------------
+
+type fakeEndorserStore struct {
+	driver.EndorserStore
+	tx      *fakeEndorserStoreTx
+	openErr error
+}
+
+func (f *fakeEndorserStore) NewEndorserStoreTransaction() (driver.EndorserStoreTransaction, error) {
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+
+	return f.tx, nil
+}
+
+type fakeEndorserStoreTx struct {
+	driver.EndorserStoreTransaction
+	calls int
+}
+
+func (f *fakeEndorserStoreTx) AddValidationRecord(context.Context, string, []byte, map[string][]byte, tokendriver.PPHash) error {
+	f.calls++
+
+	return nil
+}
+
+// TestGuardBoundsAddValidationRecord verifies the endorser-transaction guard sums
+// the tx id, token request and metadata map (keys included) of a validation record.
+func TestGuardBoundsAddValidationRecord(t *testing.T) {
+	assertSizeBoundary(t, "AddValidationRecord", 4+5+(1+3), func(t *testing.T, p guard.Policy) (int, error) {
+		t.Helper()
+		fake := &fakeEndorserStore{tx: &fakeEndorserStoreTx{}}
+		w, err := guard.WrapEndorser(fake, p).NewEndorserStoreTransaction()
+		require.NoError(t, err)
+
+		err = w.AddValidationRecord(
+			t.Context(),
+			strings.Repeat("t", 4),
+			make([]byte, 5),
+			map[string][]byte{"k": make([]byte, 3)},
+			nil,
+		)
+
+		return fake.tx.calls, err
+	})
+}
+
+// --- token store -----------------------------------------------------------
+
+type fakeTokenStore struct {
+	driver.TokenStore
+	calls   int
+	tx      *fakeTokenStoreTx
+	openErr error
+}
+
+func (f *fakeTokenStore) StorePublicParams(context.Context, []byte) error {
+	f.calls++
+
+	return nil
+}
+
+func (f *fakeTokenStore) StoreCertifications(context.Context, map[*token.ID][]byte) error {
+	f.calls++
+
+	return nil
+}
+
+func (f *fakeTokenStore) NewTokenDBTransaction() (driver.TokenStoreTransaction, error) {
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+
+	return f.tx, nil
+}
+
+func (f *fakeTokenStore) ContinueTokenDBTransaction(driver.Transaction) (driver.TokenStoreTransaction, error) {
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+
+	return f.tx, nil
+}
+
+type fakeTokenStoreTx struct {
+	driver.TokenStoreTransaction
+	calls int
+}
+
+func (f *fakeTokenStoreTx) StoreToken(context.Context, driver.TokenRecord, []string) error {
+	f.calls++
+
+	return nil
+}
+
+// TestGuardBoundsTokenStoreWrites verifies the size arithmetic of the guarded
+// token-store writes: public parameters, certifications (values only) and the
+// per-token record written inside a token-store transaction.
+func TestGuardBoundsTokenStoreWrites(t *testing.T) {
+	// StoreToken sums every persisted string/blob field of the record plus each
+	// owner identifier.
+	const storeTokenSize = 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 6
+
+	tests := []struct {
+		op       string
+		wantSize int
+		write    func(t *testing.T, ctx context.Context, s driver.TokenStore) (int, error)
+	}{
+		{
+			op:       "StorePublicParams",
+			wantSize: 9,
+			write: func(t *testing.T, ctx context.Context, s driver.TokenStore) (int, error) {
+				t.Helper()
+
+				return -1, s.StorePublicParams(ctx, make([]byte, 9))
+			},
+		},
+		{
+			// Only the certification blobs are summed, not the token-id keys.
+			op:       "StoreCertifications",
+			wantSize: 7,
+			write: func(t *testing.T, ctx context.Context, s driver.TokenStore) (int, error) {
+				t.Helper()
+
+				return -1, s.StoreCertifications(ctx, map[*token.ID][]byte{
+					{TxId: strings.Repeat("x", 6), Index: 0}: make([]byte, 7),
+				})
+			},
+		},
+		{
+			op:       "StoreToken",
+			wantSize: storeTokenSize,
+			write: func(t *testing.T, ctx context.Context, s driver.TokenStore) (int, error) {
+				t.Helper()
+				w, err := s.NewTokenDBTransaction()
+				require.NoError(t, err)
+
+				return -1, w.StoreToken(ctx, tokenRecord(), []string{strings.Repeat("o", 6)})
+			},
+		},
+		{
+			// The same guard must apply to a transaction continued from an
+			// existing one, not only to a freshly opened transaction.
+			op:       "StoreToken",
+			wantSize: storeTokenSize,
+			write: func(t *testing.T, ctx context.Context, s driver.TokenStore) (int, error) {
+				t.Helper()
+				w, err := s.ContinueTokenDBTransaction(nil)
+				require.NoError(t, err)
+
+				return -1, w.StoreToken(ctx, tokenRecord(), []string{strings.Repeat("o", 6)})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.op, func(t *testing.T) {
+			assertSizeBoundary(t, test.op, test.wantSize, func(t *testing.T, p guard.Policy) (int, error) {
+				t.Helper()
+				fake := &fakeTokenStore{tx: &fakeTokenStoreTx{}}
+				_, err := test.write(t, t.Context(), guard.WrapToken(fake, p))
+
+				return fake.calls + fake.tx.calls, err
+			})
+		})
+	}
+}
+
+// tokenRecord returns a token record whose persisted fields have distinct,
+// known lengths so the guard's per-field sum can be pinned exactly.
+func tokenRecord() driver.TokenRecord {
+	return driver.TokenRecord{
+		TxID:           strings.Repeat("a", 4),
+		IssuerRaw:      make([]byte, 5),
+		OwnerRaw:       make([]byte, 6),
+		OwnerIdentity:  make([]byte, 7),
+		OwnerType:      strings.Repeat("b", 8),
+		OwnerWalletID:  strings.Repeat("c", 9),
+		Ledger:         make([]byte, 10),
+		LedgerFormat:   token.Format(strings.Repeat("d", 11)),
+		LedgerMetadata: make([]byte, 12),
+		Quantity:       strings.Repeat("e", 13),
+		Type:           token.Type(strings.Repeat("f", 14)),
+	}
+}
+
+// --- audit transaction store -----------------------------------------------
+
+type fakeAuditTxStore struct {
+	driver.AuditTransactionStore
+	queries int
+	tx      *fakeStoreTx
+	openErr error
+}
+
+func (f *fakeAuditTxStore) QueryTransactions(context.Context, driver.QueryTransactionsParams, driver2.Pagination) (*driver2.PageIterator[*driver.TransactionRecord], error) {
+	f.queries++
+
+	return &driver2.PageIterator[*driver.TransactionRecord]{}, nil
+}
+
+func (f *fakeAuditTxStore) NewTransactionStoreTransaction() (driver.TransactionStoreTransaction, error) {
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+
+	return f.tx, nil
+}
+
+type fakeStoreTx struct {
+	driver.TransactionStoreTransaction
+	calls int
+}
+
+func (f *fakeStoreTx) AddTokenRequest(context.Context, string, []byte, map[string][]byte, map[string][]byte, tokendriver.PPHash) error {
+	f.calls++
+
+	return nil
+}
+
+func (f *fakeStoreTx) AddTransaction(context.Context, ...driver.TransactionRecord) error {
+	f.calls++
+
+	return nil
+}
+
+func (f *fakeStoreTx) AddMovement(context.Context, ...driver.MovementRecord) error {
+	f.calls++
+
+	return nil
+}
+
+// TestGuardBoundsAuditQueryTransactions verifies the audit-store read guard
+// rejects unbounded and oversize pages and lets a page within the cap through.
+func TestGuardBoundsAuditQueryTransactions(t *testing.T) {
+	const maxPageSize = 10
+
+	overMax, err := pagination.Offset(0, maxPageSize+1)
+	require.NoError(t, err)
+	atMax, err := pagination.Offset(0, maxPageSize)
+	require.NoError(t, err)
+
+	rejected := []struct {
+		name string
+		p    driver2.Pagination
+	}{
+		{name: "nil", p: nil},
+		{name: "none", p: pagination.None()},
+		{name: "over max page size", p: overMax},
+	}
+	for _, test := range rejected {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeAuditTxStore{}
+			store := guard.WrapAuditTransaction(fake, guard.Policy{MaxPayloadSize: guard.DefaultMaxPayloadSize, MaxPageSize: maxPageSize})
+
+			_, err := store.QueryTransactions(t.Context(), driver.QueryTransactionsParams{}, test.p)
+			require.Error(t, err)
+			require.Zero(t, fake.queries, "a rejected read must not reach the store")
+		})
+	}
+
+	t.Run("at max page size", func(t *testing.T) {
+		fake := &fakeAuditTxStore{}
+		store := guard.WrapAuditTransaction(fake, guard.Policy{MaxPayloadSize: guard.DefaultMaxPayloadSize, MaxPageSize: maxPageSize})
+
+		it, err := store.QueryTransactions(t.Context(), driver.QueryTransactionsParams{}, atMax)
+		require.NoError(t, err)
+		require.NotNil(t, it)
+		require.Equal(t, 1, fake.queries)
+	})
+}
+
+// TestGuardBoundsAuditStoreTransactionWrites verifies the transaction opened on
+// the audit store is guarded too, not just the owner store's.
+func TestGuardBoundsAuditStoreTransactionWrites(t *testing.T) {
+	fake := &fakeAuditTxStore{tx: &fakeStoreTx{}}
+	store := guard.WrapAuditTransaction(fake, guard.Policy{MaxPayloadSize: 20, MaxPageSize: guard.DefaultMaxPageSize})
+
+	w, err := store.NewTransactionStoreTransaction()
+	require.NoError(t, err)
+
+	err = w.AddTokenRequest(t.Context(), "tx", make([]byte, 100), nil, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum")
+	require.Zero(t, fake.tx.calls, "a rejected write must not reach the store")
+
+	require.NoError(t, w.AddTokenRequest(t.Context(), "tx", make([]byte, 20), nil, nil, nil))
+	require.Equal(t, 1, fake.tx.calls)
+}
+
+// --- owner transaction store: endorsement acks -----------------------------
+
+type fakeOwnerTxStore struct {
+	driver.TokenTransactionStore
+	calls   int
+	queries int
+	tx      *fakeStoreTx
+	openErr error
+}
+
+func (f *fakeOwnerTxStore) QueryTransactions(context.Context, driver.QueryTransactionsParams, driver2.Pagination) (*driver2.PageIterator[*driver.TransactionRecord], error) {
+	f.queries++
+
+	return &driver2.PageIterator[*driver.TransactionRecord]{}, nil
+}
+
+func (f *fakeOwnerTxStore) NewTransactionStoreTransaction() (driver.TransactionStoreTransaction, error) {
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+
+	return f.tx, nil
+}
+
+func (f *fakeOwnerTxStore) AddTransactionEndorsementAck(context.Context, string, token2.Identity, []byte) error {
+	f.calls++
+
+	return nil
+}
+
+// TestGuardBoundsAddTransactionEndorsementAck verifies the guard sums the tx id,
+// endorser identity and signature of an endorsement ack.
+func TestGuardBoundsAddTransactionEndorsementAck(t *testing.T) {
+	assertSizeBoundary(t, "AddTransactionEndorsementAck", 4+5+6, func(t *testing.T, p guard.Policy) (int, error) {
+		t.Helper()
+		fake := &fakeOwnerTxStore{}
+		err := guard.WrapOwnerTransaction(fake, p).AddTransactionEndorsementAck(
+			t.Context(),
+			strings.Repeat("t", 4),
+			token2.Identity(make([]byte, 5)),
+			make([]byte, 6),
+		)
+
+		return fake.calls, err
+	})
+}
+
+// TestGuardBoundsOwnerQueryTransactions verifies the owner-store read guard lets a
+// page within the cap through and rejects one above it. decorator_test.go covers
+// the nil and None cases against the SQL store.
+func TestGuardBoundsOwnerQueryTransactions(t *testing.T) {
+	const maxPageSize = 10
+
+	atMax, err := pagination.Offset(0, maxPageSize)
+	require.NoError(t, err)
+	overMax, err := pagination.Offset(0, maxPageSize+1)
+	require.NoError(t, err)
+
+	fake := &fakeOwnerTxStore{}
+	store := guard.WrapOwnerTransaction(fake, guard.Policy{MaxPayloadSize: guard.DefaultMaxPayloadSize, MaxPageSize: maxPageSize})
+
+	_, err = store.QueryTransactions(t.Context(), driver.QueryTransactionsParams{}, overMax)
+	require.Error(t, err)
+	require.Zero(t, fake.queries, "a rejected read must not reach the store")
+
+	it, err := store.QueryTransactions(t.Context(), driver.QueryTransactionsParams{}, atMax)
+	require.NoError(t, err)
+	require.NotNil(t, it)
+	require.Equal(t, 1, fake.queries)
+}
+
+// TestGuardBoundsMultiRecordWrites verifies AddTransaction and AddMovement sum
+// every record in a batch, and that a nil amount contributes nothing while a
+// non-nil one contributes its decimal-string length.
+func TestGuardBoundsMultiRecordWrites(t *testing.T) {
+	tests := []struct {
+		op       string
+		wantSize int
+		write    func(ctx context.Context, w driver.TransactionStoreTransaction) error
+	}{
+		{
+			op: "AddTransaction",
+			// first record: tx id + sender + recipient + token type + len("100")
+			// second record: tx id + sender + recipient + token type + nil amount
+			wantSize: (4 + 5 + 6 + 7 + 3) + (2 + 3 + 4 + 5 + 0),
+			write: func(ctx context.Context, w driver.TransactionStoreTransaction) error {
+				return w.AddTransaction(ctx,
+					driver.TransactionRecord{
+						TxID:         strings.Repeat("a", 4),
+						SenderEID:    strings.Repeat("s", 5),
+						RecipientEID: strings.Repeat("r", 6),
+						TokenType:    token.Type(strings.Repeat("t", 7)),
+						Amount:       big.NewInt(100),
+					},
+					driver.TransactionRecord{
+						TxID:         strings.Repeat("b", 2),
+						SenderEID:    strings.Repeat("s", 3),
+						RecipientEID: strings.Repeat("r", 4),
+						TokenType:    token.Type(strings.Repeat("t", 5)),
+						Amount:       nil,
+					},
+				)
+			},
+		},
+		{
+			op: "AddMovement",
+			// first record: tx id + enrollment id + token type + len("-1234")
+			// second record: tx id + enrollment id + token type + nil amount
+			wantSize: (3 + 4 + 5 + 5) + (2 + 2 + 2 + 0),
+			write: func(ctx context.Context, w driver.TransactionStoreTransaction) error {
+				return w.AddMovement(ctx,
+					driver.MovementRecord{
+						TxID:         strings.Repeat("a", 3),
+						EnrollmentID: strings.Repeat("e", 4),
+						TokenType:    token.Type(strings.Repeat("t", 5)),
+						Amount:       big.NewInt(-1234),
+					},
+					driver.MovementRecord{
+						TxID:         strings.Repeat("b", 2),
+						EnrollmentID: strings.Repeat("e", 2),
+						TokenType:    token.Type(strings.Repeat("t", 2)),
+						Amount:       nil,
+					},
+				)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.op, func(t *testing.T) {
+			assertSizeBoundary(t, test.op, test.wantSize, func(t *testing.T, p guard.Policy) (int, error) {
+				t.Helper()
+				fake := &fakeOwnerTxStore{tx: &fakeStoreTx{}}
+				w, err := guard.WrapOwnerTransaction(fake, p).NewTransactionStoreTransaction()
+				require.NoError(t, err)
+
+				return fake.tx.calls, test.write(t.Context(), w)
+			})
+		})
+	}
+}
+
+// TestGuardPropagatesTransactionOpenError verifies each decorator that opens a
+// nested transaction returns the store's error unchanged instead of handing back a
+// guard wrapped around a nil transaction, which would panic on first use.
+func TestGuardPropagatesTransactionOpenError(t *testing.T) {
+	openErr := errors.New("cannot open transaction")
+
+	t.Run("endorser", func(t *testing.T) {
+		w, err := guard.WrapEndorser(&fakeEndorserStore{openErr: openErr}, guard.DefaultPolicy()).NewEndorserStoreTransaction()
+		require.ErrorIs(t, err, openErr)
+		require.Nil(t, w)
+	})
+
+	t.Run("token new", func(t *testing.T) {
+		w, err := guard.WrapToken(&fakeTokenStore{openErr: openErr}, guard.DefaultPolicy()).NewTokenDBTransaction()
+		require.ErrorIs(t, err, openErr)
+		require.Nil(t, w)
+	})
+
+	t.Run("token continue", func(t *testing.T) {
+		w, err := guard.WrapToken(&fakeTokenStore{openErr: openErr}, guard.DefaultPolicy()).ContinueTokenDBTransaction(nil)
+		require.ErrorIs(t, err, openErr)
+		require.Nil(t, w)
+	})
+
+	t.Run("owner transaction", func(t *testing.T) {
+		w, err := guard.WrapOwnerTransaction(&fakeOwnerTxStore{openErr: openErr}, guard.DefaultPolicy()).NewTransactionStoreTransaction()
+		require.ErrorIs(t, err, openErr)
+		require.Nil(t, w)
+	})
+
+	t.Run("audit transaction", func(t *testing.T) {
+		w, err := guard.WrapAuditTransaction(&fakeAuditTxStore{openErr: openErr}, guard.DefaultPolicy()).NewTransactionStoreTransaction()
+		require.ErrorIs(t, err, openErr)
+		require.Nil(t, w)
+	})
+}

--- a/token/services/storage/db/guard/endorser.go
+++ b/token/services/storage/db/guard/endorser.go
@@ -1,0 +1,56 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package guard
+
+import (
+	"context"
+
+	tokendriver "github.com/LFDT-Panurus/panurus/token/driver"
+	driver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+)
+
+// WrapEndorser wraps an endorser store with the guard policy.
+func WrapEndorser(s driver.EndorserStore, p Policy) driver.EndorserStore {
+	if s == nil {
+		return s
+	}
+
+	return &guardedEndorserStore{EndorserStore: s, policy: p}
+}
+
+type guardedEndorserStore struct {
+	driver.EndorserStore
+	policy Policy
+}
+
+// QueryValidations is intentionally not row-capped and delegates to the embedded
+// store unchanged: QueryValidationRecordsParams carries no page-size or cursor,
+// so a caller that hits a cap has no way to page around it. Bounding this read
+// needs a SQL-level LIMIT on the query itself (tracked follow-up), not a wrapper.
+
+func (g *guardedEndorserStore) NewEndorserStoreTransaction() (driver.EndorserStoreTransaction, error) {
+	w, err := g.EndorserStore.NewEndorserStoreTransaction()
+	if err != nil {
+		return nil, err
+	}
+
+	return &guardedEndorserStoreTx{EndorserStoreTransaction: w, policy: g.policy}, nil
+}
+
+type guardedEndorserStoreTx struct {
+	driver.EndorserStoreTransaction
+	policy Policy
+}
+
+func (w *guardedEndorserStoreTx) AddValidationRecord(ctx context.Context, txID string, tokenRequest []byte, meta map[string][]byte, ppHash tokendriver.PPHash) error {
+	size := len(txID) + len(tokenRequest) + BlobMapSize(meta)
+	if err := CheckPayload("AddValidationRecord", size, w.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return w.EndorserStoreTransaction.AddValidationRecord(ctx, txID, tokenRequest, meta, ppHash)
+}

--- a/token/services/storage/db/guard/identity.go
+++ b/token/services/storage/db/guard/identity.go
@@ -1,0 +1,74 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package guard
+
+import (
+	"context"
+
+	tokendriver "github.com/LFDT-Panurus/panurus/token/driver"
+	idriver "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
+	driver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+)
+
+// WrapIdentity wraps an identity store with the guard policy.
+func WrapIdentity(s driver.IdentityStore, p Policy) driver.IdentityStore {
+	if s == nil {
+		return s
+	}
+
+	return &guardedIdentityStore{IdentityStore: s, policy: p}
+}
+
+type guardedIdentityStore struct {
+	driver.IdentityStore
+	policy Policy
+}
+
+// IteratorConfigurations is intentionally not row-capped and delegates to the
+// embedded store unchanged. It takes no pagination argument, and
+// LocalMembership.storedIdentityConfigurations drains it in full on the identity
+// Load path, so a cap here would turn "this node has many registered identities"
+// into a hard identity-loading failure with no way for the caller to page around
+// it. Bounding this read needs a SQL-level LIMIT (tracked follow-up).
+
+func (g *guardedIdentityStore) AddConfiguration(ctx context.Context, wp idriver.IdentityConfiguration) error {
+	size := len(wp.ID) + len(wp.Type) + len(wp.URL) + len(wp.Config) + len(wp.Raw)
+	if err := CheckPayload("AddConfiguration", size, g.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return g.IdentityStore.AddConfiguration(ctx, wp)
+}
+
+func (g *guardedIdentityStore) StoreIdentityData(ctx context.Context, id []byte, identityAudit []byte, tokenMetadata []byte, tokenMetadataAudit []byte) error {
+	size := len(id) + len(identityAudit) + len(tokenMetadata) + len(tokenMetadataAudit)
+	if err := CheckPayload("StoreIdentityData", size, g.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return g.IdentityStore.StoreIdentityData(ctx, id, identityAudit, tokenMetadata, tokenMetadataAudit)
+}
+
+func (g *guardedIdentityStore) StoreSignerInfo(ctx context.Context, id tokendriver.Identity, info []byte) error {
+	if err := CheckPayload("StoreSignerInfo", len(id)+len(info), g.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return g.IdentityStore.StoreSignerInfo(ctx, id, info)
+}
+
+func (g *guardedIdentityStore) RegisterIdentityDescriptor(ctx context.Context, descriptor *idriver.IdentityDescriptor, alias tokendriver.Identity) error {
+	size := len(alias)
+	if descriptor != nil {
+		size += len(descriptor.Identity) + len(descriptor.AuditInfo) + len(descriptor.SignerInfo)
+	}
+	if err := CheckPayload("RegisterIdentityDescriptor", size, g.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return g.IdentityStore.RegisterIdentityDescriptor(ctx, descriptor, alias)
+}

--- a/token/services/storage/db/guard/payload.go
+++ b/token/services/storage/db/guard/payload.go
@@ -1,0 +1,32 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package guard
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// CheckPayload rejects a write whose serialised size exceeds max (when max > 0).
+// op names the operation for the error message.
+func CheckPayload(op string, size, max int) error {
+	if max > 0 && size > max {
+		return errors.Errorf("%s payload size %d bytes exceeds maximum %d bytes", op, size, max)
+	}
+
+	return nil
+}
+
+// BlobMapSize returns the total byte size of a key/blob map (keys included), the
+// shape used by the token-request and validation metadata maps.
+func BlobMapSize(m map[string][]byte) int {
+	n := 0
+	for k, v := range m {
+		n += len(k) + len(v)
+	}
+
+	return n
+}

--- a/token/services/storage/db/guard/payload_test.go
+++ b/token/services/storage/db/guard/payload_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package guard
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckPayload(t *testing.T) {
+	cases := []struct {
+		name    string
+		size    int
+		max     int
+		wantErr bool
+	}{
+		{"within limit", 10, 20, false},
+		{"at limit", 20, 20, false},
+		{"over limit", 21, 20, true},
+		{"disabled with zero max", 1_000_000, 0, false},
+		{"disabled with negative max", 1_000_000, -1, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := CheckPayload("op", c.size, c.max)
+			if c.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if c.wantErr && !strings.Contains(err.Error(), "exceeds maximum") {
+				t.Fatalf("expected 'exceeds maximum' error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestBlobMapSize(t *testing.T) {
+	m := map[string][]byte{
+		"a":  []byte("xy"),  // 1 + 2
+		"bb": []byte("zzz"), // 2 + 3
+	}
+	if got := BlobMapSize(m); got != 8 {
+		t.Fatalf("expected 8, got %d", got)
+	}
+	if got := BlobMapSize(nil); got != 0 {
+		t.Fatalf("expected 0 for nil map, got %d", got)
+	}
+}

--- a/token/services/storage/db/guard/policy.go
+++ b/token/services/storage/db/guard/policy.go
@@ -1,0 +1,90 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package guard provides a stackable decorator layer over the storage-service
+// stores. It enforces cross-cutting resource limits — a maximum write payload
+// size and a maximum number of rows a single read may return — without the
+// concrete SQL stores having to know about them.
+//
+// Decorators embed the driver store interface (so every method delegates by
+// default) and override only the methods that need a check, plus the nested
+// transaction objects and returned iterators. They are applied once, at the
+// multiplexed driver seam, driven by a single Policy loaded from configuration.
+package guard
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
+)
+
+const (
+	// DefaultMaxPayloadSize is the default maximum write payload size in bytes
+	// (0 disables the check).
+	DefaultMaxPayloadSize = 4 << 20 // 4 MiB
+	// DefaultMaxPageSize is the default maximum number of rows a single read may return.
+	DefaultMaxPageSize = 1000
+)
+
+const (
+	// ConfigKeyMaxPayloadSize is the config key for the max write size in bytes
+	// (0 disables). Absent means use the default.
+	ConfigKeyMaxPayloadSize = "token.storage.maxPayloadSize"
+
+	// ConfigKeyMaxPageSize is the config key for the max rows a single read may
+	// return. Absent means use the default.
+	ConfigKeyMaxPageSize = "token.storage.maxPageSize"
+)
+
+// Policy holds the resource limits enforced by the guard decorators.
+type Policy struct {
+	// MaxPayloadSize is the max write size in bytes; 0 disables the check.
+	MaxPayloadSize int
+	// MaxPageSize is the max rows a single read may return; 0 disables the cap.
+	MaxPageSize int
+}
+
+// DefaultPolicy returns the built-in limits.
+func DefaultPolicy() Policy {
+	return Policy{MaxPayloadSize: DefaultMaxPayloadSize, MaxPageSize: DefaultMaxPageSize}
+}
+
+// LoadPolicy reads the limits from cfg, falling back to the defaults for any
+// key that is absent. An explicit value (including 0) overrides the default,
+// so operators can disable a check by setting the key to 0.
+func LoadPolicy(cfg driver.Config) (Policy, error) {
+	p := DefaultPolicy()
+
+	maxPayloadSize, err := loadOptionalInt(cfg, ConfigKeyMaxPayloadSize)
+	if err != nil {
+		return Policy{}, err
+	}
+	if maxPayloadSize != nil {
+		p.MaxPayloadSize = *maxPayloadSize
+	}
+
+	maxPageSize, err := loadOptionalInt(cfg, ConfigKeyMaxPageSize)
+	if err != nil {
+		return Policy{}, err
+	}
+	if maxPageSize != nil {
+		p.MaxPageSize = *maxPageSize
+	}
+
+	return p, nil
+}
+
+// loadOptionalInt reads an int config value, returning nil when cfg is nil or
+// the key is absent so callers can tell "unset" from a set 0.
+func loadOptionalInt(cfg driver.Config, key string) (*int, error) {
+	if cfg == nil || !cfg.IsSet(key) {
+		return nil, nil
+	}
+	var v int
+	if err := cfg.UnmarshalKey(key, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}

--- a/token/services/storage/db/guard/policy_test.go
+++ b/token/services/storage/db/guard/policy_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package guard
+
+import (
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// stubConfig is a minimal driver.Config for exercising LoadPolicy.
+type stubConfig struct {
+	values map[string]int
+	// unmarshalErr, when set, is returned instead of reading a value, so the
+	// malformed-configuration path can be exercised.
+	unmarshalErr error
+}
+
+func (c *stubConfig) IsSet(key string) bool {
+	_, ok := c.values[key]
+
+	return ok
+}
+
+func (c *stubConfig) UnmarshalKey(key string, rawVal any) error {
+	if c.unmarshalErr != nil {
+		return c.unmarshalErr
+	}
+	if v, ok := c.values[key]; ok {
+		*rawVal.(*int) = v
+	}
+
+	return nil
+}
+
+func TestLoadPolicyDefaults(t *testing.T) {
+	p, err := LoadPolicy(&stubConfig{values: map[string]int{}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.MaxPayloadSize != DefaultMaxPayloadSize {
+		t.Fatalf("expected default payload size %d, got %d", DefaultMaxPayloadSize, p.MaxPayloadSize)
+	}
+	if p.MaxPageSize != DefaultMaxPageSize {
+		t.Fatalf("expected default page size %d, got %d", DefaultMaxPageSize, p.MaxPageSize)
+	}
+}
+
+func TestLoadPolicyNilConfig(t *testing.T) {
+	p, err := LoadPolicy(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p != DefaultPolicy() {
+		t.Fatalf("expected default policy for nil config, got %+v", p)
+	}
+}
+
+func TestLoadPolicyOverrideAndDisable(t *testing.T) {
+	// An explicit 0 disables the payload check; page size is overridden.
+	p, err := LoadPolicy(&stubConfig{values: map[string]int{
+		ConfigKeyMaxPayloadSize: 0,
+		ConfigKeyMaxPageSize:    250,
+	}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.MaxPayloadSize != 0 {
+		t.Fatalf("expected payload size 0 (disabled), got %d", p.MaxPayloadSize)
+	}
+	if p.MaxPageSize != 250 {
+		t.Fatalf("expected page size 250, got %d", p.MaxPageSize)
+	}
+}
+
+// TestLoadPolicyUnmarshalError verifies a malformed value for either key fails
+// the load instead of silently falling back to the default limit, which would
+// leave the node running with limits the operator did not configure.
+func TestLoadPolicyUnmarshalError(t *testing.T) {
+	broken := errors.New("malformed value")
+
+	for _, key := range []string{ConfigKeyMaxPayloadSize, ConfigKeyMaxPageSize} {
+		p, err := LoadPolicy(&stubConfig{
+			values:       map[string]int{key: 1},
+			unmarshalErr: broken,
+		})
+		if !errors.Is(err, broken) {
+			t.Fatalf("%s: expected the unmarshal error, got %v", key, err)
+		}
+		if p != (Policy{}) {
+			t.Fatalf("%s: expected a zero policy on error, got %+v", key, p)
+		}
+	}
+}

--- a/token/services/storage/db/guard/token.go
+++ b/token/services/storage/db/guard/token.go
@@ -1,0 +1,92 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package guard
+
+import (
+	"context"
+
+	driver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	"github.com/LFDT-Panurus/panurus/token/token"
+)
+
+// WrapToken wraps a token store with the guard policy.
+func WrapToken(s driver.TokenStore, p Policy) driver.TokenStore {
+	if s == nil {
+		return s
+	}
+
+	return &guardedTokenStore{TokenStore: s, policy: p}
+}
+
+type guardedTokenStore struct {
+	driver.TokenStore
+	policy Policy
+}
+
+// Token-store streaming reads are intentionally not row-capped: their consumers
+// (selectors, integrity checks, token upgrade) drain them in full, so a cap would
+// break a legitimate read once a wallet holds more than MaxPageSize tokens. They
+// delegate to the embedded store unchanged. Writes are still payload-capped below.
+
+// --- writes: cap payload size ---
+
+func (g *guardedTokenStore) StorePublicParams(ctx context.Context, raw []byte) error {
+	if err := CheckPayload("StorePublicParams", len(raw), g.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return g.TokenStore.StorePublicParams(ctx, raw)
+}
+
+func (g *guardedTokenStore) StoreCertifications(ctx context.Context, certifications map[*token.ID][]byte) error {
+	size := 0
+	for _, v := range certifications {
+		size += len(v)
+	}
+	if err := CheckPayload("StoreCertifications", size, g.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return g.TokenStore.StoreCertifications(ctx, certifications)
+}
+
+func (g *guardedTokenStore) NewTokenDBTransaction() (driver.TokenStoreTransaction, error) {
+	w, err := g.TokenStore.NewTokenDBTransaction()
+	if err != nil {
+		return nil, err
+	}
+
+	return &guardedTokenStoreTx{TokenStoreTransaction: w, policy: g.policy}, nil
+}
+
+func (g *guardedTokenStore) ContinueTokenDBTransaction(tx driver.Transaction) (driver.TokenStoreTransaction, error) {
+	w, err := g.TokenStore.ContinueTokenDBTransaction(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &guardedTokenStoreTx{TokenStoreTransaction: w, policy: g.policy}, nil
+}
+
+type guardedTokenStoreTx struct {
+	driver.TokenStoreTransaction
+	policy Policy
+}
+
+func (w *guardedTokenStoreTx) StoreToken(ctx context.Context, tr driver.TokenRecord, owners []string) error {
+	size := len(tr.TxID) + len(tr.IssuerRaw) + len(tr.OwnerRaw) + len(tr.OwnerIdentity) +
+		len(tr.OwnerType) + len(tr.OwnerWalletID) + len(tr.Ledger) + len(tr.LedgerFormat) +
+		len(tr.LedgerMetadata) + len(tr.Quantity) + len(tr.Type)
+	for _, o := range owners {
+		size += len(o)
+	}
+	if err := CheckPayload("StoreToken", size, w.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return w.TokenStoreTransaction.StoreToken(ctx, tr, owners)
+}

--- a/token/services/storage/db/guard/transactions.go
+++ b/token/services/storage/db/guard/transactions.go
@@ -1,0 +1,149 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package guard
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	tdriver "github.com/LFDT-Panurus/panurus/token/driver"
+	driver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query/pagination"
+	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+)
+
+// WrapOwnerTransaction wraps an owner transaction store with the guard policy.
+func WrapOwnerTransaction(s driver.TokenTransactionStore, p Policy) driver.TokenTransactionStore {
+	if s == nil {
+		return s
+	}
+
+	return &guardedOwnerTx{TokenTransactionStore: s, policy: p}
+}
+
+// WrapAuditTransaction wraps an audit transaction store with the guard policy.
+func WrapAuditTransaction(s driver.AuditTransactionStore, p Policy) driver.AuditTransactionStore {
+	if s == nil {
+		return s
+	}
+
+	return &guardedAuditTx{AuditTransactionStore: s, policy: p}
+}
+
+type guardedOwnerTx struct {
+	driver.TokenTransactionStore
+	policy Policy
+}
+
+func (g *guardedOwnerTx) QueryTransactions(ctx context.Context, params driver.QueryTransactionsParams, p driver2.Pagination) (*driver2.PageIterator[*driver.TransactionRecord], error) {
+	if err := pagination.ValidateLimited(p, g.policy.MaxPageSize); err != nil {
+		return nil, err
+	}
+
+	return g.TokenTransactionStore.QueryTransactions(ctx, params, p)
+}
+
+// QueryTokenRequests is intentionally not row-capped on either transaction store
+// and delegates to the embedded store unchanged: QueryTokenRequestsParams carries
+// only a status filter, with no page size or cursor, so a caller that hits a cap
+// cannot page around it. Bounding this read needs a SQL-level LIMIT on the query
+// itself (tracked follow-up). QueryTransactions above is capped instead, because
+// it does take a pagination argument, so rejecting an unbounded page is actionable.
+
+func (g *guardedOwnerTx) AddTransactionEndorsementAck(ctx context.Context, txID string, endorser token.Identity, sigma []byte) error {
+	if err := CheckPayload("AddTransactionEndorsementAck", len(txID)+len(endorser)+len(sigma), g.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return g.TokenTransactionStore.AddTransactionEndorsementAck(ctx, txID, endorser, sigma)
+}
+
+func (g *guardedOwnerTx) NewTransactionStoreTransaction() (driver.TransactionStoreTransaction, error) {
+	w, err := g.TokenTransactionStore.NewTransactionStoreTransaction()
+	if err != nil {
+		return nil, err
+	}
+
+	return &guardedStoreTx{TransactionStoreTransaction: w, policy: g.policy}, nil
+}
+
+type guardedAuditTx struct {
+	driver.AuditTransactionStore
+	policy Policy
+}
+
+func (g *guardedAuditTx) QueryTransactions(ctx context.Context, params driver.QueryTransactionsParams, p driver2.Pagination) (*driver2.PageIterator[*driver.TransactionRecord], error) {
+	if err := pagination.ValidateLimited(p, g.policy.MaxPageSize); err != nil {
+		return nil, err
+	}
+
+	return g.AuditTransactionStore.QueryTransactions(ctx, params, p)
+}
+
+func (g *guardedAuditTx) NewTransactionStoreTransaction() (driver.TransactionStoreTransaction, error) {
+	w, err := g.AuditTransactionStore.NewTransactionStoreTransaction()
+	if err != nil {
+		return nil, err
+	}
+
+	return &guardedStoreTx{TransactionStoreTransaction: w, policy: g.policy}, nil
+}
+
+// guardedStoreTx enforces the write payload limit on the atomic write path used
+// by both the owner and audit transaction stores.
+type guardedStoreTx struct {
+	driver.TransactionStoreTransaction
+	policy Policy
+}
+
+func (w *guardedStoreTx) AddTransaction(ctx context.Context, records ...driver.TransactionRecord) error {
+	// The summed fields mirror the columns the SQL store actually persists for a
+	// transaction row (tx_id, sender/recipient EID, token type, amount); the
+	// record's metadata maps are stored via AddTokenRequest, which is guarded
+	// separately, so they are deliberately not counted here.
+	size := 0
+	for _, r := range records {
+		size += len(r.TxID) + len(r.SenderEID) + len(r.RecipientEID) + len(r.TokenType) + amountLen(r.Amount)
+	}
+	if err := CheckPayload("AddTransaction", size, w.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return w.TransactionStoreTransaction.AddTransaction(ctx, records...)
+}
+
+func (w *guardedStoreTx) AddMovement(ctx context.Context, records ...driver.MovementRecord) error {
+	size := 0
+	for _, r := range records {
+		size += len(r.TxID) + len(r.EnrollmentID) + len(r.TokenType) + amountLen(r.Amount)
+	}
+	if err := CheckPayload("AddMovement", size, w.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return w.TransactionStoreTransaction.AddMovement(ctx, records...)
+}
+
+func (w *guardedStoreTx) AddTokenRequest(ctx context.Context, txID string, tr []byte, applicationMetadata, publicMetadata map[string][]byte, ppHash tdriver.PPHash) error {
+	size := len(tr) + BlobMapSize(applicationMetadata) + BlobMapSize(publicMetadata)
+	if err := CheckPayload("AddTokenRequest", size, w.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return w.TransactionStoreTransaction.AddTokenRequest(ctx, txID, tr, applicationMetadata, publicMetadata, ppHash)
+}
+
+// amountLen returns the decimal-string length of a token amount, treating a nil
+// amount as zero-length (the underlying store validates the amount itself).
+func amountLen(amount *big.Int) int {
+	if amount == nil {
+		return 0
+	}
+
+	return len(amount.String())
+}

--- a/token/services/storage/db/guard/wallet.go
+++ b/token/services/storage/db/guard/wallet.go
@@ -1,0 +1,38 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package guard
+
+import (
+	"context"
+
+	token2 "github.com/LFDT-Panurus/panurus/token"
+	idriver "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
+	driver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+)
+
+// WrapWallet wraps a wallet store with the guard policy.
+func WrapWallet(s driver.WalletStore, p Policy) driver.WalletStore {
+	if s == nil {
+		return s
+	}
+
+	return &guardedWalletStore{WalletStore: s, policy: p}
+}
+
+type guardedWalletStore struct {
+	driver.WalletStore
+	policy Policy
+}
+
+func (g *guardedWalletStore) StoreIdentity(ctx context.Context, identity token2.Identity, eID string, wID idriver.WalletID, roleID int, meta []byte, confID string) error {
+	size := len(identity) + len(eID) + len(wID) + len(meta) + len(confID)
+	if err := CheckPayload("StoreIdentity", size, g.policy.MaxPayloadSize); err != nil {
+		return err
+	}
+
+	return g.WalletStore.StoreIdentity(ctx, identity, eID, wID, roleID, meta, confID)
+}

--- a/token/services/storage/db/multiplexed/driver.go
+++ b/token/services/storage/db/multiplexed/driver.go
@@ -7,14 +7,19 @@ SPDX-License-Identifier: Apache-2.0
 package multiplexed
 
 import (
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	driver4 "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/guard"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	driver3 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 )
 
-var _ driver4.Driver = &Driver{}
+var (
+	_      driver4.Driver = &Driver{}
+	logger                = logging.MustGetLogger()
+)
 
 func NewDriver(config driver4.Config, ds ...driver4.NamedDriver) Driver {
 	drivers := make(map[driver3.PersistenceType]driver4.Driver, len(ds))
@@ -22,15 +27,25 @@ func NewDriver(config driver4.Config, ds ...driver4.NamedDriver) Driver {
 		drivers[d.Name] = d.Driver
 	}
 
+	// The storage guard policy is cross-cutting and applies to every backing
+	// driver, so it is loaded once here and applied as each store is created.
+	policy, err := guard.LoadPolicy(config)
+	if err != nil {
+		logger.Warnf("failed to load storage guard policy: %v — using defaults", err)
+		policy = guard.DefaultPolicy()
+	}
+
 	return Driver{
 		drivers: drivers,
 		config:  common.NewConfig(config),
+		policy:  policy,
 	}
 }
 
 type Driver struct {
 	drivers map[driver3.PersistenceType]driver4.Driver
 	config  driver2.PersistenceConfig
+	policy  guard.Policy
 }
 
 func (d Driver) NewTokenLock(name driver2.PersistenceName, params ...string) (driver4.TokenLockStore, error) {
@@ -47,8 +62,12 @@ func (d Driver) NewWallet(name driver2.PersistenceName, params ...string) (drive
 	if err != nil {
 		return nil, err
 	}
+	s, err := dr.NewWallet(name, params...)
+	if err != nil {
+		return nil, err
+	}
 
-	return dr.NewWallet(name, params...)
+	return guard.WrapWallet(s, d.policy), nil
 }
 
 func (d Driver) NewIdentity(name driver2.PersistenceName, params ...string) (driver4.IdentityStore, error) {
@@ -56,8 +75,12 @@ func (d Driver) NewIdentity(name driver2.PersistenceName, params ...string) (dri
 	if err != nil {
 		return nil, err
 	}
+	s, err := dr.NewIdentity(name, params...)
+	if err != nil {
+		return nil, err
+	}
 
-	return dr.NewIdentity(name, params...)
+	return guard.WrapIdentity(s, d.policy), nil
 }
 
 func (d Driver) NewKeyStore(name driver2.PersistenceName, params ...string) (driver4.KeyStore, error) {
@@ -74,8 +97,12 @@ func (d Driver) NewToken(name driver2.PersistenceName, params ...string) (driver
 	if err != nil {
 		return nil, err
 	}
+	s, err := dr.NewToken(name, params...)
+	if err != nil {
+		return nil, err
+	}
 
-	return dr.NewToken(name, params...)
+	return guard.WrapToken(s, d.policy), nil
 }
 
 func (d Driver) NewAuditTransaction(name driver2.PersistenceName, params ...string) (driver4.AuditTransactionStore, error) {
@@ -83,8 +110,12 @@ func (d Driver) NewAuditTransaction(name driver2.PersistenceName, params ...stri
 	if err != nil {
 		return nil, err
 	}
+	s, err := dr.NewAuditTransaction(name, params...)
+	if err != nil {
+		return nil, err
+	}
 
-	return dr.NewAuditTransaction(name, params...)
+	return guard.WrapAuditTransaction(s, d.policy), nil
 }
 
 func (d Driver) NewOwnerTransaction(name driver2.PersistenceName, params ...string) (driver4.TokenTransactionStore, error) {
@@ -92,8 +123,12 @@ func (d Driver) NewOwnerTransaction(name driver2.PersistenceName, params ...stri
 	if err != nil {
 		return nil, err
 	}
+	s, err := dr.NewOwnerTransaction(name, params...)
+	if err != nil {
+		return nil, err
+	}
 
-	return dr.NewOwnerTransaction(name, params...)
+	return guard.WrapOwnerTransaction(s, d.policy), nil
 }
 
 func (d Driver) NewEndorser(name driver2.PersistenceName, params ...string) (driver4.EndorserStore, error) {
@@ -101,8 +136,12 @@ func (d Driver) NewEndorser(name driver2.PersistenceName, params ...string) (dri
 	if err != nil {
 		return nil, err
 	}
+	s, err := dr.NewEndorser(name, params...)
+	if err != nil {
+		return nil, err
+	}
 
-	return dr.NewEndorser(name, params...)
+	return guard.WrapEndorser(s, d.policy), nil
 }
 
 func (d Driver) getDriver(name driver2.PersistenceName) (driver4.Driver, error) {

--- a/token/services/storage/db/sql/common/transactions.go
+++ b/token/services/storage/db/sql/common/transactions.go
@@ -395,7 +395,7 @@ func (db *TransactionStore) Notifier() (dbdriver.TransactionNotifier, error) {
 	return db.notifier, nil
 }
 
-// QueryTokenRequests returns an iterator over the token requests matching the passed params
+// QueryTokenRequests returns an iterator over the token requests matching the passed params.
 func (db *TransactionStore) QueryTokenRequests(ctx context.Context, params dbdriver.QueryTokenRequestsParams) (dbdriver.TokenRequestIterator, error) {
 	query, args := q.Select().
 		FieldsByName("tx_id", "request", "status").

--- a/token/services/storage/db/sql/common/transactions_test_util.go
+++ b/token/services/storage/db/sql/common/transactions_test_util.go
@@ -121,10 +121,12 @@ func TestQueryTransactions(t *testing.T, store transactionsStoreConstructor) {
 			"FROM TRANSACTIONS LEFT JOIN REQUESTS ON TRANSACTIONS.tx_id = REQUESTS.tx_id ORDER BY TRANSACTIONS.stored_at DESC").
 		WillReturnRows(mockDB.NewRows([]string{"tx_id", "action_type", "sender_eid", "recipient_eid", "token_type", "amount", "status", "application_metadata", "public_metadata", "stored_at"}).AddRow(output...))
 
+	page, err := pagination.Offset(0, 10)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	info, err := store(db).QueryTransactions(t.Context(),
 		driver.QueryTransactionsParams{
 			IDs: []string{},
-		}, pagination.None())
+		}, page)
 
 	gomega.Expect(mockDB.ExpectationsWereMet()).To(gomega.Succeed())
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())

--- a/token/services/storage/db/sql/postgres/driver.go
+++ b/token/services/storage/db/sql/postgres/driver.go
@@ -58,10 +58,11 @@ func NewDriver(config driver3.Config) *Driver {
 
 // NewDriverWithDbProvider returns a new Driver for Postgres using the given database provider.
 func NewDriverWithDbProvider(config driver3.Config, dbProvider fscPostgres.DbProvider) *Driver {
-	tableNamesConfig, err := common3.LoadTableNamesConfig(config)
+	storageConfig, err := common3.LoadStorageConfig(config)
 	if err != nil {
-		logger.Warnf("failed to load table name overrides: %v — using defaults", err)
+		logger.Warnf("failed to load storage config: %v — using defaults", err)
 	}
+	tableNamesConfig := storageConfig.TableNames
 
 	d := &Driver{
 		cp:               fscPostgres.NewConfigProvider(common.NewConfig(config)),

--- a/token/services/storage/db/sql/query/pagination/keyset.go
+++ b/token/services/storage/db/sql/query/pagination/keyset.go
@@ -161,6 +161,10 @@ func (p *keyset[I, V]) Prev() (driver.Pagination, error) { return p.GoBack(1) }
 
 func (p *keyset[I, V]) Next() (driver.Pagination, error) { return p.GoForward(1) }
 
+// pageSize implements pageSized so ValidateLimited can bound every keyset[I, V]
+// instantiation uniformly, regardless of its type parameters.
+func (p *keyset[I, V]) pageSize() int { return p.PageSize }
+
 func (k *keyset[I, V]) Equal(other driver.Pagination) bool {
 	otherKeyset, ok := other.(*keyset[I, V])
 	if !ok {

--- a/token/services/storage/db/sql/query/pagination/offset.go
+++ b/token/services/storage/db/sql/query/pagination/offset.go
@@ -72,6 +72,9 @@ func (p *offset) GoBack(numOfpages int) (driver.Pagination, error) {
 func (p *offset) Prev() (driver.Pagination, error) { return p.GoBack(1) }
 func (p *offset) Next() (driver.Pagination, error) { return p.GoForward(1) }
 
+// pageSize implements pageSized so ValidateLimited can bound the page uniformly.
+func (p *offset) pageSize() int { return p.PageSize }
+
 func (o *offset) Equal(other driver.Pagination) bool {
 	otherOffset, ok := other.(*offset)
 	if !ok {

--- a/token/services/storage/db/sql/query/pagination/validate.go
+++ b/token/services/storage/db/sql/query/pagination/validate.go
@@ -1,0 +1,72 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pagination
+
+import (
+	"reflect"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+)
+
+// pageSized is implemented by the bounded paginations that carry a page-size
+// limit (offset and every keyset[I, V] instantiation). ValidateLimited uses it
+// to bound them uniformly, so a keyset with a concrete value type cannot slip
+// past the check the way an explicit type switch on keyset[I, any] would.
+type pageSized interface {
+	pageSize() int
+}
+
+// ValidateLimited rejects pagination that would run an unlimited scan: nil,
+// None(), or a page (offset or keyset) whose page size is non-positive or
+// exceeds maxPageSize (limited only when maxPageSize > 0). Empty pagination
+// (an always-empty page) is allowed. Any pagination type that does not expose a
+// page-size limit is rejected (fail closed): the guard cannot prove it is
+// bounded, so it must not be allowed to run a possibly unlimited scan.
+func ValidateLimited(p driver.Pagination, maxPageSize int) error {
+	if p == nil {
+		return errors.New("pagination is required: a page-size limit must be provided")
+	}
+	// Guard a typed-nil pointer (e.g. (*offset)(nil) boxed into the interface)
+	// so the checks below don't panic dereferencing it.
+	if rv := reflect.ValueOf(p); rv.Kind() == reflect.Pointer && rv.IsNil() {
+		return errors.New("pagination is required: a page-size limit must be provided")
+	}
+
+	switch p.(type) {
+	case *none:
+		return errors.New("unlimited pagination (None) is not allowed")
+	case *empty:
+		// Empty compiles to LIMIT 0 (returns zero rows), so it is always within
+		// any cap and safe to allow regardless of maxPageSize. Do not reject it:
+		// None (no LIMIT clause) is the unbounded case, handled above.
+		return nil
+	}
+
+	// offset and every keyset[I, V] expose their page size through pageSized,
+	// so a single check bounds them all regardless of the keyset's type
+	// parameters.
+	ps, ok := p.(pageSized)
+	if !ok {
+		return errors.Errorf("unsupported pagination type %T: cannot verify its page-size limit", p)
+	}
+
+	return validatePageSize(ps.pageSize(), maxPageSize)
+}
+
+// validatePageSize checks a page size against the store cap: it must be
+// positive and, when maxPageSize > 0, no larger than maxPageSize.
+func validatePageSize(pageSize, maxPageSize int) error {
+	if pageSize <= 0 {
+		return errors.Errorf("pagination page size must be positive, got %d", pageSize)
+	}
+	if maxPageSize > 0 && pageSize > maxPageSize {
+		return errors.Errorf("pagination page size %d exceeds maximum %d", pageSize, maxPageSize)
+	}
+
+	return nil
+}

--- a/token/services/storage/db/sql/query/pagination/validate_test.go
+++ b/token/services/storage/db/sql/query/pagination/validate_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pagination
+
+import (
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query/common"
+)
+
+// unknownPagination implements driver.Pagination but not pageSized, so
+// ValidateLimited must reject it (fail closed) rather than allow it.
+type unknownPagination struct{}
+
+func (unknownPagination) Prev() (driver.Pagination, error) { return nil, nil }
+func (unknownPagination) Next() (driver.Pagination, error) { return nil, nil }
+func (unknownPagination) Equal(driver.Pagination) bool     { return false }
+func (unknownPagination) Serialize() ([]byte, error)       { return nil, nil }
+
+// concreteRow is a keyset value type with a concrete (non-any) V parameter.
+type concreteRow struct{ ID string }
+
+func TestValidateLimited(t *testing.T) {
+	off, err := Offset(0, 10)
+	if err != nil {
+		t.Fatalf("unexpected error building offset: %v", err)
+	}
+	bigOff, err := Offset(0, 100)
+	if err != nil {
+		t.Fatalf("unexpected error building offset: %v", err)
+	}
+	zeroOff, err := Offset(0, 0)
+	if err != nil {
+		t.Fatalf("unexpected error building offset: %v", err)
+	}
+
+	// keyset with the usual any value type.
+	ksAny, err := KeysetWithField[string](0, 10, common.FieldName("id"), PropertyName[string]("ID"))
+	if err != nil {
+		t.Fatalf("unexpected error building keyset: %v", err)
+	}
+	bigKsAny, err := KeysetWithField[string](0, 100, common.FieldName("id"), PropertyName[string]("ID"))
+	if err != nil {
+		t.Fatalf("unexpected error building keyset: %v", err)
+	}
+	// keyset with a concrete value type: previously fell through to the default
+	// case and was allowed unbounded — it must now be capped like any other.
+	bigKsConcrete, err := Keyset[string, concreteRow](0, 100, common.FieldName("id"), func(r concreteRow) string { return r.ID })
+	if err != nil {
+		t.Fatalf("unexpected error building concrete keyset: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		build   func() error
+		wantErr bool
+	}{
+		{"nil is rejected", func() error { return ValidateLimited(nil, 50) }, true},
+		{"typed-nil offset is rejected", func() error { return ValidateLimited((*offset)(nil), 50) }, true},
+		{"None is rejected", func() error { return ValidateLimited(None(), 50) }, true},
+		{"Empty is allowed", func() error { return ValidateLimited(Empty(), 50) }, false},
+		{"offset within the limit is allowed", func() error { return ValidateLimited(off, 50) }, false},
+		{"offset over max is rejected", func() error { return ValidateLimited(bigOff, 50) }, true},
+		{"zero page size is rejected", func() error { return ValidateLimited(zeroOff, 50) }, true},
+		{"no max disables the cap", func() error { return ValidateLimited(bigOff, 0) }, false},
+		{"keyset[any] within the limit is allowed", func() error { return ValidateLimited(ksAny, 50) }, false},
+		{"keyset[any] over max is rejected", func() error { return ValidateLimited(bigKsAny, 50) }, true},
+		{"keyset[concrete] over max is rejected", func() error { return ValidateLimited(bigKsConcrete, 50) }, true},
+		{"unsupported pagination type is rejected", func() error { return ValidateLimited(unknownPagination{}, 50) }, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.build()
+			if c.wantErr && err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/token/services/storage/db/sql/sqlite/driver.go
+++ b/token/services/storage/db/sql/sqlite/driver.go
@@ -53,10 +53,11 @@ func NewDriver(config driver3.Config) *Driver {
 }
 
 func NewDriverWithDbProvider(config driver3.Config, dbProvider fscSqlite.DbProvider) *Driver {
-	tableNamesConfig, err := common2.LoadTableNamesConfig(config)
+	storageConfig, err := common2.LoadStorageConfig(config)
 	if err != nil {
-		logger.Warnf("failed to load table name overrides: %v — using defaults", err)
+		logger.Warnf("failed to load storage config: %v — using defaults", err)
 	}
+	tableNamesConfig := storageConfig.TableNames
 
 	d := &Driver{
 		cp:               fscSqlite.NewConfigProvider(common.NewConfig(config)),


### PR DESCRIPTION
Add size limits to the storage service so one huge write or one unlimited query can't overload the database. Fixes the [MED] issue #1630 (denial of service from unlimited resource use, CWE-400 / CWE-770).

## What changed since the first revision

The first revision implemented the limits **only for the transaction store**, via per-constructor `WithMax*` options + inline checks. Per review feedback (that approach doesn't scale beyond one store), this has been reworked into a single, **stackable guard decorator layer** applied across the whole storage service. The transaction store was migrated onto it, so there is now one mechanism.

## How it works

- New package `token/services/storage/db/guard/`: a `Policy` (loaded once from config), payload-size checks, a row-capping `LimitIterator`, and interface-embedding decorators for the transaction, token, endorser, identity and wallet stores. Each decorator embeds the store interface (delegating everything) and overrides only the methods that need a check, plus the nested write-transactions and returned iterators.
- Applied once at the `multiplexed.Driver` seam: every `NewXxx` result is wrapped, so all backing drivers (SQLite, PostgreSQL) and all stores are covered uniformly. Additional layers (metrics/tracing) can stack the same way, with the concrete SQL store at the bottom.

## What is guarded

**Write payload size** — `maxPayloadSize` (default 4 MiB; `0` disables), rejected before reaching the DB:
- transaction: `AddTokenRequest`, `AddTransaction`, `AddMovement`, `AddTransactionEndorsementAck`
- token: `StoreToken`, `StorePublicParams`, `StoreCertifications`
- endorser: `AddValidationRecord`
- identity: `StoreIdentityData`, `StoreSignerInfo`, `RegisterIdentityDescriptor`, `AddConfiguration`
- wallet: `StoreIdentity`

**Read caps** — `maxPageSize` (default 1000):
- paginated `QueryTransactions` — `nil` / `pagination.None()` / over-max pages are rejected
- streaming iterators — token unspent/spendable/unsupported iterators, `QueryValidations`, `QueryTokenRequests`, `IteratorConfigurations` — capped by a `LimitIterator` that errors (rather than silently truncating) once the cap is exceeded

**Intentionally uncapped:** `QueryMovements` (feeds balance totals; dropping rows would silently return wrong balances).

Also closes two gaps in `pagination.ValidateLimited`: keyset page size is now capped against `maxPageSize`, and a typed-nil offset is guarded.

## Configuration / upgrade note

Limits are **on by default** (4 MiB / 1000), so existing deployments get them automatically. Override via `token.storage.maxPayloadSize` / `token.storage.maxPageSize`; an explicit `0` disables the respective check. Paging on `QueryTransactions` cannot be turned off — `nil`/`None` are rejected — so any caller that read everything at once now pages (see `collectAllTransactions` / `checks.go`).

## Not yet addressed (tracked follow-up)

These vectors can't be closed by a wrapper alone, because the SQL has already materialised the full result before the decorator sees it — they need query-level changes and will be handled in a follow-up:

- **Materialized slice/map reads**: `ListUnspentTokens`, `ListUnspentTokensByWallets`, `ListHistoryIssuedTokens`, `ListAuditTokens`, `QueryTokenDetails`, `ConfigurationsByID`, `GetWalletIDs`, `GetExistingSignerInfo` — need a SQL-level `LIMIT` (with a defined order + documented truncation) or conversion to iterators.
- **Variadic input-size caps**: `DeleteTokens`, `GetTokens`, `GetTokenRequests` — a huge id list expands into a huge `IN (...)` clause.
- **`Keystore.Put`**: opaque value serialised inside the store, so its size is only known at marshal time.

Closes #1630.
