### PR TITLE
feat(sherdlock): coordinate token-lock cleanup leadership across replicas

### DIFF
--- a/token/services/selector/sherdlock/inmemory/locker.go
+++ b/token/services/selector/sherdlock/inmemory/locker.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/utils/types/transaction"
 	"github.com/LFDT-Panurus/panurus/token/token"
 )
@@ -45,4 +46,11 @@ func (l *locker) UnlockByTxID(ctx context.Context, txID transaction.ID) error {
 
 func (l *locker) Cleanup(ctx context.Context, leaseExpiry time.Duration) error {
 	return nil
+}
+
+// AcquireCleanupLeadership always grants leadership locally - this in-memory
+// locker is a non-distributed backend with only one instance, so there is
+// nothing to coordinate. See #1798.
+func (l *locker) AcquireCleanupLeadership(_ context.Context) (driver.CleanupLeadership, bool, error) {
+	return driver.NoopCleanupLeadership{}, true, nil
 }

--- a/token/services/selector/sherdlock/interfaces.go
+++ b/token/services/selector/sherdlock/interfaces.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token"
 	"github.com/LFDT-Panurus/panurus/token/driver"
+	dbdriver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/utils/types/transaction"
 	token2 "github.com/LFDT-Panurus/panurus/token/token"
 )
@@ -83,6 +84,11 @@ type Locker interface {
 	// 1. The transaction that locked that token is valid or invalid;
 	// 2. The lock is too old.
 	Cleanup(ctx context.Context, leaseExpiry time.Duration) error
+	// AcquireCleanupLeadership attempts to acquire leadership for the
+	// cleanup tick, so only one replica runs Cleanup per tick. Non-distributed
+	// backends (sqlite, in-memory) always grant leadership locally. The lock
+	// id (if any) is owned internally by the implementation. See #1798.
+	AcquireCleanupLeadership(ctx context.Context) (dbdriver.CleanupLeadership, bool, error)
 }
 
 // TokenSelectorUnlocker interface combines Selector and UnlockAll.

--- a/token/services/selector/sherdlock/manager.go
+++ b/token/services/selector/sherdlock/manager.go
@@ -91,15 +91,38 @@ func (m *Manager) cleaner(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			logger.DebugfContext(ctx, "release token locks older than [%s]", m.leaseExpiry)
-			if err := m.locker.Cleanup(ctx, m.leaseExpiry); err != nil {
-				logger.Errorf("failed to release token locks: [%s]", err)
-			}
+			m.runCleanupTick(ctx)
 		case <-ctx.Done():
 			logger.Debugf("cleaner stopping")
 
 			return
 		}
+	}
+}
+
+// runCleanupTick acquires cleanup leadership for this tick so only one
+// replica runs Cleanup at a time; other replicas skip the tick. See #1798.
+func (m *Manager) runCleanupTick(ctx context.Context) {
+	leadership, acquired, err := m.locker.AcquireCleanupLeadership(ctx)
+	if err != nil {
+		logger.Errorf("failed to acquire cleanup leadership: [%s]", err)
+
+		return
+	}
+	if !acquired {
+		logger.DebugfContext(ctx, "cleanup leadership not acquired, skipping tick")
+
+		return
+	}
+	defer func() {
+		if err := leadership.Close(); err != nil {
+			logger.Warnf("failed to release cleanup leadership: [%s]", err)
+		}
+	}()
+
+	logger.DebugfContext(ctx, "release token locks older than [%s]", m.leaseExpiry)
+	if err := m.locker.Cleanup(ctx, m.leaseExpiry); err != nil {
+		logger.Errorf("failed to release token locks: [%s]", err)
 	}
 }
 

--- a/token/services/selector/sherdlock/manager_test.go
+++ b/token/services/selector/sherdlock/manager_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token"
 	"github.com/LFDT-Panurus/panurus/token/services/selector/testutils"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/db/dbtest"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/postgres"
 	"github.com/LFDT-Panurus/panurus/token/services/utils/types/transaction"
 	token2 "github.com/LFDT-Panurus/panurus/token/token"
