### PR TITLE
more optimization for calculating lagrange numerators

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/csp.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/csp.go
@@ -12,6 +12,38 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
+// collapseTrailingEqualPoints folds a maximal trailing run of identical points
+// into a single entry whose scalar is the sum of the run's scalars. As MSM is
+// linear, MSM(points, scalars) is unchanged.
+//
+// The CSP generators are power-of-two padded with a trailing run of GenG1, so
+// this shrinks the gen_f MSM to its distinct generators. It returns reduced
+// views of the inputs and overwrites scalars[start] with the run sum, so the
+// caller must not reuse scalars afterwards. The slices are returned unchanged
+// when the trailing run has length < 2.
+func collapseTrailingEqualPoints(points []*mathlib.G1, scalars []*mathlib.Zr, curve *mathlib.Curve) ([]*mathlib.G1, []*mathlib.Zr) {
+	n := len(points)
+	if n < 2 {
+		return points, scalars
+	}
+
+	start := n - 1
+	for start > 0 && points[start-1].Equals(points[n-1]) {
+		start--
+	}
+	if start == n-1 {
+		return points, scalars // no run to fold
+	}
+
+	sum := scalars[start].Copy()
+	for i := start + 1; i < n; i++ {
+		sum = curve.ModAdd(sum, scalars[i], curve.GroupOrder)
+	}
+	scalars[start] = sum
+
+	return points[:start+1], scalars[:start+1]
+}
+
 // Proof is the non-interactive compressed sigma-protocol proof for a linear
 // form evaluation over a Pedersen commitment.
 //
@@ -295,25 +327,39 @@ func (v *verifier) Verify(proof *Proof) error {
 		comScalars = append(comScalars, mulScratch.Copy())
 	}
 
-	com := v.Curve.MultiScalarMul(comPoints, comScalars)
-
 	// Compute the coefficient vector s such that
 	//   gen_f = sum_i s[i] · gen[i]   and   f_f = sum_i s[i] · f[i]
 	// then evaluate both via a single MSM and a single inner product.
 	n := 1 << v.NumberOfRounds
 	s := sVector(n, challenges, v.Curve)
 
-	// gen_f = MSM(Generators, s)
-	genF := v.Curve.MultiScalarMul(v.Generators, s)
-
-	// f_f = ⟨s, LinearForm⟩  (scalar-field MSM via ModAddMul)
+	// f_f = ⟨s, LinearForm⟩  (scalar-field MSM via ModAddMul).
+	// Computed before the gen_f collapse below, which may truncate s in place.
 	fF := math.InnerProduct(s, v.LinearForm, v.Curve)
 
-	// Final check: com_f^{f_f} == gen_f^{val_f}
-	lhs := com.Mul(fF)
-	rhs := genF.Mul(val)
+	// gen_f = MSM(Generators, s). The generators are power-of-two padded with a
+	// trailing run of GenG1; fold it away so the MSM runs over distinct points.
+	genPoints, genScalars := collapseTrailingEqualPoints(v.Generators, s, v.Curve)
 
