### PR TITLE
perf(zkatdlog): reduce CPU time and allocations in CSP range-proof crypto

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/math/native.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/math/native.go
@@ -91,6 +91,32 @@ func NativeBatchInverse[T any, E GnarkFr[T]](elems []E) []E {
 	return resultE
 }
 
+// NativeBatchInverseInto is the zero-allocation counterpart of NativeBatchInverse,
+// for hot loops that perform many same-size batch inversions: the caller hoists
+// prefix and out once and reuses them across calls instead of paying 3 fresh
+// allocations (prefix, result, resultE) per call.
+//
+// elems, prefix, and out must all have equal, non-zero length; prefix and out
+// must not alias elems or each other. out[i] must already be a valid pointer
+// into caller-owned storage (e.g. out[i] = E(&outBacking[i])).
+func NativeBatchInverseInto[T any, E GnarkFr[T]](elems []E, prefix []T, out []E) {
+	n := len(elems)
+
+	prefix[0] = *elems[0]
+	for i := 1; i < n; i++ {
+		E(&prefix[i]).Mul(E(&prefix[i-1]), elems[i])
+	}
+
+	var acc T
+	E(&acc).Inverse(E(&prefix[n-1]))
+
+	for i := n - 1; i > 0; i-- {
+		out[i].Mul(E(&acc), E(&prefix[i-1]))
+		E(&acc).Mul(E(&acc), elems[i])
+	}
+	*out[0] = acc
+}
+
 // DispatchCurve returns true for BLS and BN254 curves based on the curve ID.
 func DispatchCurve(curve *mathlib.Curve) (isBLS bool, isBN254 bool) {
 	switch curve.GroupOrder.CurveID() {

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/csp.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/csp.go
@@ -148,8 +148,8 @@ func (p *prover) Prove() (*Proof, error) {
 		// Cross-commitments via MSM:
 		//   left[i]  = MSM(gen_L, wit_R)   gen_L = generators[:n], wit_R = witness[n:]
 		//   right[i] = MSM(gen_R, wit_L)   gen_R = generators[n:], wit_L = witness[:n]
-		left[i] = p.Curve.MultiScalarMul(generators[:n], witness[n:])
-		right[i] = p.Curve.MultiScalarMul(generators[n:], witness[:n])
+		left[i] = smallMSM(p.Curve, generators[:n], witness[n:])
+		right[i] = smallMSM(p.Curve, generators[n:], witness[:n])
 
 		// Cross scalar products via ModAddMul (scalar-field MSM):
 		//   vLeft[i]  = ⟨f_L, wit_R⟩
@@ -359,7 +359,7 @@ func (v *verifier) Verify(proof *Proof) error {
 		allScalars = append(allScalars, v.Curve.ModMul(genScalars[i], negVal, v.Curve.GroupOrder))
 	}
 
-	if !v.Curve.MultiScalarMul(allPoints, allScalars).IsInfinity() {
+	if !smallMSM(v.Curve, allPoints, allScalars).IsInfinity() {
 		return errors.New("CSP proof verification failed")
 	}
 

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_native.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_native.go
@@ -211,28 +211,43 @@ func interpolateNative[T any, E math2.GnarkFr[T]](n uint64, valuesOverN []*mathl
 	result := make([]*mathlib.Zr, 2*int(n)+1) // #nosec G115
 	copy(result, valuesOverN)
 
+	// Scratch buffers reused across every x in the loop below. Calling
+	// Mul/Add through the generic dictionary-dispatched E defeats escape
+	// analysis, so anything declared inside the loop would heap-allocate on
+	// every one of the O(n) outer iterations (each doing an O(m) batch
+	// inversion); declaring them once and reusing them (each iteration fully
+	// overwrites every entry before reading it) amortizes that to a single
+	// allocation per buffer for the whole call.
+	var li, px, val T
+	liE, pxE, valE := E(&li), E(&px), E(&val)
+
+	xMinusJ := make([]T, m)
+	xMinusJE := make([]E, m)
+	for j := range m {
+		xMinusJE[j] = E(&xMinusJ[j])
+	}
+
+	invPrefix := make([]T, m)
+	xMinusJInvs := make([]T, m)
+	xMinusJInvsE := make([]E, m)
+	for j := range m {
+		xMinusJInvsE[j] = E(&xMinusJInvs[j])
+	}
+
 	// Evaluate at each x in {n+1, ..., 2n} via Lagrange interpolation.
 	for x := int(n) + 1; x <= 2*int(n); x++ { // #nosec G115
 		// xMinusJ[j] = x - j, and px = ∏_j xMinusJ[j]
-		xMinusJ := make([]T, m)
-		xMinusJE := make([]E, m)
-		var px T
-		pxE := E(&px)
 		pxE.SetOne()
 		for j := range m {
-			xMinusJE[j] = E(&xMinusJ[j])
 			xMinusJE[j].SetInt64(int64(x - j)) // #nosec G115
 			pxE.Mul(pxE, xMinusJE[j])
 		}
 
-		xMinusJInvs := math2.NativeBatchInverse[T, E](xMinusJE)
+		math2.NativeBatchInverseInto[T, E](xMinusJE, invPrefix, xMinusJInvsE)
 
-		var val T
-		valE := E(&val)
+		valE.SetZero()
 		for i := range m {
-			var li T
-			liE := E(&li)
-			liE.Mul(pxE, xMinusJInvs[i])
+			liE.Mul(pxE, xMinusJInvsE[i])
 			liE.Mul(liE, denomInvs[i])
 			liE.Mul(liE, valsE[i])
 			valE.Add(valE, liE)

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/msm.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/msm.go
@@ -1,0 +1,32 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package csp
+
+import (
+	mathlib "github.com/IBM/mathlib"
+)
+
+// smallMSM computes MSM(points, scalars), dispatching to a direct scalar
+// multiplication for the small, fixed sizes that dominate CSP's per-round
+// calls (its folding rounds shrink every vector down to length 2 and then 1).
+// gnark-crypto's MultiScalarMul always spawns a goroutine fan-out sized for
+// runtime.NumCPU(), which for n<=2 costs more than it saves: benchmarked on
+// BLS12-381, plain Mul is ~2.5x faster than MultiScalarMul at n=1, and Mul2
+// is ~25% faster at n=2. From n=3 up, MultiScalarMul already wins, so this
+// only special-cases n=1 and n=2.
+//
+// points and scalars must have equal, non-zero length.
+func smallMSM(curve *mathlib.Curve, points []*mathlib.G1, scalars []*mathlib.Zr) *mathlib.G1 {
+	switch len(points) {
+	case 1:
+		return points[0].Mul(scalars[0])
+	case 2:
+		return points[0].Mul2(scalars[0], points[1], scalars[1])
+	default:
+		return curve.MultiScalarMul(points, scalars)
+	}
+}

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rp.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rp.go
@@ -211,7 +211,7 @@ func (rp *rangeProver) Prove() (*RangeProof, error) {
 	}
 	pokTv := rp.Curve.NewRandomZr(rand)
 	pokTr := rp.Curve.NewRandomZr(rand)
-	pokA := rp.Curve.MultiScalarMul(rp.VGenerators, []*mathlib.Zr{pokTv, pokTr})
+	pokA := smallMSM(rp.Curve, rp.VGenerators, []*mathlib.Zr{pokTv, pokTr})
 	tr.Absorb(pokA.Bytes())
 	pokE, err := tr.Squeeze()
 	if err != nil {
@@ -264,7 +264,7 @@ func (rp *rangeProver) Prove() (*RangeProof, error) {
 	copy(g[n+1:], rp.BGenerators)
 
 	// First prover message: pComm = MSM(g, p). Absorb and squeeze eta, c.
-	pComm := rp.Curve.MultiScalarMul(g, p)
+	pComm := smallMSM(rp.Curve, g, p)
 	tr.Absorb(pComm.Bytes())
 	eta, err := tr.Squeeze()
 	if err != nil {
@@ -375,7 +375,7 @@ func (rp *rangeProver) Prove() (*RangeProof, error) {
 	for i := range sBlind {
 		sBlind[i] = rp.Curve.NewRandomZr(rand)
 	}
-	sComm := rp.Curve.MultiScalarMul(gExt, sBlind)
+	sComm := smallMSM(rp.Curve, gExt, sBlind)
 	// Compute sVal = ⟨lf, sBlind⟩ — dispatch to native for supported curves.
 	var sVal *mathlib.Zr
 	if isBLS {
@@ -515,7 +515,7 @@ func (rv *rangeVerifier) Verify(proof *RangeProof) error {
 	if err != nil {
 		return errors.New("unable to recompute PoK challenge")
 	}
-	pokLHS := rv.Curve.MultiScalarMul(rv.VGenerators, proof.pokV.Z)
+	pokLHS := smallMSM(rv.Curve, rv.VGenerators, proof.pokV.Z)
 	pokRHS := proof.pokV.A.Copy()
 	pokRHS.Add(rv.VCommitment.Mul(pokE))
 	if !pokLHS.Equals(pokRHS) {

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/transcript.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/transcript.go
@@ -15,6 +15,12 @@ import (
 
 type Transcript struct {
 	fsState []byte
+	// scratch is a reused input buffer for Absorb's fsState||hashBytes
+	// concatenation. Without it, every Absorb call would append into a
+	// freshly grown slice (fsState's capacity never exceeds its length),
+	// forcing a heap allocation per call across the many Absorb calls per
+	// CSP/range-proof round.
+	scratch []byte
 	Curve   *mathlib.Curve
 }
 
@@ -33,8 +39,17 @@ func (tr *Transcript) InitHasherWithDomain(domainSeparator string) {
 
 // Absorb the message from transcript
 func (tr *Transcript) Absorb(hashBytes []byte) {
-	bytesToHash := append(tr.fsState, hashBytes...)
-	newHash := sha256.Sum256(bytesToHash)
+	need := len(tr.fsState) + len(hashBytes)
+	if cap(tr.scratch) < need {
+		tr.scratch = make([]byte, need)
+	}
+	buf := tr.scratch[:need]
+	copy(buf, tr.fsState)
+	copy(buf[len(tr.fsState):], hashBytes)
+
+	newHash := sha256.Sum256(buf)
+	// fsState is replaced with a fresh array (not a view into scratch) so a
+	// slice previously returned by State() is never mutated by later Absorb calls.
 	tr.fsState = newHash[:]
 }
 


### PR DESCRIPTION
Fixes #1994

## Summary

Optimizes the Compressed Sigma Protocol (CSP) range-proof package
(`crypto/rp/csp`) with no change to its public API, wire format, or verification
semantics:

- `crypto/rp/csp/msm.go` (new): dispatches small, fixed-size multi-scalar
  multiplications to direct `Mul`/`Mul2` instead of gnark-crypto's
  `MultiScalarMul`. CSP's folding rounds shrink every vector down to length 2
  and then 1 in their last two rounds, and several call sites always operate
  on exactly 2 generators/scalars; `MultiScalarMul`'s goroutine fan-out (sized
  for `runtime.NumCPU()*2`) costs more than it saves at n<=2. Benchmarked on
  BLS12-381 (M1 Max): direct `Mul` is ~2.5x faster than `MultiScalarMul` at
  n=1, `Mul2` ~25-29% faster at n=2; from n=3 the two are at parity or
  `MultiScalarMul` wins, so `smallMSM` only special-cases n=1/n=2 and falls
  through to `MultiScalarMul` otherwise (strictly non-regressive). Applied at
  all 6 production `MultiScalarMul` call sites in `csp.go`/`rp.go`.

- `crypto/math/native.go`: adds `NativeBatchInverseInto`, a batch
  field-inversion helper that writes into caller-supplied buffers instead of
  allocating fresh ones on every call.

- `crypto/rp/csp/lagrange_native.go`: `interpolateNative`'s outer loop
  previously allocated 5 fresh same-size slices/scalars per iteration.
  Rewritten to hoist every per-x buffer and scalar scratch outside the outer
  loop via `NativeBatchInverseInto`, so each is allocated once per call
  instead of once per iteration.

- `crypto/rp/csp/transcript.go`: `Transcript.Absorb` is called many times per
  proving/verification round; reuses a scratch buffer across calls instead of
  growing a fresh slice on every `Absorb`.

Benchmarked on `BenchmarkBFProver` (n=32/n=64, `BLS12_381_BBS_GURVY`, count=8,
`benchstat`): combined effect of the MSM dispatch and batch-inversion changes
is roughly -6% ns/op and -35-40% allocs/op (geomean), each individually
significant at p<0.01. No public API, wire format, or verification behavior
changed.

## Test plan

- [x] `make checks`
- [x] `make lint-auto-fix`
- [x] `make unit-tests`
- [x] Targeted: `go test ./token/core/zkatdlog/nogh/v1/crypto/rp/csp/... ./token/core/zkatdlog/nogh/v1/crypto/math/... ./token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/...`
- [x] `benchstat` before/after on `BenchmarkBFProver`, count=8