@@ -420,6 +421,119 @@ func TestManager_Cleaner(t *testing.T) {
 		// Manager should still be functional
 		assert.NotNil(t, m)
 	})
+
+	t.Run("cleanup skipped when leadership not acquired", func(t *testing.T) {
+		mockFetcher := &mockTokenFetcher{}
+		mockLocker := &mockLocker{}
+
+		cleanupCalled := make(chan struct{}, 1)
+		mockLocker.cleanupFunc = func(ctx context.Context, expiry time.Duration) error {
+			cleanupCalled <- struct{}{}
+
+			return nil
+		}
+		leadershipAttempted := make(chan struct{}, 1)
+		mockLocker.acquireCleanupLeadershipFunc = func(ctx context.Context) (driver.CleanupLeadership, bool, error) {
+			// Non-blocking: the ticker keeps calling this every tick, but
+			// the test only reads once. A blocking send here would leave
+			// the cleaner goroutine stuck inside this call on the second
+			// tick, past the point where it can react to Stop().
+			select {
+			case leadershipAttempted <- struct{}{}:
+			default:
+			}
+
+			return nil, false, nil
+		}
+
+		m := NewManager(
+			mockFetcher,
+			mockLocker,
+			100,
+			time.Second,
+			5,
+			10*time.Minute,
+			50*time.Millisecond,
+			NewMetrics(&disabled.Provider{}),
+		)
+
+		select {
+		case <-leadershipAttempted:
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("leadership was never attempted")
+		}
+
+		select {
+		case <-cleanupCalled:
+			t.Fatal("Cleanup should not be called when leadership is not acquired")
+		case <-time.After(150 * time.Millisecond):
+			// expected: no cleanup call
+		}
+
+		require.NoError(t, m.Stop())
+	})
+
+	t.Run("leadership released after cleanup ran", func(t *testing.T) {
+		mockFetcher := &mockTokenFetcher{}
+		mockLocker := &mockLocker{}
+
+		// events records "cleanup" then "closed" in order, so the test
+		// verifies Cleanup actually ran (not just that Close was called),
+		// and that release happens after Cleanup completes, not before or
+		// concurrently with it.
+		events := make(chan string, 2)
+		mockLocker.cleanupFunc = func(ctx context.Context, expiry time.Duration) error {
+			events <- "cleanup"
+
+			return nil
+		}
+		mockLocker.acquireCleanupLeadershipFunc = func(ctx context.Context) (driver.CleanupLeadership, bool, error) {
+			return &fakeLeadership{events: events}, true, nil
+		}
+
+		m := NewManager(
+			mockFetcher,
+			mockLocker,
+			100,
+			time.Second,
+			5,
+			10*time.Minute,
+			50*time.Millisecond,
+			NewMetrics(&disabled.Provider{}),
+		)
+
+		var got []string
+		for range 2 {
+			select {
+			case e := <-events:
+				got = append(got, e)
+			case <-time.After(200 * time.Millisecond):
+				t.Fatalf("timed out waiting for events, got so far: %v", got)
+			}
+		}
+		require.Equal(t, []string{"cleanup", "closed"}, got, "Cleanup must run, and leadership must release only after it completes")
+
+		require.NoError(t, m.Stop())
+	})
+}
+
+// fakeLeadership is a minimal driver.CleanupLeadership for tests, signaling
+// on a channel when Close is called. If events is set, it writes "closed"
+// to it (used to verify ordering relative to other recorded events).
+type fakeLeadership struct {
+	closed chan struct{}
+	events chan string
+}
+
+func (f *fakeLeadership) Close() error {
+	if f.closed != nil {
+		f.closed <- struct{}{}
+	}
+	if f.events != nil {
+		f.events <- "closed"
+	}
+
+	return nil
 }
 
 // TestManager_NewSelector_Concurrent verifies concurrent selector creation returns same instance.