-	if !lhs.Equals(rhs) {
+	// Final check: com^{f_f} == gen_f^{val}, where com = MSM(comPoints, comScalars)
+	// and gen_f = MSM(genPoints, genScalars). Since MSM is linear this is the same as
+	//   MSM(comPoints ∪ genPoints, [comScalars·f_f, genScalars·(−val)]) == identity,
+	// so we pre-scale the two scalar vectors (field muls), concatenate, and run a
+	// single MSM instead of two MSMs plus two EC scalar multiplications.
+	negVal := v.Curve.ModNeg(val, v.Curve.GroupOrder)
+
+	allPoints := make([]*mathlib.G1, 0, len(comPoints)+len(genPoints))
+	allScalars := make([]*mathlib.Zr, 0, len(comPoints)+len(genPoints))
+	for i := range comPoints {
+		allPoints = append(allPoints, comPoints[i])
+		allScalars = append(allScalars, v.Curve.ModMul(comScalars[i], fF, v.Curve.GroupOrder))
+	}
+	for i := range genPoints {
+		allPoints = append(allPoints, genPoints[i])
+		allScalars = append(allScalars, v.Curve.ModMul(genScalars[i], negVal, v.Curve.GroupOrder))
+	}
+
+	if !v.Curve.MultiScalarMul(allPoints, allScalars).IsInfinity() {
 		return errors.New("CSP proof verification failed")
 	}
 

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_binary_tree_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_binary_tree_test.go
@@ -1,0 +1,356 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package csp
+
+import (
+	"testing"
+
+	mathlib "github.com/IBM/mathlib"
+	bls12381fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// naiveNumeratorsBLS computes ∏_{j≠i} input[j] for each i using a straightforward
+// O(n²) loop. Used as a reference oracle in tests.
+func naiveNumeratorsBLS(input []*bls12381fr.Element, m int) []*bls12381fr.Element {
+	out := make([]*bls12381fr.Element, m)
+	for i := range m {
+		out[i] = new(bls12381fr.Element).SetOne()
+		for j := range m {
+			if j != i {
+				out[i].Mul(out[i], input[j])
+			}
+		}
+	}
+
+	return out
+}
+
+// naiveNumeratorsBN254 is the BN254 counterpart of naiveNumeratorsBLS.
+func naiveNumeratorsBN254(input []*bn254fr.Element, m int) []*bn254fr.Element {
+	out := make([]*bn254fr.Element, m)
+	for i := range m {
+		out[i] = new(bn254fr.Element).SetOne()
+		for j := range m {
+			if j != i {
+				out[i].Mul(out[i], input[j])
+			}
+		}
+	}
+
+	return out
+}
+
+// blsNumeratorsBinaryTree runs the binary tree algorithm for the given c and m,
+// and returns the numerators. Test-only helper.
+func blsNumeratorsBinaryTree(c int64, m int) []*bls12381fr.Element {
+	curve := mathlib.Curves[mathlib.BLS12_381]
+	cZr := curve.NewZrFromInt(c)
+	pooled := getTreeArrays[bls12381fr.Element](m)
+	result := computeNumeratorsBinaryTree[bls12381fr.Element, *bls12381fr.Element](m, cZr, pooled, nil)
+	putTreeArrays(pooled)
+
+	return result
+}
+
+// bn254NumeratorsBinaryTree is the BN254 counterpart of blsNumeratorsBinaryTree.
+func bn254NumeratorsBinaryTree(c int64, m int) []*bn254fr.Element {
+	curve := mathlib.Curves[mathlib.BN254]
+	cZr := curve.NewZrFromInt(c)
+	pooled := getTreeArrays[bn254fr.Element](m)
+	result := computeNumeratorsBinaryTree[bn254fr.Element, *bn254fr.Element](m, cZr, pooled, nil)
+	putTreeArrays(pooled)
+
+	return result
+}
+
+// buildCMinusJBLS builds cMinusJE[j] = c - j for j = 0..m-1.
+func buildCMinusJBLS(c int64, m int) []*bls12381fr.Element {
+	elems := make([]*bls12381fr.Element, m)
+	for j := range m {
+		e := new(bls12381fr.Element)
+		e.SetInt64(c - int64(j)) // #nosec G115
+		elems[j] = e
+	}
+
+	return elems
+}
+
+func buildCMinusJBN254(c int64, m int) []*bn254fr.Element {
+	elems := make([]*bn254fr.Element, m)
+	for j := range m {
+		e := new(bn254fr.Element)
+		e.SetInt64(c - int64(j)) // #nosec G115
+		elems[j] = e
+	}
+
+	return elems
+}
+
+// equalsBLS reports whether two BLS12-381 elements are equal.
+func equalsBLS(a, b *bls12381fr.Element) bool { return a.Equal(b) }
+
+// equalsBN254 reports whether two BN254 elements are equal.
+func equalsBN254(a, b *bn254fr.Element) bool { return a.Equal(b) }
+
+// smallMValues are small sizes of both parities exercising different tree shapes
+// (method0 supports even and odd m via consecutive left-to-right pairing).
+var smallMValues = []int{2, 3, 4, 5, 7, 8, 9, 13, 16}
+
+// productionMValues are the sizes used in production (full path n+1 and partial path 2n+1
+// for n∈{8,16,32,64}), plus even neighbours {64,128} for extra coverage.
+var productionMValues = []int{17, 33, 64, 65, 128, 129}
+
+// TestComputeNumeratorsBinaryTreeVsNaiveBLS verifies the binary-tree implementation
+// against a naive O(n²) reference over small sizes (both parities) for BLS12-381.
+//
+// Given cMinusJE[j] = c-j for various (c, m),
+// When computeNumeratorsBinaryTree is called,
+// Then each numers[i] must equal ∏_{j≠i} cMinusJE[j].
+func TestComputeNumeratorsBinaryTreeVsNaiveBLS(t *testing.T) {
+	cValues := []int64{100, 7, 42}
+
+	for _, m := range smallMValues {
+		for _, c := range cValues {
+			t.Run("", func(t *testing.T) {
+				t.Logf("m=%d c=%d", m, c)
+				input := buildCMinusJBLS(c, m)
+
+				got := blsNumeratorsBinaryTree(c, m)
+				want := naiveNumeratorsBLS(input, m)
+
+				require.Len(t, got, m, "result length must equal m")
+				for i := range m {
+					assert.True(t, equalsBLS(got[i], want[i]),
+						"m=%d c=%d i=%d: binary-tree result differs from naive reference", m, c, i)
+				}
+			})
+		}
+	}
+}
+
+// TestComputeNumeratorsBinaryTreeVsNaiveBN254 is the BN254 counterpart.
+func TestComputeNumeratorsBinaryTreeVsNaiveBN254(t *testing.T) {
+	cValues := []int64{100, 7, 42}
+
+	for _, m := range smallMValues {
+		for _, c := range cValues {
+			t.Run("", func(t *testing.T) {
+				t.Logf("m=%d c=%d", m, c)
+				input := buildCMinusJBN254(c, m)
+
+				got := bn254NumeratorsBinaryTree(c, m)
+				want := naiveNumeratorsBN254(input, m)
+
+				require.Len(t, got, m, "result length must equal m")
+				for i := range m {
+					assert.True(t, equalsBN254(got[i], want[i]),
+						"m=%d c=%d i=%d: binary-tree result differs from naive reference", m, c, i)
+				}
+			})
+		}
+	}
+}
+
+// TestComputeNumeratorsBinaryTreeProductionSizes verifies method0 against the naive
+// reference for the production sizes {17,33,65,129} (plus even {64,128}), which exercise the
+// top-down leaf trick at scale. c=10000 keeps every (c-j) distinct and non-zero.
+func TestComputeNumeratorsBinaryTreeProductionSizes(t *testing.T) {
+	const c = int64(10000)
+
+	for _, m := range productionMValues {
+		t.Run("BLS12381", func(t *testing.T) {
+			input := buildCMinusJBLS(c, m)
+			got := blsNumeratorsBinaryTree(c, m)
+			want := naiveNumeratorsBLS(input, m)
+			require.Len(t, got, m)
+			for i := range m {
+				assert.True(t, equalsBLS(got[i], want[i]), "m=%d i=%d: mismatch", m, i)
+			}
+		})
+
+		t.Run("BN254", func(t *testing.T) {
+			input := buildCMinusJBN254(c, m)
+			got := bn254NumeratorsBinaryTree(c, m)
+			want := naiveNumeratorsBN254(input, m)
+			require.Len(t, got, m)
+			for i := range m {
+				assert.True(t, equalsBN254(got[i], want[i]), "m=%d i=%d: mismatch", m, i)
+			}
+		})
+	}
+}
+
+// TestComputeNumeratorsBinaryTreeEvenM verifies method0 handles even m (which has no leftover
+// leaf — all leaves pair up) correctly against the naive reference, on both curves.
+func TestComputeNumeratorsBinaryTreeEvenM(t *testing.T) {
+	const c = int64(10000)
+	for _, m := range []int{2, 4, 6, 8, 10, 16, 32, 64, 128} {
+		input := buildCMinusJBLS(c, m)
+		got := blsNumeratorsBinaryTree(c, m)
+		want := naiveNumeratorsBLS(input, m)
+		require.Len(t, got, m)
+		for i := range m {
+			assert.True(t, equalsBLS(got[i], want[i]), "BLS m=%d i=%d: mismatch", m, i)
+		}
+
+		inputBN := buildCMinusJBN254(c, m)
+		gotBN := bn254NumeratorsBinaryTree(c, m)
+		wantBN := naiveNumeratorsBN254(inputBN, m)
+		for i := range m {
+			assert.True(t, equalsBN254(gotBN[i], wantBN[i]), "BN254 m=%d i=%d: mismatch", m, i)
+		}
+	}
+}
+
+// TestComputeNumeratorsBinaryTreeThreeElements verifies the m=3 case with
+// hand-computed expected values (independent of the naive oracle).
+//
+// With c=10:
+//   - cMinusJ = [10, 9, 8]
+//   - numers[0] = 9*8 = 72
+//   - numers[1] = 10*8 = 80
+//   - numers[2] = 10*9 = 90
+func TestComputeNumeratorsBinaryTreeThreeElements(t *testing.T) {
+	got := blsNumeratorsBinaryTree(10, 3)
+	require.Len(t, got, 3)
+
+	expected := []int64{72, 80, 90}
+	for i, exp := range expected {
+		var e bls12381fr.Element
+		e.SetInt64(exp)
+		assert.True(t, equalsBLS(got[i], &e), "m=3: numers[%d] should be %d", i, exp)
+	}
+}
+
+// TestComputeNumeratorsBinaryTreeNineElements verifies an odd size with a leftover leaf
+// (m=9: four consecutive pairs + one unpaired leaf) against hand-computed expected values.
+//
+// With c=10, cMinusJ = [10,9,8,7,6,5,4,3,2]; numers[i] = ∏_{j≠i} (10-j).
+func TestComputeNumeratorsBinaryTreeNineElements(t *testing.T) {
+	const c, m = int64(10), 9
+	got := blsNumeratorsBinaryTree(c, m)
+	require.Len(t, got, m)
+
+	// numers[i] = 9! / ((10-i)) scaled: full product P = 10*9*...*2 = 3628800.
+	full := int64(1)
+	for j := range m {
+		full *= c - int64(j)
+	}
+	for i := range m {
+		exp := full / (c - int64(i))
+		var e bls12381fr.Element
+		e.SetInt64(exp)
+		assert.True(t, equalsBLS(got[i], &e), "m=9: numers[%d] should be %d", i, exp)
+	}
+}
+
+// TestComputeNumeratorsBinaryTreeOutputLength checks that the returned slice always has
+// exactly m elements, for both even and odd m.
+func TestComputeNumeratorsBinaryTreeOutputLength(t *testing.T) {
+	for _, m := range []int{2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 32, 33} {
+		got := blsNumeratorsBinaryTree(1000, m)
+		assert.Len(t, got, m, "expected output length == m for m=%d", m)
+	}
+}
+
+// TestComputeNumeratorsBinaryTreeAllDifferent verifies that distinct input elements
+// produce distinct numerators (no accidental aliasing in the tree).
+func TestComputeNumeratorsBinaryTreeAllDifferent(t *testing.T) {
+	m := 5
+	c := int64(1000) // far from 0..4 so all values are distinct
+
+	got := blsNumeratorsBinaryTree(c, m)
+	require.Len(t, got, m)
+
+	for i := range m {
+		for j := i + 1; j < m; j++ {
+			assert.False(t, equalsBLS(got[i], got[j]),
+				"m=%d c=%d: numers[%d] and numers[%d] should be distinct", m, c, i, j)
+		}
+	}
+}
+
+// TestComputeNumeratorsBinaryTreeDeterministic verifies repeated calls with the same c
+// return identical results (the pooled slab is not carried over between calls).
+func TestComputeNumeratorsBinaryTreeDeterministic(t *testing.T) {
+	m := 7
+	c := int64(50)
+
+	got1 := blsNumeratorsBinaryTree(c, m)
+	got2 := blsNumeratorsBinaryTree(c, m)
+
+	for i := range m {
+		assert.True(t, equalsBLS(got1[i], got2[i]),
+			"repeated call with same c=%d produced different result at index %d", c, i)
+	}
+}
+
+// blsNumeratorsBinaryTreeMasked runs the binary tree with a relevance mask (partial pruning).
+func blsNumeratorsBinaryTreeMasked(c int64, m int, relevant []bool) []*bls12381fr.Element {
+	curve := mathlib.Curves[mathlib.BLS12_381]
+	cZr := curve.NewZrFromInt(c)
+	pooled := getTreeArrays[bls12381fr.Element](m)
+	result := computeNumeratorsBinaryTree[bls12381fr.Element, *bls12381fr.Element](m, cZr, pooled, relevant)
+	putTreeArrays(pooled)
+
+	return result
+}
+
+func bn254NumeratorsBinaryTreeMasked(c int64, m int, relevant []bool) []*bn254fr.Element {
+	curve := mathlib.Curves[mathlib.BN254]
+	cZr := curve.NewZrFromInt(c)
+	pooled := getTreeArrays[bn254fr.Element](m)
+	result := computeNumeratorsBinaryTree[bn254fr.Element, *bn254fr.Element](m, cZr, pooled, relevant)
+	putTreeArrays(pooled)
+
+	return result
+}
+
+// partialRelevant builds the partial-path relevance mask over total=2n+1 points: {0, n+1, ..., 2n}.
+func partialRelevant(n int) []bool {
+	total := 2*n + 1
+	rel := make([]bool, total)
+	rel[0] = true
+	for k := 1; k <= n; k++ {
+		rel[n+k] = true
+	}
+
+	return rel
+}
+
+// TestComputeNumeratorsBinaryTreePartialPruning verifies that pruning the top-down to the partial
+// relevant set {0, n+1, ..., 2n} yields exactly the same numerators at those indices as the full
+// (unpruned) computation, and that both match the naive reference. This is the pruning used by
+// getLagrangeMultipliersPartialNative.
+func TestComputeNumeratorsBinaryTreePartialPruning(t *testing.T) {
+	const c = int64(10007)
+	for _, n := range []int{4, 8, 16, 32, 64} {
+		total := 2*n + 1
+		rel := partialRelevant(n)
+
+		fullBLS := blsNumeratorsBinaryTree(c, total)
+		prunedBLS := blsNumeratorsBinaryTreeMasked(c, total, rel)
+		naiveBLS := naiveNumeratorsBLS(buildCMinusJBLS(c, total), total)
+
+		fullBN := bn254NumeratorsBinaryTree(c, total)
+		prunedBN := bn254NumeratorsBinaryTreeMasked(c, total, rel)
+		naiveBN := naiveNumeratorsBN254(buildCMinusJBN254(c, total), total)
+
+		for v := range total {
+			if !rel[v] {
+				continue
+			}
+			assert.True(t, equalsBLS(prunedBLS[v], fullBLS[v]), "BLS n=%d v=%d: pruned != full", n, v)
+			assert.True(t, equalsBLS(prunedBLS[v], naiveBLS[v]), "BLS n=%d v=%d: pruned != naive", n, v)
+			assert.True(t, equalsBN254(prunedBN[v], fullBN[v]), "BN254 n=%d v=%d: pruned != full", n, v)
+			assert.True(t, equalsBN254(prunedBN[v], naiveBN[v]), "BN254 n=%d v=%d: pruned != naive", n, v)
+		}
+	}
+}

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_native.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_native.go
@@ -13,6 +13,210 @@ import (
 	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
 )
 
+// leftChild returns the index of the left child of node i in the tree array.
+func leftChild(i int) int {
+	return 2*i + 1
+}
+
+// rightChild returns the index of the right child of node i in the tree array.
+func rightChild(i int) int {
+	return 2*i + 2
+}
+
+// computeNumeratorsBinaryTree computes the Lagrange numerators — for each point i in [0,m)
+// it returns ∏_{k≠i}(c-k) — via a binary tree over the leaves (c-k), backed by pooled.slab.
+//
+// Adjacent leaves are paired thus exploiting the fact that their integer points differ by 1:
+//
+//   - Leaves are placed so every sibling leaf pair holds (c-2i) and (c-(2i+1)).
+//     for odd m the value c-(m-1) is the unpaired leftover and is placed as the first leaf at leafStart.
+//
+//   - Bottom-up: every node should hold the product of the leaves in its sub-tree.
+//     This is computed from the leaves up so that every node computes the product of its two children.
+//
+//     Level 1 (just above the leaves) computes these products with only additions and 1 product, as follows:
+//     The i's node should compute the product of the i'th pair: (c-2i)(c-(2i+1))
+//     Start with the product of the first pair: N_0 = c·(c-1) [cost = 1 product]
+//     then every subsequence product of pair  : N_i = (c-2i)(c-(2i+1)) = N_{i-1} - 4c + (8i-2)
+//     So computing N_i from N{i-1} involves additions only.
+//     Higher levels of the tree are computed with every node computing the product of its 2 children.
+//
+//   - Top-down leaf level: At this phase every node in the top-down tree should hold
+//     the product of all the leaves in the entire tree, excluding the leaves of the node's sub-tree.
+//     The root's value is 1. The going top down - consider visiting a node N with an exclude value E
+//     and the values Nleft, Nright computed for its two child nodes in the bottom-up stage.
+//     Now compute the exclusion values of the two child nodes of N as follows:
+//     Eleft = E*Nright, and Eright = E*Nleft [cost = two products per parent node]
+//
+//     The exclusion values for the leaves are computed in the nodes of Level 1 (just above the leaves).
+//     This is done with one product per parent node (instead of two) as follows:
+//     For the i'th parent of the leaf-pair (c-2i)(c-(2i+1)) which has exclude value E
+//     compute the exclude values of the two child leaves (i.e. the respective target lagrange numerators)
+//     as follows:
+//     numer_left  = E·(c-(2i+1))   [cost = one product] and
+//     numer_right = numer_left + E [one addition, since (c-2i) = (c-(2i+1))+1].
+//
+// Slab layout (see lagrange_pool.go):
+//
+//	slab = [ tree+leaves (treeSize) | exclude+numers (treeSize) | scratch (numeratorScratch) ]
+//
+// The first half holds subtree products (indices [0,leafStart)) and leaves ([leafStart,treeSize));
+// the second half mirrors it with exclude products / numerator outputs; the tail is scratch.
+// Leaf-pair parents occupy [leafPairsStart, leafStart)
+// A node is a parent of leaves iff leftChild(i) >= leafStart.
+// Both even and odd m are supported.
+//
+// relevant is an optional mask (indexed by output integer v in [0,m)) marking which numerators
+// the caller will actually use; nil means all of them. When set, the top-down pass is pruned to
+// the ancestors of relevant leaves — a node's exclude value is computed only if its subtree
+// contains a relevant leaf — so the products for discarded numerators are skipped (used by the
+// partial path, which keeps only {0, n+1, ..., 2n}). Placement and both bottom-up phases are
+// unaffected: a kept leaf's exclude still needs the aggregate products of the discarded subtrees.
+func computeNumeratorsBinaryTree[T any, E math2.GnarkFr[T]](m int, c *mathlib.Zr, pooled *treeArrays[T], relevant []bool) []E {
+	leafStart := m - 1
+	treeSize := 2*m - 1
+	m2 := m / 2
+	sl := pooled.slab
+
+	// Working field elements are taken from the pooled slab's scratch tail — so there are no allocations.
+	// Every integer constant we need forms an arithmetic sequence, so it is produced by cheap
+	// field additions from a Montgomery-encoded step instead of a per-use SetInt64 (each
+	// SetInt64 costs ~a multiply). Costing only ~4 SetInt64 run per call.
+	scratch := sl[2*treeSize:]
+	base := leafStart + (m & 1)
+	numPairedLeaves := 2 * m2 // paired leaves == m when m is even, or m-1 when m is odd
+
+	// cE aliases the first leaf slot (integer 0 → c-0 = c), so placing c needs no separate
+	// copy; leaf slots are never overwritten by the bottom-up sweep. (m==1 has no pairs; its
+	// single leaf is the leftover at leafStart.)
+	var cE E
+	if numPairedLeaves > 0 {
+		cE = E(&sl[base])
+	} else {
+		cE = E(&sl[leafStart])
+	}
+	math2.SetNativeFromZr[T, E](c, cE)
+
+	oneE := E(&scratch[0])
+	oneE.SetInt64(1)
+
+	// Leaves: slot base+j holds integer j (value c-j). Chain each from its predecessor by -1,
+	// thus avoiding a costly SetInt64 op.
+	for j := 1; j < numPairedLeaves; j++ {
+		E(&sl[base+j]).Sub(E(&sl[base+j-1]), oneE)
+	}
+	// Odd m: the value c-(m-1) is the unpaired leftover and is placed at slot leafStart.
+	if m&1 == 1 && numPairedLeaves > 0 {
+		tmp := E(&scratch[4])
+		tmp.SetInt64(int64(m - 1))
+		E(&sl[leafStart]).Sub(cE, tmp)
+	}
+
+	// Leaf-pair parents occupy [leafPairsStart, leafStart); pair i -> slot leafPairsStart+i.
+	leafPairsStart := leafStart - m2
+
+	// Phase 1: Bottom-up.
+	// Level 1:
+	// The i'th parent of the i;th pair should compute the product
+	//   N_i = (c-2i)(c-(2i+1))
+	// Start by compute N_0 with one product:
+	//   N_0 = c·(c-1)
+	// The compute the next pairs with only additions:
+	//   N_i = N_{i-1} - 4c + (8i-2)   [= c^2 - (4i+1)c + 2i(2i+1)].
+	// The added constant 8i-2 = 6,14,22,... steps by 8, so it is carried incrementally too.
+	if m2 > 0 {
+		c4 := E(&scratch[1])
+		c4.Add(cE, cE) // 2c
+		c4.Add(c4, c4) // 4c
+		cm1 := E(&scratch[5])
+		cm1.Sub(cE, oneE)                   // c-1
+		E(&sl[leafPairsStart]).Mul(cE, cm1) // seed N_0 (the only level-1 multiplication)
+		if m2 > 1 {
+			delta := E(&scratch[2])
+			eight := E(&scratch[3])
+			delta.SetInt64(6) // 8·1 - 2
+			eight.SetInt64(8)
+			for i := 1; i < m2; i++ {
+				cur := E(&sl[leafPairsStart+i])
+				cur.Sub(E(&sl[leafPairsStart+i-1]), c4)
+				cur.Add(cur, delta)
+				delta.Add(delta, eight)
+			}
+		}
+	}
+
+	// Level 2+: each internal node is the product of its two children (children have higher
+	// indices, so a descending sweep has them ready). Folds in the odd-m leftover leaf.
+	for i := leafPairsStart - 1; i >= 0; i-- {
+		E(&sl[i]).Mul(E(&sl[leftChild(i)]), E(&sl[rightChild(i)]))
+	}
+
+	// When this function is called in the context of "partial" nominators, some of the
+	// nominators will not be required by the caller, and are deemed "irrelevant".
+	// Optional relevance mask: nodeRel[i] is true iff node i's subtree holds a kept numerator,
+	// so the top-down can skip everything else. nil ⇒ everything is relevant (full path).
+	var nodeRel []bool
+	if relevant != nil {
+		nodeRel = make([]bool, treeSize)
+		for j := range numPairedLeaves { // slot base+j holds integer j
+			nodeRel[base+j] = relevant[j]
+		}
+		if m&1 == 1 { // leftover slot leafStart holds integer m-1
+			nodeRel[leafStart] = relevant[m-1]
+		}
+		for i := leafStart - 1; i >= 0; i-- {
+			nodeRel[i] = nodeRel[leftChild(i)] || nodeRel[rightChild(i)]
+		}
+	}
+
+	// Phase 2: Top-down — exclude products; leaf slots receive the numerators.
+	E(&sl[treeSize]).SetOne() // exclude[root] = 1
+	for i := range leafStart {
+		if nodeRel != nil && !nodeRel[i] {
+			continue // no kept numerator under this node — its exclude is never read
+		}
+		l, r := leftChild(i), rightChild(i)
+		exclI := E(&sl[treeSize+i]) // the already-computed exclusion value of node i
+		relL := nodeRel == nil || nodeRel[l]
+		relR := nodeRel == nil || nodeRel[r]
+		if l >= leafStart {
+			// => node i is a Leaf-pair parent with exclude=exclI
+			// => its children are consecutive leaves (r=l+1) and hold consecutive values (sl[l] = sl[r] + 1).
+			//   numer_left  = exclude · sl[r] (one product)
+			//   numer_right = numer_left + exclude (one addition)
+			switch {
+			case relL && relR:
+				exclL := E(&sl[treeSize+l])
+				exclL.Mul(exclI, E(&sl[r]))
+				E(&sl[treeSize+r]).Add(exclL, exclI)
+			case relL:
+				E(&sl[treeSize+l]).Mul(exclI, E(&sl[r]))
+			case relR:
+				E(&sl[treeSize+r]).Mul(exclI, E(&sl[l]))
+			}
+		} else {
+			if relL {
+				E(&sl[treeSize+l]).Mul(exclI, E(&sl[r]))
+			}
+			if relR {
+				E(&sl[treeSize+r]).Mul(exclI, E(&sl[l]))
+			}
+		}
+	}
+
+	// Extraction: the leaf slot holding (c-v) carries numer[v].
+	numersE := make([]E, m)
+	if m&1 == 1 {
+		numersE[m-1] = E(&sl[treeSize+leafStart])
+	}
+	for i := range m2 {
+		numersE[2*i] = E(&sl[treeSize+base+2*i])
+		numersE[2*i+1] = E(&sl[treeSize+base+2*i+1])
+	}
+
+	return numersE
+}
+
 // getLagrangeMultipliersNative is the native fr.Element implementation of
 // getLagrangeMultipliers. Conversions between mathlib.Zr and fr.Element occur
 // only once at the boundary (once for input c, n+1 times for the output slice),
@@ -23,33 +227,11 @@ import (
 func getLagrangeMultipliersNative[T any, E math2.GnarkFr[T]](n uint64, c *mathlib.Zr, curve *mathlib.Curve, denomInvs []E) ([]*mathlib.Zr, error) {
 	m := int(n) + 1 // #nosec G115
 
-	// Convert c once.
-	cE := math2.NativeFromZr[T, E](c)
-
-	// cMinusJ[j] = c - j  for j = 0..n
-	cMinusJ := make([]T, m)
-	cMinusJE := make([]E, m)
-	for j := range m {
-		cMinusJE[j] = E(&cMinusJ[j])
-		var jE T
-		E(&jE).SetInt64(int64(j))
-		cMinusJE[j].Sub(cE, E(&jE))
-	}
-
 	// Compute numerator for each Lagrange basis polynomial L_i(c).
 	// Denominators come from the cache — no O(n²) recomputation.
-	numers := make([]T, m)
-	numersE := make([]E, m)
-	for i := range numers {
-		numersE[i] = E(&numers[i])
-		numersE[i].SetOne()
-		for j := range m {
-			if j == i {
-				continue
-			}
-			numersE[i].Mul(numersE[i], cMinusJE[j])
-		}
-	}
+	// The full path uses every numerator, so no relevance mask (nil ⇒ all).
+	pooled := getTreeArrays[T](m)
+	numersE := computeNumeratorsBinaryTree[T, E](m, c, pooled, nil)
 
 	result := make([]*mathlib.Zr, m)
 	for i := range m {
@@ -57,6 +239,7 @@ func getLagrangeMultipliersNative[T any, E math2.GnarkFr[T]](n uint64, c *mathli
 		E(&prod).Mul(numersE[i], denomInvs[i])
 		result[i] = math2.NativeToZr[T, E](E(&prod), curve)
 	}
+	putTreeArrays(pooled)
 
 	return result, nil
 }
@@ -67,47 +250,31 @@ func getLagrangeMultipliersNative[T any, E math2.GnarkFr[T]](n uint64, c *mathli
 func getLagrangeMultipliersPartialNative[T any, E math2.GnarkFr[T]](n uint64, c *mathlib.Zr, curve *mathlib.Curve, denomInvs []E) ([]*mathlib.Zr, error) {
 	total := 2*int(n) + 1 // #nosec G115 // all evaluation points: 0..2n
 
-	cE := math2.NativeFromZr[T, E](c)
-
-	// cMinusJ[j] = c - j  for j = 0..2n
-	cMinusJ := make([]T, total)
-	cMinusJE := make([]E, total)
-	for j := range total {
-		cMinusJE[j] = E(&cMinusJ[j])
-		var jE T
-		E(&jE).SetInt64(int64(j))
-		cMinusJE[j].Sub(cE, E(&jE))
-	}
-
-	// Relevant indices in the full point set: {0, n+1, n+2, ..., 2n}
-	relevant := make([]int, int(n)+1) // #nosec G115
-	relevant[0] = 0
+	// Only numerators at the relevant indices {0, n+1, n+2, ..., 2n} are used below; the rest
+	// are discarded. Passing that mask lets computeNumeratorsBinaryTree prune the top-down pass
+	// (skip the exclude products of any subtree with no relevant leaf).
+	relevant := make([]bool, total)
+	relevant[0] = true
 	for k := 1; k <= int(n); k++ { // #nosec G115
-		relevant[k] = int(n) + k // #nosec G115
+		relevant[int(n)+k] = true
 	}
+	pooled := getTreeArrays[T](total)
+	allNumersE := computeNumeratorsBinaryTree[T, E](total, c, pooled, relevant)
 
-	numers := make([]T, len(relevant))
-	numersE := make([]E, len(relevant))
-	for k := range relevant {
-		numersE[k] = E(&numers[k])
-	}
+	result := make([]*mathlib.Zr, int(n)+1) // #nosec G115
 
-	for k, i := range relevant {
-		numersE[k].SetOne()
-		for j := range total {
-			if j == i {
-				continue
-			}
-			numersE[k].Mul(numersE[k], cMinusJE[j])
-		}
-	}
+	// k=0: relevant index is 0
+	var prod0 T
+	E(&prod0).Mul(allNumersE[0], denomInvs[0])
+	result[0] = math2.NativeToZr[T, E](E(&prod0), curve)
 
-	result := make([]*mathlib.Zr, len(relevant))
-	for k := range relevant {
+	// k=1..n: relevant index is n+k
+	for k := 1; k <= int(n); k++ { // #nosec G115
 		var prod T
-		E(&prod).Mul(numersE[k], denomInvs[k])
+		E(&prod).Mul(allNumersE[int(n)+k], denomInvs[k]) // #nosec G115
 		result[k] = math2.NativeToZr[T, E](E(&prod), curve)
 	}
+	putTreeArrays(pooled)
 
 	return result, nil
 }

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_numerator_bench_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_numerator_bench_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package csp
+
+import (
+	"fmt"
+	"testing"
+
+	mathlib "github.com/IBM/mathlib"
+	math2 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/math"
+	bls12381fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+)
+
+// benchNumerators isolates computeNumeratorsBinaryTree from the rest of transfer validation.
+// The tree slab is reused across iterations so the measurement reflects field arithmetic,
+// not pool/alloc churn.
+func benchNumerators[T any, E math2.GnarkFr[T]](b *testing.B, m int, c *mathlib.Zr) {
+	b.Helper()
+	pooled := getTreeArrays[T](m)
+	defer putTreeArrays(pooled)
+	for b.Loop() {
+		_ = computeNumeratorsBinaryTree[T, E](m, c, pooled, nil)
+	}
+}
+
+// BenchmarkNumeratorsBinaryTree measures the numerator tree at the production sizes
+// m=65 (full path, n=64) and m=129 (partial path, 2n+1 at n=64), on both curves.
+//
+// A/B: run on this branch (method0) and on the pristine base commit (method1), diff ns/op.
+//
+// method0 removes ~m/2 multiplications from the dominant top-down pass (the leaf level: 32 at
+// m=65, 64 at m=129, each 2 products → 1 product + 1 add). Since the profile shows the tree is
+// compute-bound on field multiplication (~52%), expect a real single-digit-to-~10% speedup at
+// m=129 and ~1 alloc/op (scratch is pooled; the fullE/excludeE pointer slices are gone).
+func BenchmarkNumeratorsBinaryTree(b *testing.B) {
+	const cVal = 999983 // far from [0, m-1] so there are no zero factors
+
+	for _, m := range []int{65, 129} {
+		blsCurve := mathlib.Curves[mathlib.BLS12_381]
+		cBLS := blsCurve.NewZrFromInt(cVal)
+		b.Run(fmt.Sprintf("BLS12-381/m=%d", m), func(b *testing.B) {
+			benchNumerators[bls12381fr.Element, *bls12381fr.Element](b, m, cBLS)
+		})
+
+		bnCurve := mathlib.Curves[mathlib.BN254]
+		cBN := bnCurve.NewZrFromInt(cVal)
+		b.Run(fmt.Sprintf("BN254/m=%d", m), func(b *testing.B) {
+			benchNumerators[bn254fr.Element, *bn254fr.Element](b, m, cBN)
+		})
+	}
+}
+
+// benchNumeratorsPartial isolates the partial numerator path: total = 2n+1 points with the
+// relevance mask {0, n+1, ..., 2n}, so the top-down is pruned to the kept indices.
+func benchNumeratorsPartial[T any, E math2.GnarkFr[T]](b *testing.B, n int, c *mathlib.Zr) {
+	b.Helper()
+	total := 2*n + 1
+	relevant := make([]bool, total)
+	relevant[0] = true
+	for k := 1; k <= n; k++ {
+		relevant[n+k] = true
+	}
+	pooled := getTreeArrays[T](total)
+	defer putTreeArrays(pooled)
+	for b.Loop() {
+		_ = computeNumeratorsBinaryTree[T, E](total, c, pooled, relevant)
+	}
+}
+
+// BenchmarkNumeratorsPartial measures the pruned partial numerator path at n∈{32,64}
+// (total = 65, 129), on both curves. The saving is the gap vs BenchmarkNumeratorsBinaryTree at
+// m = total (the unpruned full tree the partial path used before this optimization).
+func BenchmarkNumeratorsPartial(b *testing.B) {
+	const cVal = 999983
+
+	for _, n := range []int{32, 64} {
+		blsCurve := mathlib.Curves[mathlib.BLS12_381]
+		cBLS := blsCurve.NewZrFromInt(cVal)
+		b.Run(fmt.Sprintf("BLS12-381/n=%d", n), func(b *testing.B) {
+			benchNumeratorsPartial[bls12381fr.Element, *bls12381fr.Element](b, n, cBLS)
+		})
+
+		bnCurve := mathlib.Curves[mathlib.BN254]
+		cBN := bnCurve.NewZrFromInt(cVal)
+		b.Run(fmt.Sprintf("BN254/n=%d", n), func(b *testing.B) {
+			benchNumeratorsPartial[bn254fr.Element, *bn254fr.Element](b, n, cBN)
+		})
+	}
+}

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_numerators_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_numerators_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package csp
+
+import (
+	"fmt"
+	"testing"
+
+	math "github.com/IBM/mathlib"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLagrangeNumeratorsVariousSizes verifies that the binary tree method
+// produces correct numerators for various numbers of leaves, including
+// edge cases like odd numbers and powers of 2.
+func TestLagrangeNumeratorsVariousSizes(t *testing.T) {
+	curve := math.Curves[math.BN254]
+	rand, err := curve.Rand()
+	require.NoError(t, err)
+
+	// Test various sizes, even and odd (method0 supports both): imperfect trees, powers of 2
+	// and ±1, and the production sizes {17,33,65,129}.
+	testSizes := []int{16, 17, 23, 30, 31, 32, 33, 64, 65, 128, 129}
+
+	for _, m := range testSizes {
+		t.Run(fmt.Sprintf("m=%d", m), func(t *testing.T) {
+			// Generate a random challenge c
+			cZr := curve.NewRandomZr(rand)
+
+			// Compute numerators using binary tree method
+			binaryTreeResult, ok, err := nativeLagrangeMultipliers(uint64(m-1), cZr, curve) // #nosec G115
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Len(t, binaryTreeResult, m)
+
+			// Compute numerators using fallback method
+			fallbackResult, err := getLagrangeMultipliers(uint64(m-1), cZr, curve) // #nosec G115
+			require.NoError(t, err)
+			require.Len(t, fallbackResult, m)
+
+			// Verify they match
+			for i := range m {
+				require.True(t, binaryTreeResult[i].Equals(fallbackResult[i]),
+					"Mismatch at index %d for m=%d", i, m)
+			}
+
+			t.Logf("✓ Verified m=%d: binary tree matches fallback", m)
+		})
+	}
+}
+
+// TestGetLagrangeMultipliersReconstruction validates the full-multiplier path for BOTH
+// parities (method0 supports even m). It is independent of the tree internals: for a random
+// degree-(m-1) polynomial p over the points {0,...,m-1}, the Lagrange multipliers μ_i at c
+// must satisfy p(c) == Σ_i μ_i · p(i).
+func TestGetLagrangeMultipliersReconstruction(t *testing.T) {
+	for _, curveID := range []math.CurveID{math.BN254, math.BLS12_381} {
+		curve := math.Curves[curveID]
+		rand, err := curve.Rand()
+		require.NoError(t, err)
+		order := curve.GroupOrder
+
+		for _, m := range []int{2, 3, 4, 5, 8, 9, 16, 17} { // even and odd
+			c := curve.NewRandomZr(rand)
+
+			// Random polynomial p(x) = Σ_k coeffs[k] x^k; eval via Horner.
+			coeffs := make([]*math.Zr, m)
+			for k := range coeffs {
+				coeffs[k] = curve.NewRandomZr(rand)
+			}
+			eval := func(x *math.Zr) *math.Zr {
+				acc := curve.NewZrFromInt(0)
+				for k := m - 1; k >= 0; k-- {
+					acc = curve.ModAdd(curve.ModMul(acc, x, order), coeffs[k], order)
+				}
+
+				return acc
+			}
+
+			mu, err := getLagrangeMultipliers(uint64(m-1), c, curve) // #nosec G115
+			require.NoError(t, err, "curve=%v m=%d must succeed (both parities)", curveID, m)
+			require.Len(t, mu, m)
+
+			got := curve.NewZrFromInt(0)
+			for i := range m {
+				yi := eval(curve.NewZrFromInt(int64(i))) // #nosec G115
+				got = curve.ModAdd(got, curve.ModMul(mu[i], yi, order), order)
+			}
+			require.True(t, got.Equals(eval(c)),
+				"curve=%v m=%d: Σ μ_i·p(i) != p(c)", curveID, m)
+		}
+	}
+}
+
+// Made with Bob

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_pool.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_pool.go
@@ -1,0 +1,164 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package csp
+
+import (
+	"sync"
+
+	bls12381fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+)
+
+// treeArrayPool manages memory pools for tree array slabs used in
+// computeNumeratorsBinaryTree. Each slab holds all three working regions
+// (tree, numers, exclude) in a single contiguous allocation, keyed by total
+// slab size. This means one pool lookup, one GC-tracked object, and better
+// cache locality compared to three separate allocations.
+type treeArrayPool[T any] struct {
+	pools map[int]*sync.Pool // key: total slab size (m + 2*leafStart)
+	mu    sync.RWMutex
+}
+
+// newTreeArrayPool creates a new pool for slabs of type T.
+func newTreeArrayPool[T any]() *treeArrayPool[T] {
+	return &treeArrayPool[T]{
+		pools: make(map[int]*sync.Pool),
+	}
+}
+
+// getPool returns the sync.Pool for the given total size, creating it if necessary.
+func (p *treeArrayPool[T]) getPool(size int) *sync.Pool {
+	p.mu.RLock()
+	pool, exists := p.pools[size]
+	p.mu.RUnlock()
+
+	if exists {
+		return pool
+	}
+
+	// Double-checked locking: create pool if still absent after acquiring write lock.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if pool, exists := p.pools[size]; exists {
+		return pool
+	}
+
+	pool = &sync.Pool{
+		New: func() any {
+			s := make([]T, size)
+
+			return &s
+		},
+	}
+	p.pools[size] = pool
+
+	return pool
+}
+
+// Global pools for BLS12-381 and BN254 curves
+var (
+	blsTreePool   = newTreeArrayPool[bls12381fr.Element]()
+	bn254TreePool = newTreeArrayPool[bn254fr.Element]()
+)
+
+// numeratorScratch is the number of extra field-element slots appended to each slab, past
+// the 2*treeSize tree region, for computeNumeratorsBinaryTree's working values: the c value,
+// a reusable SetInt64 scratch, and the level-1 chain temporaries (4c and c-1). Drawing these
+// from the pooled slab keeps the hot path free of the per-call heap allocations that plain
+// local `var`s incur (generics defeat stack escape). 4 are used; a little headroom is kept.
+const numeratorScratch = 6
+
+// treeArrays is a single contiguous slab used by the binary-tree numerator algorithm.
+//
+// Layout:
+//
+//	slab = [ tree+leaves (treeSize) | exclude+numers (treeSize) | scratch (numeratorScratch) ]
+//	         slab[0:treeSize]          slab[treeSize:2*treeSize]    slab[2*treeSize:]
+//
+// Within the first half: slab[0:leafStart] are internal-node products (tree),
+// slab[leafStart:treeSize] are the c-j input values (leaves).
+// Within the second half: slab[treeSize:treeSize+leafStart] are exclude products,
+// slab[treeSize+leafStart:2*treeSize] are the output numerators.
+// The final numeratorScratch slots are working field elements.
+//
+// Callers index slab directly using leafStart and treeSize, which they already
+// hold — no sub-slice fields needed.
+type treeArrays[T any] struct {
+	slab []T // backing allocation returned to pool on put
+	pool *treeArrayPool[T]
+}
+
+// getTreeArrays retrieves a pooled slab of length 2*treeSize+numeratorScratch for type T.
+// m is the number of leaves; leafStart = m-1 is derived internally.
+func getTreeArrays[T any](m int) *treeArrays[T] {
+	treeSize := 2*m - 1
+	total := 2*treeSize + numeratorScratch
+	pool := getTypedPool[T]()
+	raw := pool.getPool(total).Get()
+	var slab []T
+	if sp, ok := raw.(*[]T); ok && len(*sp) == total {
+		slab = *sp
+	} else {
+		slab = make([]T, total)
+	}
+
+	return &treeArrays[T]{
+		slab: slab,
+		pool: pool,
+	}
+}
+
+// putTreeArrays returns the slab inside ta back to its pool.
+func putTreeArrays[T any](ta *treeArrays[T]) {
+	if ta == nil {
+		return
+	}
+	pool := ta.pool.getPool(len(ta.slab))
+	pool.Put(&ta.slab)
+}
+
+// typedPools is a registry mapping element-type name to an untyped pool wrapper.
+// We use a two-level approach: a map from type key → *treeArrayPool[T] stored
+// as any, unwrapped via a typed accessor registered at init time.
+var typedPoolRegistry = map[string]any{} // populated by registerTypedPool
+
+// getTypedPool returns the *treeArrayPool[T] for type T.
+// It panics if no pool has been registered for T.
+func getTypedPool[T any]() *treeArrayPool[T] {
+	var zero T
+	key := typedPoolKey(zero)
+	p, ok := typedPoolRegistry[key]
+	if !ok {
+		panic("csp: no treeArrayPool registered for type " + key)
+	}
+
+	return p.(*treeArrayPool[T])
+}
+
+// typedPoolKey returns a string key for a value of any type, used to look up
+// the pool in typedPoolRegistry.
+func typedPoolKey(v any) string {
+	return typeOf(v)
+}
+
+// typeOf returns a stable string name for the dynamic type of v.
+func typeOf(v any) string {
+	switch v.(type) {
+	case bls12381fr.Element:
+		return "bls12381fr.Element"
+	case bn254fr.Element:
+		return "bn254fr.Element"
+	default:
+		panic("csp: unsupported element type")
+	}
+}
+
+func init() {
+	typedPoolRegistry["bls12381fr.Element"] = blsTreePool
+	typedPoolRegistry["bn254fr.Element"] = bn254TreePool
+}

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_pool_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_pool_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package csp
+
+import (
+	"testing"
+
+	bls12381fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTreeArrayPoolBLS(t *testing.T) {
+	// Test basic get/put operations
+	m := 65
+	treeSize := 2*m - 1
+
+	arrays := getTreeArrays[bls12381fr.Element](m)
+	require.NotNil(t, arrays)
+	require.Len(t, arrays.slab, 2*treeSize+numeratorScratch)
+
+	// Return to pool
+	putTreeArrays(arrays)
+
+	// Get again - should reuse from pool
+	arrays2 := getTreeArrays[bls12381fr.Element](m)
+	require.NotNil(t, arrays2)
+	require.Len(t, arrays2.slab, 2*treeSize+numeratorScratch)
+
+	putTreeArrays(arrays2)
+}
+
+func TestTreeArrayPoolBN254(t *testing.T) {
+	// Test basic get/put operations
+	m := 129
+	treeSize := 2*m - 1
+
+	arrays := getTreeArrays[bn254fr.Element](m)
+	require.NotNil(t, arrays)
+	require.Len(t, arrays.slab, 2*treeSize+numeratorScratch)
+
+	// Return to pool
+	putTreeArrays(arrays)
+
+	// Get again - should reuse from pool
+	arrays2 := getTreeArrays[bn254fr.Element](m)
+	require.NotNil(t, arrays2)
+	require.Len(t, arrays2.slab, 2*treeSize+numeratorScratch)
+
+	putTreeArrays(arrays2)
+}
+
+func TestTreeArrayPoolConcurrent(t *testing.T) {
+	// Test concurrent access to pool
+	const goroutines = 10
+	const iterations = 100
+	const m = 65
+	const leafStart = m - 1
+	const treeSize = 2*m - 1
+
+	done := make(chan bool, goroutines)
+
+	for range goroutines {
+		go func() {
+			for range iterations {
+				arrays := getTreeArrays[bls12381fr.Element](m)
+				// Simulate some work using direct slab offsets.
+				// slab[0]          → tree[0]
+				// slab[treeSize]   → exclude[0]
+				// slab[treeSize+leafStart] → numers[0]
+				arrays.slab[0].SetOne()
+				arrays.slab[treeSize].SetZero()
+				arrays.slab[treeSize+leafStart].SetOne()
+				putTreeArrays(arrays)
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for range goroutines {
+		<-done
+	}
+}
+
+func TestTreeArrayPoolDifferentSizes(t *testing.T) {
+	// Test that different sizes use different pools
+	ms := []int{33, 65, 129, 257}
+
+	for _, m := range ms {
+		treeSize := 2*m - 1
+		arrays := getTreeArrays[bls12381fr.Element](m)
+		require.Len(t, arrays.slab, 2*treeSize+numeratorScratch)
+		putTreeArrays(arrays)
+	}
+}
+
+// BenchmarkTreeArrayPoolBLS benchmarks the pool performance for BLS12-381
+func BenchmarkTreeArrayPoolBLS(b *testing.B) {
+	const m = 65
+	const leafStart = m - 1
+
+	b.Run("with_pool", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			arrays := getTreeArrays[bls12381fr.Element](m)
+			// Simulate some work: touch tree[0] at slab[0].
+			arrays.slab[0].SetOne()
+			putTreeArrays(arrays)
+		}
+	})
+
+	b.Run("without_pool", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			tree := make([]bls12381fr.Element, leafStart)
+			numers := make([]bls12381fr.Element, m)
+			exclude := make([]bls12381fr.Element, leafStart)
+			// Simulate some work
+			tree[0].SetOne()
+			_ = numers
+			_ = exclude
+		}
+	})
+}
+
+// BenchmarkTreeArrayPoolBN254 benchmarks the pool performance for BN254
+func BenchmarkTreeArrayPoolBN254(b *testing.B) {
+	const m = 129
+	const leafStart = m - 1
+
+	b.Run("with_pool", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			arrays := getTreeArrays[bn254fr.Element](m)
+			// Simulate some work: touch tree[0] at slab[0].
+			arrays.slab[0].SetOne()
+			putTreeArrays(arrays)
+		}
+	})
+
+	b.Run("without_pool", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			tree := make([]bn254fr.Element, leafStart)
+			numers := make([]bn254fr.Element, m)
+			exclude := make([]bn254fr.Element, leafStart)
+			// Simulate some work
+			tree[0].SetOne()
+			_ = numers
+			_ = exclude
+		}
+	})
+}
+
+// Made with Bob

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rp_enhanced_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rp_enhanced_test.go
@@ -264,13 +264,13 @@ func TestInterpolateCorrectness(t *testing.T) {
 
 			n := uint64(3)
 
-			// Create random polynomial values at {0, 1, 2, 3}
+			// Create random polynomial values at {0, 1, ..., n}
 			vals := make([]*math.Zr, n+1)
 			for i := range vals {
 				vals[i] = curve.NewRandomZr(rand)
 			}
 
-			// Interpolate to get values at {0, 1, 2, 3, 4, 5, 6}
+			// Interpolate to get values at {0, 1, ..., 2n}
 			extended, err := interpolate(n, vals, curve)
 			require.NoError(t, err)
 			require.Len(t, extended, 2*int(n)+1)


### PR DESCRIPTION
Add @aaadir  optimizations to the tree-based computation - mainly saving some allocations and also leaf computation in the exclude tree

(authored by @aaadir )