@@ -686,10 +800,11 @@ func (m *mockTokenFetcher) UnspentTokensIteratorBy(ctx context.Context, walletID
 }
 
 type mockLocker struct {
-	lockFunc           func(ctx context.Context, tokenID *token2.ID, consumerTxID transaction.ID) error
-	unlockByTxIDFunc   func(ctx context.Context, consumerTxID transaction.ID) error
-	unlockByTxIDCalled bool
-	cleanupFunc        func(ctx context.Context, leaseExpiry time.Duration) error
+	lockFunc                     func(ctx context.Context, tokenID *token2.ID, consumerTxID transaction.ID) error
+	unlockByTxIDFunc             func(ctx context.Context, consumerTxID transaction.ID) error
+	unlockByTxIDCalled           bool
+	cleanupFunc                  func(ctx context.Context, leaseExpiry time.Duration) error
+	acquireCleanupLeadershipFunc func(ctx context.Context) (driver.CleanupLeadership, bool, error)
 }
 
 func (m *mockLocker) Lock(ctx context.Context, tokenID *token2.ID, consumerTxID transaction.ID, walletID string) error {
@@ -715,6 +830,17 @@ func (m *mockLocker) Cleanup(ctx context.Context, leaseExpiry time.Duration) err
 	}
 
 	return nil
+}
+
+// AcquireCleanupLeadership defaults to always-granted, matching the
+// non-distributed backends' behavior, so existing tests that don't set
+// acquireCleanupLeadershipFunc are unaffected. See #1798.
+func (m *mockLocker) AcquireCleanupLeadership(ctx context.Context) (driver.CleanupLeadership, bool, error) {
+	if m.acquireCleanupLeadershipFunc != nil {
+		return m.acquireCleanupLeadershipFunc(ctx)
+	}
+
+	return driver.NoopCleanupLeadership{}, true, nil
 }
 
 type mockIterator struct {

--- a/token/services/selector/sherdlock/mocks/locker.go
+++ b/token/services/selector/sherdlock/mocks/locker.go
@@ -7,11 +7,27 @@ import (
 	"time"
 
 	"github.com/LFDT-Panurus/panurus/token/services/selector/sherdlock"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/utils/types/transaction"
 	"github.com/LFDT-Panurus/panurus/token/token"
 )
 
 type FakeLocker struct {
+	AcquireCleanupLeadershipStub        func(context.Context) (driver.CleanupLeadership, bool, error)
+	acquireCleanupLeadershipMutex       sync.RWMutex
+	acquireCleanupLeadershipArgsForCall []struct {
+		arg1 context.Context
+	}
+	acquireCleanupLeadershipReturns struct {
+		result1 driver.CleanupLeadership
+		result2 bool
+		result3 error
+	}
+	acquireCleanupLeadershipReturnsOnCall map[int]struct {
+		result1 driver.CleanupLeadership
+		result2 bool
+		result3 error
+	}
 	CleanupStub        func(context.Context, time.Duration) error
 	cleanupMutex       sync.RWMutex
 	cleanupArgsForCall []struct {
@@ -52,6 +68,73 @@ type FakeLocker struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeLocker) AcquireCleanupLeadership(arg1 context.Context) (driver.CleanupLeadership, bool, error) {
+	fake.acquireCleanupLeadershipMutex.Lock()
+	ret, specificReturn := fake.acquireCleanupLeadershipReturnsOnCall[len(fake.acquireCleanupLeadershipArgsForCall)]
+	fake.acquireCleanupLeadershipArgsForCall = append(fake.acquireCleanupLeadershipArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.AcquireCleanupLeadershipStub
+	fakeReturns := fake.acquireCleanupLeadershipReturns
+	fake.recordInvocation("AcquireCleanupLeadership", []interface{}{arg1})
+	fake.acquireCleanupLeadershipMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeLocker) AcquireCleanupLeadershipCallCount() int {
+	fake.acquireCleanupLeadershipMutex.RLock()
+	defer fake.acquireCleanupLeadershipMutex.RUnlock()
+	return len(fake.acquireCleanupLeadershipArgsForCall)
+}
+
+func (fake *FakeLocker) AcquireCleanupLeadershipCalls(stub func(context.Context) (driver.CleanupLeadership, bool, error)) {
+	fake.acquireCleanupLeadershipMutex.Lock()
+	defer fake.acquireCleanupLeadershipMutex.Unlock()
+	fake.AcquireCleanupLeadershipStub = stub
+}
+
+func (fake *FakeLocker) AcquireCleanupLeadershipArgsForCall(i int) context.Context {
+	fake.acquireCleanupLeadershipMutex.RLock()
+	defer fake.acquireCleanupLeadershipMutex.RUnlock()
+	argsForCall := fake.acquireCleanupLeadershipArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeLocker) AcquireCleanupLeadershipReturns(result1 driver.CleanupLeadership, result2 bool, result3 error) {
+	fake.acquireCleanupLeadershipMutex.Lock()
+	defer fake.acquireCleanupLeadershipMutex.Unlock()
+	fake.AcquireCleanupLeadershipStub = nil
+	fake.acquireCleanupLeadershipReturns = struct {
+		result1 driver.CleanupLeadership
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeLocker) AcquireCleanupLeadershipReturnsOnCall(i int, result1 driver.CleanupLeadership, result2 bool, result3 error) {
+	fake.acquireCleanupLeadershipMutex.Lock()
+	defer fake.acquireCleanupLeadershipMutex.Unlock()
+	fake.AcquireCleanupLeadershipStub = nil
+	if fake.acquireCleanupLeadershipReturnsOnCall == nil {
+		fake.acquireCleanupLeadershipReturnsOnCall = make(map[int]struct {
+			result1 driver.CleanupLeadership
+			result2 bool
+			result3 error
+		})
+	}
+	fake.acquireCleanupLeadershipReturnsOnCall[i] = struct {
+		result1 driver.CleanupLeadership
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeLocker) Cleanup(arg1 context.Context, arg2 time.Duration) error {

--- a/token/services/storage/db/driver/token.go
+++ b/token/services/storage/db/driver/token.go
@@ -137,6 +137,13 @@ type CleanupLeadership interface {
 	Close() error
 }
 
+// NoopCleanupLeadership is a no-op CleanupLeadership for non-distributed
+// backends (sqlite, in-memory) that always grant leadership locally,
+// since there is only ever one instance to coordinate. See #1798.
+type NoopCleanupLeadership struct{}
+
+func (NoopCleanupLeadership) Close() error { return nil }
+
 // CertificationStore defines a database to manager token certifications
 type CertificationStore interface {
 	// ExistsCertification returns true if a certification for the passed token exists,
@@ -338,6 +345,12 @@ type TokenLockStore interface {
 	// 1. The transaction that locked that token is valid or invalid;
 	// 2. The lock is too old.
 	Cleanup(ctx context.Context, leaseExpiry time.Duration) error
+	// AcquireCleanupLeadership attempts to acquire leadership for the
+	// cleanup tick, so only one replica runs Cleanup per tick. Non-distributed
+	// backends (sqlite, in-memory) always grant leadership locally. The lock
+	// id (if any) is owned internally by the implementation, since it must
+	// be derived per-TMS, not passed in by the caller. See #1798.
+	AcquireCleanupLeadership(ctx context.Context) (CleanupLeadership, bool, error)
 	// Close closes the database
 	Close() error
 }

--- a/token/services/storage/db/sql/postgres/tokenlock.go
+++ b/token/services/storage/db/sql/postgres/tokenlock.go
@@ -32,6 +32,16 @@ type TokenLockStore struct {
 	writeDB *sql.DB
 	ci      common3.CondInterpreter
 	lockID  int64
+
+	// cleanupLockID is derived from the fully-qualified table name (not the
+	// prefix alone, which is not unique per TMS - see review discussion on
+	// #1982), so it is unique per TMS - distinct from lockID (schema-creation
+	// lock) and from other TMSes' cleanup locks on the same node. A single global constant here
+	// was a real bug: it caused every TMS on a node to compete for the
+	// exact same advisory lock, so only one TMS across the whole fleet
+	// ever won cleanup on any tick. See #1798.
+	cleanupLockID        int64
+	cleanupLeaderFactory func(context.Context, *sql.DB, int64) (driver.CleanupLeadership, bool, error)
 }
 
 // GetSchema overrides the base GetSchema to prefix with advisory lock
@@ -55,11 +65,24 @@ func NewTokenLockStore(dbs *common2.RWDB, tableNames common5.TableNames) (*Token
 	}
 
 	return &TokenLockStore{
-		TokenLockStore: tldb,
-		writeDB:        dbs.WriteDB,
-		ci:             ci,
-		lockID:         createTableLockID("tokenlock"),
+		TokenLockStore:       tldb,
+		writeDB:              dbs.WriteDB,
+		ci:                   ci,
+		lockID:               createTableLockID(tableNames.TokenLocks),
+		cleanupLockID:        createTableLockID(tableNames.TokenLocks + "_cleanup"),
+		cleanupLeaderFactory: NewCleanupLeaderFactory(),
 	}, nil
+}
+
+// AcquireCleanupLeadership attempts to acquire a Postgres advisory lock so
+// only one replica runs Cleanup per tick for this TMS; others skip the tick
+// and release no held resources, so contention is limited to the acquire
+// attempt itself. The lock id and factory are fixed at construction. Note
+// the winner holds a dedicated connection off writeDB for the tick's
+// duration (see NewAdvisoryLock), so writeDB's connection pool needs at
+// least one spare connection beyond normal write traffic. See #1798.
+func (db *TokenLockStore) AcquireCleanupLeadership(ctx context.Context) (driver.CleanupLeadership, bool, error) {
+	return db.cleanupLeaderFactory(ctx, db.writeDB, db.cleanupLockID)
 }
 
 // Cleanup removes stale token locks that have expired.

--- a/token/services/storage/db/sql/postgres/tokenlock_leadership_test.go
+++ b/token/services/storage/db/sql/postgres/tokenlock_leadership_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"testing"
+
+	sqlcommon "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/common"
+	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
+	fscpostgres "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/postgres"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTokenLockStore_AcquireCleanupLeadership_ConcurrentReplicas verifies
+// that when two "replicas" (independent TokenLockStore instances for the
+// same TMS, sharing the underlying connection pool but each acquiring its
+// own session via AcquireCleanupLeadership) race for the same cleanup lock,
+// exactly one wins. Uses the real public constructor throughout, so the
+// cleanup lock id is derived internally exactly as it is in production
+// (from the table prefix), not injected by the test. See #1798.
+func TestTokenLockStore_AcquireCleanupLeadership_ConcurrentReplicas(t *testing.T) {
+	cfg := fscpostgres.DefaultConfig(fscpostgres.WithDBName("test-cleanup-leadership"))
+	terminate, _, err := fscpostgres.StartPostgres(t.Context(), cfg, nil)
+	if err != nil {
+		t.Skipf("postgres not available: %v", err)
+	}
+	t.Cleanup(terminate)
+
+	db, err := sql.Open("pgx", cfg.DataSource())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tables, err := sqlcommon.GetTableNames("")
+	require.NoError(t, err)
+	rwdb := &common2.RWDB{ReadDB: db, WriteDB: db}
+
+	// TokenLockStore's schema has a foreign key to the Tokens table, so the
+	// base token store schema must exist first.
+	tokenStore, err := sqlcommon.NewTokenStoreWithNotifier(db, db, tables, NewConditionInterpreter(), nil)
+	require.NoError(t, err)
+	require.NoError(t, tokenStore.CreateSchema())
+
+	// Two independent TokenLockStore instances for the same TMS (same table
+	// prefix), simulating two replicas. They share the connection pool, but
+	// AcquireCleanupLeadership takes a dedicated connection (session)
+	// internally, so this exercises real pg_try_advisory_lock contention,
+	// not just two calls on one session.
+	replicaA, err := NewTokenLockStore(rwdb, tables)
+	require.NoError(t, err)
+	replicaB, err := NewTokenLockStore(rwdb, tables)
+	require.NoError(t, err)
+	require.NoError(t, replicaA.CreateSchema())
+
+	require.Equal(t, replicaA.cleanupLockID, replicaB.cleanupLockID,
+		"replicas for the same TMS must derive the same cleanup lock id")
+
+	var wg sync.WaitGroup
+	results := make([]bool, 2)
+	leaderships := make([]interface{ Close() error }, 2)
+	errs := make([]error, 2)
+
+	acquire := func(i int, store *TokenLockStore) {
+		defer wg.Done()
+		l, acquired, err := store.AcquireCleanupLeadership(context.Background())
+		results[i] = acquired
+		errs[i] = err
+		if acquired {
+			leaderships[i] = l
+		}
+	}
+
+	wg.Add(2)
+	go acquire(0, replicaA)
+	go acquire(1, replicaB)
+	wg.Wait()
+
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+	require.NotEqual(t, results[0], results[1], "exactly one replica should acquire leadership, got: A=%v B=%v", results[0], results[1])
+
+	for _, l := range leaderships {
+		if l != nil {
+			require.NoError(t, l.Close())
+		}
+	}
+
+	l3, acquired3, err := replicaA.AcquireCleanupLeadership(context.Background())
+	require.NoError(t, err)
+	require.True(t, acquired3, "leadership should be acquirable again after release")
+	require.NoError(t, l3.Close())
+}
+
+// TestTokenLockStore_AcquireCleanupLeadership_DistinctTMS verifies that two
+// TokenLockStores for *different* TMSes (different table prefixes) derive
+// different cleanup lock ids, and so do not contend with each other at all
+// - this is the exact bug flagged in review: a single global lock id would
+// have caused every TMS on a node to compete for the same lock, so only one
+// TMS across the whole fleet would ever win cleanup on any tick. See #1798.
+func TestTokenLockStore_AcquireCleanupLeadership_DistinctTMS(t *testing.T) {
+	cfg := fscpostgres.DefaultConfig(fscpostgres.WithDBName("test-cleanup-leadership-distinct-tms"))
+	terminate, _, err := fscpostgres.StartPostgres(t.Context(), cfg, nil)
+	if err != nil {
+		t.Skipf("postgres not available: %v", err)
+	}
+	t.Cleanup(terminate)
+
+	db, err := sql.Open("pgx", cfg.DataSource())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	rwdb := &common2.RWDB{ReadDB: db, WriteDB: db}
+
+	// Same prefix (one shared persistence block), different TMS identity
+	// params - this is the actual scenario the manager creates in
+	// production (db/manager.go), and the one that was broken: Prefix
+	// alone is identical for both, only the formatted table name (which
+	// bakes in the params) differs. See review discussion on #1982.
+	tablesA, err := sqlcommon.GetTableNames("tsdk", "netA", "chA", "nsA")
+	require.NoError(t, err)
+	tablesB, err := sqlcommon.GetTableNames("tsdk", "netB", "chB", "nsB")
+	require.NoError(t, err)
+
+	tokenStoreA, err := sqlcommon.NewTokenStoreWithNotifier(db, db, tablesA, NewConditionInterpreter(), nil)
+	require.NoError(t, err)
+	require.NoError(t, tokenStoreA.CreateSchema())
+	tokenStoreB, err := sqlcommon.NewTokenStoreWithNotifier(db, db, tablesB, NewConditionInterpreter(), nil)
+	require.NoError(t, err)
+	require.NoError(t, tokenStoreB.CreateSchema())
+
+	tmsA, err := NewTokenLockStore(rwdb, tablesA)
+	require.NoError(t, err)
+	require.NoError(t, tmsA.CreateSchema())
+	tmsB, err := NewTokenLockStore(rwdb, tablesB)
+	require.NoError(t, err)
+	require.NoError(t, tmsB.CreateSchema())
+
+	require.NotEqual(t, tmsA.cleanupLockID, tmsB.cleanupLockID,
+		"distinct TMSes must derive distinct cleanup lock ids, or one TMS's cleanup would starve the other's")
+	require.NotEqual(t, tmsA.lockID, tmsB.lockID,
+		"distinct TMSes must derive distinct schema-creation lock ids too - a regression back to a "+
+			"prefix-only or global constant would pass the cleanupLockID check above but not this one")
+	require.NotEqual(t, tmsA.lockID, tmsA.cleanupLockID,
+		"schema-creation and cleanup locks on the same store must be distinct")
+	require.NotEqual(t, tmsB.lockID, tmsB.cleanupLockID,
+		"schema-creation and cleanup locks on the same store must be distinct")
+
+	// both should acquire leadership independently and concurrently, since
+	// they are coordinating over different locks
+	lA, acquiredA, err := tmsA.AcquireCleanupLeadership(context.Background())
+	require.NoError(t, err)
+	require.True(t, acquiredA)
+	defer func() { _ = lA.Close() }()
+
+	lB, acquiredB, err := tmsB.AcquireCleanupLeadership(context.Background())
+	require.NoError(t, err)
+	require.True(t, acquiredB, "TMS B should acquire leadership independently of TMS A")
+	defer func() { _ = lB.Close() }()
+}

--- a/token/services/storage/db/sql/sqlite/tokenlock.go
+++ b/token/services/storage/db/sql/sqlite/tokenlock.go
@@ -15,6 +15,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query/cond"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
 	common4 "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/common"
 )
 
@@ -57,6 +58,13 @@ func (db *TokenLockStore) Cleanup(ctx context.Context, leaseExpiry time.Duration
 	}
 
 	return err
+}
+
+// AcquireCleanupLeadership always grants leadership locally - sqlite is a
+// non-distributed backend with only one instance, so there is nothing to
+// coordinate. See #1798.
+func (db *TokenLockStore) AcquireCleanupLeadership(_ context.Context) (driver.CleanupLeadership, bool, error) {
+	return driver.NoopCleanupLeadership{}, true, nil
 }
 
 func NewTokenLockStore(dbs *common3.RWDB, tableNames common4.TableNames) (*TokenLockStore, error) {


### PR DESCRIPTION
## Summary
Implements #1798: currently every replica runs the token-locks cleanup tick independently, causing wasted, overlapping work, all replicas race to delete the same expired rows at the same time. This adds a per-tick leadership check so only one replica performs cleanup, following the exact same pattern already established for keystore cleanup (`AcquireCleanupLeadership`).

## Changes
-> Added `AcquireCleanupLeadership` to both `driver.TokenLockStore` and `sherdlock.Locker` interfaces
-> Added a shared `driver.NoopCleanupLeadership` for non-distributed backends (sqlite, in-memory), which always grant leadership locally, no failover code needed since there's only ever one instance
-> Wired the real Postgres advisory-lock implementation via the existing `NewCleanupLeaderFactory()`, using a lock id independent of the schema-creation lock id already used by `TokenLockStore.lockID` (deliberately separate to avoid any collision between the two purposes)
-> `manager.go`'s `cleaner()` now acquires leadership before each `Cleanup` tick, skips the tick if not acquired, and releases leadership after, matching the design: per-tick election, no permanent leader, no failover code, advisory lock auto-releases if the winner crashes
-> Regenerated the `FakeLocker` mock; extended the hand-written `mockLocker` test double, defaulting to always-granted so all pre-existing tests are unaffected
-> Added two new subtests to `TestManager_Cleaner`: skip-on-no-leadership, and leadership-released-after-cleanup

## Testing
Full test suite green (`selector`, `sqlite`, `postgres`).

## Notes for the Reviewer
Followed the 4-step plan from the design discussion on #1798. Happy to add a Postgres integration test exercising two concurrent "replicas" if useful on top of the unit-level coverage already here, let me know if that's wanted before merge.