### PR TITLE
fix(recovery): derive the recovery lock id per TMS

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,14 +253,6 @@ token:
               # Relationship: Should be greater than the expected network latency + processing time for transaction status queries.
               leaseDuration: 30s
               
-              # advisoryLockID is the PostgreSQL advisory lock identifier used for recovery leader election.
-              # This ensures only one replica performs recovery sweeps at a time in multi-instance deployments.
-              # Default: 8389190333894887286 (hex: 0x74746b7265636f76, ASCII: "ttkrecov")
-              # The default value is derived from the ASCII encoding of "ttkrecov" (Token Transaction Recovery).
-              # Only change this if you need to run multiple independent recovery managers on the same database.
-              # Note: PostgreSQL advisory locks use 64-bit integers. This value must be unique across your application.
-              advisoryLockID: 8389190333894887286
-              
               # instanceID identifies this replica as the owner of recovery claims.
               # If empty, a process-local identifier is generated automatically at startup using a UUID.
               # Set this explicitly in containerized environments to maintain consistent identity across restarts.
@@ -314,14 +306,6 @@ token:
             # Decrease to reduce resource consumption on constrained systems.
             # Performance impact: More workers increase CPU utilization during cleanup sweeps.
             workerCount: 1
-            
-            # advisoryLockID is the PostgreSQL advisory lock identifier used for cleanup leader election.
-            # This ensures only one replica performs cleanup sweeps at a time in multi-instance deployments.
-            # Default: 8389190333894887277 (hex: 0x74746b636c65616e, ASCII: "ttkclean")
-            # The default value is derived from the ASCII encoding of "ttkclean" (Token Transaction Keystore Cleanup).
-            # Only change this if you need to run multiple independent cleanup managers on the same database.
-            # Note: PostgreSQL advisory locks use 64-bit integers. This value must be unique across your application.
-            advisoryLockID: 8389190333894887277
             
             # instanceID identifies this replica in logs and monitoring.
             # If empty, a unique identifier is generated automatically at startup.
@@ -657,7 +641,6 @@ token:
               batchSize: 100
               workerCount: 4
               leaseDuration: 30s
-              advisoryLockID: 8389190333894887286
               instanceID:
               notFoundGracePeriod: 30m
 ```
@@ -670,7 +653,6 @@ Default values:
 - batchSize: 100
 - workerCount: 4
 - leaseDuration: 30s
-- advisoryLockID: 8389190333894887286 (`0x74746b7265636f76`)
 - instanceID: empty, auto-generated when the recovery manager starts
 - notFoundGracePeriod: 30m (set to 0 to disable promotion to Orphan)
 
@@ -679,7 +661,7 @@ Default values:
 - **Recovery is enabled by default** to ensure automatic recovery of lost finality listeners.
 - **Only pending transactions older than `ttl` are considered for recovery** to avoid interfering with active transaction processing.
 - **The manager validates** that `ttl`, `scanInterval`, `batchSize`, `workerCount`, and `leaseDuration` are all greater than zero.
-- **`advisoryLockID`** is used to acquire PostgreSQL advisory-lock leadership so that only one replica performs a recovery sweep at a time. The default value (8389190333894887286 or 0x74746b7265636f76) represents the ASCII string "ttkrecov" (Token Transaction Recovery) encoded as a 64-bit integer.
+- **Recovery leadership** uses a PostgreSQL advisory lock so that only one replica performs a recovery sweep at a time, on the owner transaction path. The lock identifier is no longer configurable: it is derived from the TMS's own `requests` table name, which already carries the network, channel and namespace. That makes it unique per TMS automatically, so several TMSes sharing one PostgreSQL database no longer compete for a single lock, and there is nothing left for an operator to keep unique by hand. The audit transaction store does not yet participate in this coordination — its recovery leader factory is nil, so every replica is granted leadership and the audit sweep runs redundantly on each of them; see [#2143](https://github.com/LFDT-Panurus/panurus/issues/2143).
 - **`instanceID`** is used as the lease owner identifier for claimed transactions; if omitted, the manager generates a unique UUID automatically at startup.
 - **`notFoundGracePeriod`** controls how long a transaction whose status query keeps returning `NotFound` is left in `Pending` before being promoted to the terminal `Orphan` status. This protects the recovery sweep from being permanently blocked by transactions whose audit log was persisted but whose broadcast never reached the ledger. The promoted row is marked `Orphan` rather than `Deleted` so operators can distinguish broadcast failures from ledger-rejected transactions. Raise the default if your network has long catch-up windows after committer/orderer restarts; set it to `0` to disable the promotion entirely.
 
@@ -784,7 +766,6 @@ token:
             scanInterval: 1h
             batchSize: 100
             workerCount: 1
-            advisoryLockID: 8389190333894887277
             instanceID:
 ```
 
@@ -795,7 +776,6 @@ Default values:
 - scanInterval: 1h
 - batchSize: 100
 - workerCount: 1
-- advisoryLockID: 8389190333894887277 (`0x74746b636c65616e`)
 - instanceID: empty, auto-generated when the cleanup manager starts
 
 **Parameter Relationships and Tuning:**
@@ -803,7 +783,7 @@ Default values:
 - **Cleanup is disabled by default** and must be explicitly enabled. This is a conservative default to prevent unexpected key deletion in existing deployments.
 - **Only deleted tokens older than `ttl` are considered for cleanup** to ensure tokens are truly finalized before key deletion.
 - **The manager validates** that `ttl`, `scanInterval`, `batchSize`, and `workerCount` are all greater than zero.
-- **`advisoryLockID`** is used to acquire PostgreSQL advisory-lock leadership so that only one replica performs a cleanup sweep at a time. The default value (8389190333894887277 or 0x74746b636c65616e) represents the ASCII string "ttkclean" (Token Transaction Keystore Cleanup) encoded as a 64-bit integer.
+- **Cleanup leadership** uses a PostgreSQL advisory lock so only one replica sweeps at a time. The identifier is not configurable: it is derived from the TMS's own token SKI cleanup table name, which already carries network, channel and namespace, so it is unique per TMS automatically.
 - **`instanceID`** is used to identify this replica in logs and monitoring; if omitted, the manager generates a unique identifier automatically at startup.
 
 **Tuning Recommendations:**
@@ -825,7 +805,6 @@ Default values:
 
 4. **For Multi-Instance Deployments:**
    - **PostgreSQL Required**: Multi-instance deployments require PostgreSQL for distributed coordination via advisory locks
-   - Keep default `advisoryLockID` unless running multiple independent cleanup systems
    - Consider setting explicit `instanceID` values for easier debugging and monitoring
 
 5. **For Single-Node Deployments:**
@@ -910,7 +889,6 @@ multiply `acquireDeadline` there.
 
 4. **For Multi-Instance Deployments:**
    - **PostgreSQL Required**: Multi-instance deployments require PostgreSQL for distributed coordination via advisory locks
-   - Keep default `advisoryLockID` unless running multiple independent recovery systems
    - Consider setting explicit `instanceID` values for easier debugging and monitoring
    - Ensure all instances share the same PostgreSQL database for proper coordination
 

--- a/docs/services/storage/keystore_cleanup.md
+++ b/docs/services/storage/keystore_cleanup.md
@@ -105,7 +105,7 @@ The Storage interface abstracts database operations needed for cleanup:
 ```go
 type Storage interface {
     // AcquireCleanupLeadership obtains distributed lock for leader election
-    AcquireCleanupLeadership(ctx context.Context, lockID int64) (Leadership, bool, error)
+    AcquireCleanupLeadership(ctx context.Context) (Leadership, bool, error)
     
     // GetDeletedTokensPendingSKICleanup queries deleted, owned tokens older than TTL that haven't been cleaned.
     // Tokens for which this node is only an auditor or issuer are excluded, since this node
@@ -168,7 +168,6 @@ services:
       scanInterval: 1h           # How often to scan
       batchSize: 100            # Max tokens per scan
       workerCount: 1            # Parallel workers (default: 1)
-      advisoryLockID: 0x74746b636c65616e  # Lock ID for leader election ("ttkclean" in hex)
       instanceID: "cleanup-1"   # Instance identifier (auto-generated if empty)
 ```
 
@@ -179,8 +178,12 @@ services:
 - **scanInterval**: How frequently the manager scans for eligible tokens
 - **batchSize**: Maximum number of tokens processed in a single sweep
 - **workerCount**: Number of parallel workers processing tokens within a sweep (default: 1)
-- **advisoryLockID**: PostgreSQL advisory lock ID for distributed coordination
 - **instanceID**: Identifies the cleanup instance; auto-generated as `cleanup-<pointer>` if not provided
+
+Leader election uses a PostgreSQL advisory lock whose identifier is not configurable. It is derived
+from the TMS's own token SKI cleanup table name, which already carries network, channel and
+namespace, so it is unique per TMS automatically and several TMSes sharing one database no longer
+compete for a single lock.
 
 **Configuration Loading:**
 
@@ -203,7 +206,6 @@ config := cleanup.Config{
     ScanInterval:    1 * time.Hour,
     BatchSize:       100,
     WorkerCount:     4,
-    AdvisoryLockID:  0x74746b636c65616e,
     InstanceID:      "cleanup-instance-1",
 }
 
@@ -390,7 +392,6 @@ The `token_ski_cleanups` table is automatically created by the schema initializa
 - **Scan Interval**: 1 hour (less aggressive than recovery's 5 seconds)
 - **Batch Size**: 100 tokens per sweep
 - **Worker Count**: 1 parallel worker (conservative default)
-- **Advisory Lock ID**: `0x74746b636c65616e` ("ttkclean" in hex)
 - **Instance ID**: Auto-generated as `cleanup-<pointer>` if not provided
 
 ### Tuning Recommendations
@@ -412,7 +413,6 @@ The `token_ski_cleanups` table is automatically created by the schema initializa
 
 4. **For Multi-Instance Deployments:**
    - **PostgreSQL Required**: Multi-instance deployments require PostgreSQL for distributed coordination
-   - Keep default `advisoryLockID` unless running multiple independent cleanup systems
    - Consider setting explicit `instanceID` values for easier debugging and monitoring
 
 ### Performance Considerations

--- a/docs/services/storage/recovery.md
+++ b/docs/services/storage/recovery.md
@@ -68,7 +68,6 @@ recovery:
   batchSize: 100             # Max transactions per scan
   workerCount: 4             # Parallel workers
   leaseDuration: 30s         # Claim lease duration
-  advisoryLockID: 8389...    # PostgreSQL lock ID
   instanceID: ""             # Instance identifier
   notFoundGracePeriod: 30m   # Promote NotFound rows to Orphan after this age (0 disables)
 ```
@@ -85,7 +84,6 @@ config := recovery.Config{
     BatchSize:           100,
     WorkerCount:         4,
     LeaseDuration:       30 * time.Second,
-    AdvisoryLockID:      8389190333894887286,
     NotFoundGracePeriod: 30 * time.Minute,
 }
 

--- a/token/services/auditor/mock/audit_transaction_store.go
+++ b/token/services/auditor/mock/audit_transaction_store.go
@@ -10,11 +10,10 @@ import (
 )
 
 type AuditTransactionStore struct {
-	AcquireRecoveryLeadershipStub        func(context.Context, int64) (driver.RecoveryLeadership, bool, error)
+	AcquireRecoveryLeadershipStub        func(context.Context) (driver.RecoveryLeadership, bool, error)
 	acquireRecoveryLeadershipMutex       sync.RWMutex
 	acquireRecoveryLeadershipArgsForCall []struct {
 		arg1 context.Context
-		arg2 int64
 	}
 	acquireRecoveryLeadershipReturns struct {
 		result1 driver.RecoveryLeadership
@@ -206,19 +205,18 @@ type AuditTransactionStore struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *AuditTransactionStore) AcquireRecoveryLeadership(arg1 context.Context, arg2 int64) (driver.RecoveryLeadership, bool, error) {
+func (fake *AuditTransactionStore) AcquireRecoveryLeadership(arg1 context.Context) (driver.RecoveryLeadership, bool, error) {
 	fake.acquireRecoveryLeadershipMutex.Lock()
 	ret, specificReturn := fake.acquireRecoveryLeadershipReturnsOnCall[len(fake.acquireRecoveryLeadershipArgsForCall)]
 	fake.acquireRecoveryLeadershipArgsForCall = append(fake.acquireRecoveryLeadershipArgsForCall, struct {
 		arg1 context.Context
-		arg2 int64
-	}{arg1, arg2})
+	}{arg1})
 	stub := fake.AcquireRecoveryLeadershipStub
 	fakeReturns := fake.acquireRecoveryLeadershipReturns
-	fake.recordInvocation("AcquireRecoveryLeadership", []interface{}{arg1, arg2})
+	fake.recordInvocation("AcquireRecoveryLeadership", []interface{}{arg1})
 	fake.acquireRecoveryLeadershipMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -232,17 +230,17 @@ func (fake *AuditTransactionStore) AcquireRecoveryLeadershipCallCount() int {
 	return len(fake.acquireRecoveryLeadershipArgsForCall)
 }
 
-func (fake *AuditTransactionStore) AcquireRecoveryLeadershipCalls(stub func(context.Context, int64) (driver.RecoveryLeadership, bool, error)) {
+func (fake *AuditTransactionStore) AcquireRecoveryLeadershipCalls(stub func(context.Context) (driver.RecoveryLeadership, bool, error)) {
 	fake.acquireRecoveryLeadershipMutex.Lock()
 	defer fake.acquireRecoveryLeadershipMutex.Unlock()
 	fake.AcquireRecoveryLeadershipStub = stub
 }
 
-func (fake *AuditTransactionStore) AcquireRecoveryLeadershipArgsForCall(i int) (context.Context, int64) {
+func (fake *AuditTransactionStore) AcquireRecoveryLeadershipArgsForCall(i int) context.Context {
 	fake.acquireRecoveryLeadershipMutex.RLock()
 	defer fake.acquireRecoveryLeadershipMutex.RUnlock()
 	argsForCall := fake.acquireRecoveryLeadershipArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1
 }
 
 func (fake *AuditTransactionStore) AcquireRecoveryLeadershipReturns(result1 driver.RecoveryLeadership, result2 bool, result3 error) {

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -661,7 +661,7 @@ type transactionDB interface {
 	GetTokenRequest(ctx context.Context, txID string) ([]byte, error)
 	SetStatus(ctx context.Context, txID string, status storage.TxStatus, message string) error
 	NotifyStatus(ctx context.Context, txID string, status storage.TxStatus, message string)
-	AcquireRecoveryLeadership(ctx context.Context, lockID int64) (recovery2.Leadership, bool, error)
+	AcquireRecoveryLeadership(ctx context.Context) (recovery2.Leadership, bool, error)
 	ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*ttxdb.RecoveryClaim, error)
 	ReleaseRecoveryClaim(ctx context.Context, txID string, owner string, message string) error
 }

--- a/token/services/storage/auditdb/store.go
+++ b/token/services/storage/auditdb/store.go
@@ -365,8 +365,8 @@ func (d *StoreService) ReleaseLocks(ctx context.Context, anchor string) {
 }
 
 // AcquireRecoveryLeadership tries to acquire the DB-backed recovery leadership lease.
-func (d *StoreService) AcquireRecoveryLeadership(ctx context.Context, lockID int64) (dbdriver.RecoveryLeadership, bool, error) {
-	leadership, acquired, err := d.db.AcquireRecoveryLeadership(ctx, lockID)
+func (d *StoreService) AcquireRecoveryLeadership(ctx context.Context) (dbdriver.RecoveryLeadership, bool, error) {
+	leadership, acquired, err := d.db.AcquireRecoveryLeadership(ctx)
 	if err != nil {
 		return nil, false, errors.Wrapf(err, "failed to acquire recovery leadership")
 	}

--- a/token/services/storage/db/driver/audit.go
+++ b/token/services/storage/db/driver/audit.go
@@ -55,7 +55,7 @@ type AuditTransactionStore interface {
 
 	// AcquireRecoveryLeadership tries to acquire the PostgreSQL advisory lock backing the sweeper leader election.
 	// If acquired is false, leadership was not obtained and the returned lease must be nil.
-	AcquireRecoveryLeadership(ctx context.Context, lockID int64) (RecoveryLeadership, bool, error)
+	AcquireRecoveryLeadership(ctx context.Context) (RecoveryLeadership, bool, error)
 
 	// ClaimPendingTransactions atomically claims a batch of Pending transactions for recovery processing.
 	// Transactions whose recovery lease expired are eligible again.

--- a/token/services/storage/db/driver/token.go
+++ b/token/services/storage/db/driver/token.go
@@ -294,7 +294,7 @@ type TokenStore interface {
 	// Returns (leadership, true, nil) if leadership was acquired.
 	// Returns (nil, false, nil) if leadership is held by another instance.
 	// Returns (nil, false, error) if an error occurred.
-	AcquireCleanupLeadership(ctx context.Context, lockID int64) (CleanupLeadership, bool, error)
+	AcquireCleanupLeadership(ctx context.Context) (CleanupLeadership, bool, error)
 }
 
 type (

--- a/token/services/storage/db/driver/ttx.go
+++ b/token/services/storage/db/driver/ttx.go
@@ -91,7 +91,7 @@ type TransactionStore interface {
 
 	// AcquireRecoveryLeadership tries to acquire the PostgreSQL advisory lock backing the sweeper leader election.
 	// If acquired is false, leadership was not obtained and the returned lease must be nil.
-	AcquireRecoveryLeadership(ctx context.Context, lockID int64) (RecoveryLeadership, bool, error)
+	AcquireRecoveryLeadership(ctx context.Context) (RecoveryLeadership, bool, error)
 
 	// ClaimPendingTransactions atomically claims a batch of Pending transactions for recovery processing.
 	// Transactions whose recovery lease expired are eligible again.

--- a/token/services/storage/db/sql/common/tokens.go
+++ b/token/services/storage/db/sql/common/tokens.go
@@ -47,7 +47,7 @@ type TokenStore struct {
 	table                tokenTables
 	ci                   common3.CondInterpreter
 	notifier             driver.TokenNotifier
-	cleanupLeaderFactory func(context.Context, *sql.DB, int64) (driver.CleanupLeadership, bool, error)
+	cleanupLeaderFactory func(context.Context, *sql.DB) (driver.CleanupLeadership, bool, error)
 
 	sttMutex              sync.RWMutex
 	supportedTokenFormats []token.Format
@@ -68,7 +68,7 @@ type TokenStore struct {
 	balanceStmts PreparedStmtHolder[string]
 }
 
-func newTokenStore(readDB, writeDB *sql.DB, tables tokenTables, ci common3.CondInterpreter, notifier driver.TokenNotifier, cleanupLeaderFactory func(context.Context, *sql.DB, int64) (driver.CleanupLeadership, bool, error)) *TokenStore {
+func newTokenStore(readDB, writeDB *sql.DB, tables tokenTables, ci common3.CondInterpreter, notifier driver.TokenNotifier, cleanupLeaderFactory func(context.Context, *sql.DB) (driver.CleanupLeadership, bool, error)) *TokenStore {
 	ts := &TokenStore{
 		readDB:               readDB,
 		writeDB:              writeDB,
@@ -100,7 +100,7 @@ func NewTokenStoreWithNotifierAndCleanup(
 	tables TableNames,
 	ci common3.CondInterpreter,
 	notifier driver.TokenNotifier,
-	cleanupLeaderFactory func(context.Context, *sql.DB, int64) (driver.CleanupLeadership, bool, error),
+	cleanupLeaderFactory func(context.Context, *sql.DB) (driver.CleanupLeadership, bool, error),
 ) (*TokenStore, error) {
 	return newTokenStore(readDB, writeDB, tokenTables{
 		Tokens:           tables.Tokens,
@@ -1359,12 +1359,12 @@ func (db *TokenStore) MarkTokenCleaned(ctx context.Context, txID string, index u
 // In distributed deployments (PostgreSQL), this uses advisory locks to ensure only one instance performs cleanup.
 // AcquireCleanupLeadership returns a leadership handle for cleanup sweeping.
 // When no leader factory is configured, leadership is granted locally.
-func (db *TokenStore) AcquireCleanupLeadership(ctx context.Context, lockID int64) (driver.CleanupLeadership, bool, error) {
+func (db *TokenStore) AcquireCleanupLeadership(ctx context.Context) (driver.CleanupLeadership, bool, error) {
 	if db.cleanupLeaderFactory == nil {
 		return noopCleanupLeadership{}, true, nil
 	}
 
-	return db.cleanupLeaderFactory(ctx, db.writeDB, lockID)
+	return db.cleanupLeaderFactory(ctx, db.writeDB)
 }
 
 // noopCleanupLeadership is a no-op implementation for non-distributed deployments

--- a/token/services/storage/db/sql/common/transactions.go
+++ b/token/services/storage/db/sql/common/transactions.go
@@ -53,7 +53,7 @@ type TransactionStore struct {
 	ci                    common3.CondInterpreter
 	pi                    common3.PagInterpreter
 	notifier              dbdriver.TransactionNotifier
-	recoveryLeaderFactory func(context.Context, *sql.DB, int64) (dbdriver.RecoveryLeadership, bool, error)
+	recoveryLeaderFactory func(context.Context, *sql.DB) (dbdriver.RecoveryLeadership, bool, error)
 
 	// getStatusStmt caches the single prepared statement for GetStatus.
 	// Unlike the token-store queries, this query has exactly one shape
@@ -74,7 +74,7 @@ func newTransactionStore(
 	ci common3.CondInterpreter,
 	pi common3.PagInterpreter,
 	notifier dbdriver.TransactionNotifier,
-	recoveryLeaderFactory func(context.Context, *sql.DB, int64) (dbdriver.RecoveryLeadership, bool, error),
+	recoveryLeaderFactory func(context.Context, *sql.DB) (dbdriver.RecoveryLeadership, bool, error),
 ) *TransactionStore {
 	ts := &TransactionStore{
 		readDB:                readDB,
@@ -131,7 +131,7 @@ func NewTransactionStoreWithNotifierAndRecovery(
 	ci common3.CondInterpreter,
 	pi common3.PagInterpreter,
 	notifier dbdriver.TransactionNotifier,
-	recoveryLeaderFactory func(context.Context, *sql.DB, int64) (dbdriver.RecoveryLeadership, bool, error),
+	recoveryLeaderFactory func(context.Context, *sql.DB) (dbdriver.RecoveryLeadership, bool, error),
 ) (*TransactionStore, error) {
 	return newTransactionStore(readDB, writeDB, tables.Prefix, tables.Params, transactionTables{
 		Movements:             tables.Movements,
@@ -381,12 +381,12 @@ func (db *TransactionStore) QueryTokenRequests(ctx context.Context, params dbdri
 
 // AcquireRecoveryLeadership returns a leadership handle for recovery sweeping.
 // When no leader factory is configured, leadership is granted locally.
-func (db *TransactionStore) AcquireRecoveryLeadership(ctx context.Context, lockID int64) (dbdriver.RecoveryLeadership, bool, error) {
+func (db *TransactionStore) AcquireRecoveryLeadership(ctx context.Context) (dbdriver.RecoveryLeadership, bool, error) {
 	if db.recoveryLeaderFactory == nil {
 		return noopRecoveryLeadership{}, true, nil
 	}
 
-	return db.recoveryLeaderFactory(ctx, db.writeDB, lockID)
+	return db.recoveryLeaderFactory(ctx, db.writeDB)
 }
 
 // ClaimPendingTransactions returns a claimed batch of Pending transactions.

--- a/token/services/storage/db/sql/postgres/advisorylock.go
+++ b/token/services/storage/db/sql/postgres/advisorylock.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	tokensdriver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	common5 "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/common"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 )
@@ -103,9 +104,19 @@ func (l *AdvisoryLock) Close() error {
 	return nil
 }
 
-// NewAdvisoryLockFactory returns a recovery leader factory function that uses PostgreSQL advisory locks.
-func NewAdvisoryLockFactory() func(context.Context, *sql.DB, int64) (tokensdriver.RecoveryLeadership, bool, error) {
-	return func(ctx context.Context, db *sql.DB, lockID int64) (tokensdriver.RecoveryLeadership, bool, error) {
+// recoveryLockID derives the advisory lock id guarding a TMS's recovery sweep from its fully
+// qualified requests table name, which already carries the network, channel and namespace. The
+// table prefix alone is not enough: TMSes normally share one persistence configuration and are
+// distinguished only by those params, so a prefix-derived id would collide across them.
+func recoveryLockID(tables common5.TableNames) int64 {
+	return createTableLockID(tables.Requests + "_recovery")
+}
+
+// NewAdvisoryLockFactoryForID returns a recovery leader factory bound to lockID. Binding the id
+// at construction keeps it out of the call path, so no caller has to know how a lock id is made
+// unique and none can accidentally pass one that is shared with another TMS.
+func NewAdvisoryLockFactoryForID(lockID int64) func(context.Context, *sql.DB) (tokensdriver.RecoveryLeadership, bool, error) {
+	return func(ctx context.Context, db *sql.DB) (tokensdriver.RecoveryLeadership, bool, error) {
 		lock, acquired, err := NewAdvisoryLock(ctx, db, lockID)
 		if err != nil || !acquired {
 			return nil, acquired, err
@@ -115,9 +126,23 @@ func NewAdvisoryLockFactory() func(context.Context, *sql.DB, int64) (tokensdrive
 	}
 }
 
-// NewCleanupLeaderFactory returns a cleanup leader factory function that uses PostgreSQL advisory locks.
-func NewCleanupLeaderFactory() func(context.Context, *sql.DB, int64) (tokensdriver.CleanupLeadership, bool, error) {
-	return func(ctx context.Context, db *sql.DB, lockID int64) (tokensdriver.CleanupLeadership, bool, error) {
+// tokenLockCleanupLockID derives the advisory lock id guarding a TMS's token lock cleanup sweep
+// from its fully qualified token locks table name. Same reasoning as recoveryLockID.
+func tokenLockCleanupLockID(tables common5.TableNames) int64 {
+	return createTableLockID(tables.TokenLocks + "_cleanup")
+}
+
+// keystoreCleanupLockID derives the advisory lock id guarding a TMS's keystore cleanup sweep from
+// its fully qualified token SKI cleanup table name, for the same reason as recoveryLockID: the
+// table prefix alone is shared by every TMS on one persistence configuration.
+func keystoreCleanupLockID(tables common5.TableNames) int64 {
+	return createTableLockID(tables.TokenSKICleanups + "_cleanup")
+}
+
+// NewCleanupLeaderFactoryForID returns a cleanup leader factory bound to lockID, so the id is
+// fixed when the store is built rather than supplied per call.
+func NewCleanupLeaderFactoryForID(lockID int64) func(context.Context, *sql.DB) (tokensdriver.CleanupLeadership, bool, error) {
+	return func(ctx context.Context, db *sql.DB) (tokensdriver.CleanupLeadership, bool, error) {
 		lock, acquired, err := NewAdvisoryLock(ctx, db, lockID)
 		if err != nil || !acquired {
 			return nil, acquired, err

--- a/token/services/storage/db/sql/postgres/advisorylock_test.go
+++ b/token/services/storage/db/sql/postgres/advisorylock_test.go
@@ -164,20 +164,19 @@ func TestAdvisoryLockFactory(t *testing.T) {
 	defer utils.IgnoreErrorFunc(db.Close)
 
 	ctx := context.Background()
-	lockID := int64(77777)
 
-	// Test factory function
-	factory := NewAdvisoryLockFactory()
+	// The factory binds its lock id at construction, so callers cannot pass one in.
+	factory := NewAdvisoryLockFactoryForID(int64(77777))
 	require.NotNil(t, factory)
 
 	// Use factory to create lock
-	lock, acquired, err := factory(ctx, db, lockID)
+	lock, acquired, err := factory(ctx, db)
 	require.NoError(t, err)
 	require.True(t, acquired)
 	require.NotNil(t, lock)
 
 	// Verify it's actually locked
-	lock2, acquired, err := factory(ctx, db, lockID)
+	lock2, acquired, err := factory(ctx, db)
 	require.NoError(t, err)
 	require.False(t, acquired)
 	require.Nil(t, lock2)
@@ -240,14 +239,13 @@ func TestRecoveryIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test advisory lock acquisition through the store
-	lockID := int64(0x74746b7265636f76) // Default recovery lock ID
-	leadership, acquired, err := store.AcquireRecoveryLeadership(ctx, lockID)
+	leadership, acquired, err := store.AcquireRecoveryLeadership(ctx)
 	require.NoError(t, err)
 	require.True(t, acquired, "Should acquire leadership")
 	require.NotNil(t, leadership)
 
 	// Try to acquire again (should fail)
-	leadership2, acquired, err := store.AcquireRecoveryLeadership(ctx, lockID)
+	leadership2, acquired, err := store.AcquireRecoveryLeadership(ctx)
 	require.NoError(t, err)
 	require.False(t, acquired, "Should not acquire leadership when already held")
 	require.Nil(t, leadership2)
@@ -257,7 +255,7 @@ func TestRecoveryIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should be able to acquire again
-	leadership3, acquired, err := store.AcquireRecoveryLeadership(ctx, lockID)
+	leadership3, acquired, err := store.AcquireRecoveryLeadership(ctx)
 	require.NoError(t, err)
 	require.True(t, acquired, "Should acquire leadership after release")
 	require.NotNil(t, leadership3)

--- a/token/services/storage/db/sql/postgres/recovery_lockid_test.go
+++ b/token/services/storage/db/sql/postgres/recovery_lockid_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"testing"
+
+	sqlcommon "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/common"
+	"github.com/stretchr/testify/require"
+)
+
+// tmsTables builds the table names the way db/manager.go does for a TMS: one shared table
+// prefix from the persistence configuration, plus network, channel and namespace as params.
+func tmsTables(t *testing.T, prefix, network, channel, namespace string) sqlcommon.TableNames {
+	t.Helper()
+	tables, err := sqlcommon.GetTableNames(prefix, network, channel, namespace)
+	require.NoError(t, err)
+
+	return tables
+}
+
+// Two TMSes normally share one persistence configuration and differ only by the network,
+// channel and namespace params, so the recovery lock id has to be derived from something that
+// carries them. Deriving from the table prefix alone would give both the same id, and every
+// TMS but one would skip its recovery sweep for as long as another held the lock.
+func TestRecoveryLockID_DistinctPerTMSOnSharedPrefix(t *testing.T) {
+	a := tmsTables(t, "tsdk", "netA", "chA", "nsA")
+	b := tmsTables(t, "tsdk", "netB", "chB", "nsB")
+
+	require.Equal(t, a.Prefix, b.Prefix, "the two TMSes share a persistence configuration")
+	require.NotEqual(t, a.Requests, b.Requests, "but they own different requests tables")
+
+	require.NotEqual(t, recoveryLockID(a), recoveryLockID(b),
+		"distinct TMSes must derive distinct recovery lock ids, or all but one would skip its sweep")
+}
+
+// A different persistence configuration must also stay distinct.
+func TestRecoveryLockID_DistinctPerPrefix(t *testing.T) {
+	a := tmsTables(t, "tsdk_one", "net", "ch", "ns")
+	b := tmsTables(t, "tsdk_two", "net", "ch", "ns")
+
+	require.NotEqual(t, recoveryLockID(a), recoveryLockID(b))
+}
+
+// The recovery lock must not collide with the schema-creation lock of the same store, otherwise
+// a sweep in progress would block schema creation and vice versa.
+func TestRecoveryLockID_DistinctFromSchemaLock(t *testing.T) {
+	tables := tmsTables(t, "tsdk", "net", "ch", "ns")
+
+	require.NotEqual(t, recoveryLockID(tables), createTableLockID("transactions"),
+		"recovery lock must differ from the transactions schema-creation lock")
+}
+
+// The derivation must be stable across calls, since every replica has to compute the same id
+// for leader election to mean anything.
+func TestRecoveryLockID_StableAcrossCalls(t *testing.T) {
+	a := tmsTables(t, "tsdk", "net", "ch", "ns")
+	b := tmsTables(t, "tsdk", "net", "ch", "ns")
+
+	require.Equal(t, recoveryLockID(a), recoveryLockID(b))
+}

--- a/token/services/storage/db/sql/postgres/tokenlock.go
+++ b/token/services/storage/db/sql/postgres/tokenlock.go
@@ -34,15 +34,14 @@ type TokenLockStore struct {
 	ci      common3.CondInterpreter
 	lockID  int64
 
-	// cleanupLockID is derived from the fully-qualified table name (not the
-	// prefix alone, which is not unique per TMS - see review discussion on
+	// cleanupLeaderFactory is bound at construction to an id derived from the fully-qualified
+	// table name (not the prefix alone, which is not unique per TMS - see review discussion on
 	// #1982), so it is unique per TMS - distinct from lockID (schema-creation
 	// lock) and from other TMSes' cleanup locks on the same node. A single global constant here
 	// was a real bug: it caused every TMS on a node to compete for the
 	// exact same advisory lock, so only one TMS across the whole fleet
 	// ever won cleanup on any tick. See #1798.
-	cleanupLockID        int64
-	cleanupLeaderFactory func(context.Context, *sql.DB, int64) (driver.CleanupLeadership, bool, error)
+	cleanupLeaderFactory func(context.Context, *sql.DB) (driver.CleanupLeadership, bool, error)
 }
 
 // GetSchema overrides the base GetSchema to prefix with advisory lock
@@ -70,8 +69,7 @@ func NewTokenLockStore(dbs *common2.RWDB, tableNames common5.TableNames) (*Token
 		writeDB:              dbs.WriteDB,
 		ci:                   ci,
 		lockID:               createTableLockID(tableNames.TokenLocks),
-		cleanupLockID:        createTableLockID(tableNames.TokenLocks + "_cleanup"),
-		cleanupLeaderFactory: NewCleanupLeaderFactory(),
+		cleanupLeaderFactory: NewCleanupLeaderFactoryForID(tokenLockCleanupLockID(tableNames)),
 	}, nil
 }
 
@@ -80,10 +78,16 @@ func NewTokenLockStore(dbs *common2.RWDB, tableNames common5.TableNames) (*Token
 // and release no held resources, so contention is limited to the acquire
 // attempt itself. The lock id and factory are fixed at construction. Note
 // the winner holds a dedicated connection off writeDB for the tick's
-// duration (see NewAdvisoryLock), so writeDB's connection pool needs at
-// least one spare connection beyond normal write traffic. See #1798.
+// duration (see NewAdvisoryLock). This lock, the recovery lock and the
+// keystore-cleanup lock are all now derived per TMS rather than shared
+// node-wide, and FSC keys connection pools by data source alone, so TMSes
+// sharing one database share one *sql.DB. A node running N such TMSes can
+// therefore have up to 3N connections pinned by lock holders at once, before
+// counting the further connections winners need for their own work (e.g.
+// recovery's ClaimPendingTransactions). Size writeDB's maxOpenConns against
+// that floor, not a single spare connection. See #1798.
 func (db *TokenLockStore) AcquireCleanupLeadership(ctx context.Context) (driver.CleanupLeadership, bool, error) {
-	return db.cleanupLeaderFactory(ctx, db.writeDB, db.cleanupLockID)
+	return db.cleanupLeaderFactory(ctx, db.writeDB)
 }
 
 // Cleanup removes stale token locks that have expired. The deletion itself is the

--- a/token/services/storage/db/sql/postgres/tokenlock_leadership_test.go
+++ b/token/services/storage/db/sql/postgres/tokenlock_leadership_test.go
@@ -59,8 +59,9 @@ func TestTokenLockStore_AcquireCleanupLeadership_ConcurrentReplicas(t *testing.T
 	require.NoError(t, err)
 	require.NoError(t, replicaA.CreateSchema())
 
-	require.Equal(t, replicaA.cleanupLockID, replicaB.cleanupLockID,
-		"replicas for the same TMS must derive the same cleanup lock id")
+	// The cleanup lock id is bound into the leader factory at construction and is no longer a
+	// field, so the assertion that both replicas share it is the concurrent acquire below:
+	// exactly one of them can win only if they are contending over the same lock.
 
 	var wg sync.WaitGroup
 	results := make([]bool, 2)
@@ -141,14 +142,14 @@ func TestTokenLockStore_AcquireCleanupLeadership_DistinctTMS(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, tmsB.CreateSchema())
 
-	require.NotEqual(t, tmsA.cleanupLockID, tmsB.cleanupLockID,
+	require.NotEqual(t, tokenLockCleanupLockID(tablesA), tokenLockCleanupLockID(tablesB),
 		"distinct TMSes must derive distinct cleanup lock ids, or one TMS's cleanup would starve the other's")
 	require.NotEqual(t, tmsA.lockID, tmsB.lockID,
 		"distinct TMSes must derive distinct schema-creation lock ids too - a regression back to a "+
-			"prefix-only or global constant would pass the cleanupLockID check above but not this one")
-	require.NotEqual(t, tmsA.lockID, tmsA.cleanupLockID,
+			"prefix-only or global constant would pass the cleanup lock id check above but not this one")
+	require.NotEqual(t, tmsA.lockID, tokenLockCleanupLockID(tablesA),
 		"schema-creation and cleanup locks on the same store must be distinct")
-	require.NotEqual(t, tmsB.lockID, tmsB.cleanupLockID,
+	require.NotEqual(t, tmsB.lockID, tokenLockCleanupLockID(tablesB),
 		"schema-creation and cleanup locks on the same store must be distinct")
 
 	// both should acquire leadership independently and concurrently, since

--- a/token/services/storage/db/sql/postgres/tokens.go
+++ b/token/services/storage/db/sql/postgres/tokens.go
@@ -73,7 +73,7 @@ func (n *TokenNotifier) Subscribe(callback func(tokensdriver.Operation, tokensdr
 
 func NewTokenStoreWithNotifier(dbs *scommon.RWDB, tableNames sqlcommon.TableNames, notifier *TokenNotifier) (*TokenStore, error) {
 	// Create cleanup leader factory using PostgreSQL advisory locks
-	cleanupLeaderFactory := NewCleanupLeaderFactory()
+	cleanupLeaderFactory := NewCleanupLeaderFactoryForID(keystoreCleanupLockID(tableNames))
 
 	baseStore, err := sqlcommon.NewTokenStoreWithNotifierAndCleanup(
 		dbs.ReadDB,

--- a/token/services/storage/db/sql/postgres/transactions.go
+++ b/token/services/storage/db/sql/postgres/transactions.go
@@ -69,8 +69,12 @@ func (s *TransactionStore) CreateSchema() error {
 
 // NewTransactionStoreWithNotifier creates a new TransactionStore with the provided notifier and recovery support.
 func NewTransactionStoreWithNotifier(dbs *scommon.RWDB, tableNames sqlcommon.TableNames, notifier *TransactionNotifier) (*TransactionStore, error) {
-	// Create recovery leader factory using PostgreSQL advisory locks
-	recoveryLeaderFactory := NewAdvisoryLockFactory()
+	// Derive the recovery lock id from the fully qualified requests table name, which already
+	// carries the network, channel and namespace that tell one TMS from another. Deriving it from
+	// the table prefix would not be enough: several TMSes normally share one persistence
+	// configuration and are distinguished only by those params, so they would all land on the same
+	// id and every TMS but one would skip its sweep. See #1798 for the same bug on the token locks.
+	recoveryLeaderFactory := NewAdvisoryLockFactoryForID(recoveryLockID(tableNames))
 
 	commonStore, err := sqlcommon.NewTransactionStoreWithNotifierAndRecovery(
 		dbs.ReadDB,

--- a/token/services/storage/db/sql/postgres/transactions_bench_test.go
+++ b/token/services/storage/db/sql/postgres/transactions_bench_test.go
@@ -36,7 +36,7 @@ func openBenchTransactionStore(b *testing.B) (*sqlcommon.TransactionStore, func(
 	}
 
 	store, err := sqlcommon.NewTransactionStoreWithNotifierAndRecovery(
-		db, db, tables, NewConditionInterpreter(), NewPaginationInterpreter(), nil, NewAdvisoryLockFactory(),
+		db, db, tables, NewConditionInterpreter(), NewPaginationInterpreter(), nil, NewAdvisoryLockFactoryForID(createTableLockID(tables.Requests+"_recovery")),
 	)
 	if err != nil {
 		b.Fatal(err)

--- a/token/services/storage/services/cleanup/config.go
+++ b/token/services/storage/services/cleanup/config.go
@@ -29,25 +29,18 @@ type Config struct {
 	BatchSize int
 	// WorkerCount is the number of local workers processing tokens
 	WorkerCount int
-	// AdvisoryLockID is the PostgreSQL advisory lock ID used for leader election
-	AdvisoryLockID int64
 	// InstanceID identifies the current replica as the cleanup owner
 	InstanceID string
 }
 
-const (
-	defaultLockID int64 = 0x74746b636c65616e // "ttkclean" in hex
-)
-
 // DefaultConfig returns the default cleanup configuration
 func DefaultConfig() Config {
 	return Config{
-		Enabled:        false,          // Disabled by default - must be explicitly enabled
-		TTL:            24 * time.Hour, // Wait 24 hours before cleaning up keys
-		ScanInterval:   1 * time.Hour,  // Scan every hour
-		BatchSize:      100,
-		WorkerCount:    1,
-		AdvisoryLockID: defaultLockID,
+		Enabled:      false,          // Disabled by default - must be explicitly enabled
+		TTL:          24 * time.Hour, // Wait 24 hours before cleaning up keys
+		ScanInterval: 1 * time.Hour,  // Scan every hour
+		BatchSize:    100,
+		WorkerCount:  1,
 	}
 }
 
@@ -81,11 +74,17 @@ func LoadConfig(cfg *config.Configuration) (Config, error) {
 	if config.WorkerCount > 0 {
 		result.WorkerCount = config.WorkerCount
 	}
-	if config.AdvisoryLockID != 0 {
-		result.AdvisoryLockID = config.AdvisoryLockID
-	}
 	if config.InstanceID != "" {
 		result.InstanceID = config.InstanceID
+	}
+	// advisoryLockID used to let an operator keep multiple independent cleanup
+	// managers on the same database from colliding. The lock id is now derived
+	// per TMS automatically, so the key is silently ignored rather than failing
+	// the load - warn so an operator who relied on it to isolate managers
+	// notices the setting stopped doing anything, instead of finding out only
+	// when leases start colliding.
+	if cfg.IsSet(ConfigKeyCleanup + ".advisoryLockID") {
+		logger.Warnf("%s.advisoryLockID is no longer used; the cleanup lock id is now derived per TMS", ConfigKeyCleanup)
 	}
 
 	return result, nil

--- a/token/services/storage/services/cleanup/config_test.go
+++ b/token/services/storage/services/cleanup/config_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cleanup_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/config"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/services/cleanup"
+	fscconfig "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An operator upgrading from a release that still had services.storage.cleanup.advisoryLockID
+// keeps that key in their config. The lock id is now derived per TMS and the field is gone, so the
+// key must simply be ignored rather than failing the load.
+func TestLoadConfig_IgnoresStaleAdvisoryLockID(t *testing.T) {
+	cp, err := fscconfig.NewProvider("./testdata/stalecfg")
+	require.NoError(t, err)
+
+	cfg := config.NewConfiguration(cp, "n1c1ns1", driver.TMSID{Network: "n1", Channel: "c1", Namespace: "ns1"})
+
+	loaded, err := cleanup.LoadConfig(cfg)
+	require.NoError(t, err, "a stale advisoryLockID key must not fail the load")
+
+	assert.True(t, loaded.Enabled)
+	assert.Equal(t, 45*time.Second, loaded.TTL, "the rest of the block must still be applied")
+}

--- a/token/services/storage/services/cleanup/manager.go
+++ b/token/services/storage/services/cleanup/manager.go
@@ -31,7 +31,7 @@ type DeletedToken struct {
 // Storage defines the interface for querying deleted tokens
 type Storage interface {
 	// AcquireCleanupLeadership acquires an advisory lock for cleanup leadership
-	AcquireCleanupLeadership(ctx context.Context, lockID int64) (Leadership, bool, error)
+	AcquireCleanupLeadership(ctx context.Context) (Leadership, bool, error)
 	// GetDeletedTokensPendingSKICleanup returns deleted tokens older than the specified duration that haven't had their SKI keys cleaned.
 	// Only tokens owned by this node are returned, since this node only holds the secret keys for tokens it owns.
 	GetDeletedTokensPendingSKICleanup(ctx context.Context, olderThan time.Duration, limit int) ([]DeletedToken, error)
@@ -140,8 +140,8 @@ func (m *Manager) Start() error {
 	m.wg.Add(1)
 	go m.cleanupLoop()
 
-	m.logger.Infof("keystore cleanup manager started (TTL: %s, Scan Interval: %s, Batch Size: %d, Workers: %d, Lock ID: %d, Instance ID: %s)",
-		m.config.TTL, m.config.ScanInterval, m.config.BatchSize, m.config.WorkerCount, m.config.AdvisoryLockID, m.config.InstanceID)
+	m.logger.Infof("keystore cleanup manager started (TTL: %s, Scan Interval: %s, Batch Size: %d, Workers: %d, Instance ID: %s)",
+		m.config.TTL, m.config.ScanInterval, m.config.BatchSize, m.config.WorkerCount, m.config.InstanceID)
 
 	return nil
 }
@@ -206,7 +206,7 @@ func (m *Manager) validateConfig() error {
 }
 
 func (m *Manager) runSweep(ctx context.Context) error {
-	leadership, acquired, err := m.storage.AcquireCleanupLeadership(ctx, m.config.AdvisoryLockID)
+	leadership, acquired, err := m.storage.AcquireCleanupLeadership(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "failed to acquire cleanup leadership")
 	}

--- a/token/services/storage/services/cleanup/mock/storage.go
+++ b/token/services/storage/services/cleanup/mock/storage.go
@@ -10,11 +10,10 @@ import (
 )
 
 type Storage struct {
-	AcquireCleanupLeadershipStub        func(context.Context, int64) (cleanup.Leadership, bool, error)
+	AcquireCleanupLeadershipStub        func(context.Context) (cleanup.Leadership, bool, error)
 	acquireCleanupLeadershipMutex       sync.RWMutex
 	acquireCleanupLeadershipArgsForCall []struct {
 		arg1 context.Context
-		arg2 int64
 	}
 	acquireCleanupLeadershipReturns struct {
 		result1 cleanup.Leadership
@@ -59,19 +58,18 @@ type Storage struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Storage) AcquireCleanupLeadership(arg1 context.Context, arg2 int64) (cleanup.Leadership, bool, error) {
+func (fake *Storage) AcquireCleanupLeadership(arg1 context.Context) (cleanup.Leadership, bool, error) {
 	fake.acquireCleanupLeadershipMutex.Lock()
 	ret, specificReturn := fake.acquireCleanupLeadershipReturnsOnCall[len(fake.acquireCleanupLeadershipArgsForCall)]
 	fake.acquireCleanupLeadershipArgsForCall = append(fake.acquireCleanupLeadershipArgsForCall, struct {
 		arg1 context.Context
-		arg2 int64
-	}{arg1, arg2})
+	}{arg1})
 	stub := fake.AcquireCleanupLeadershipStub
 	fakeReturns := fake.acquireCleanupLeadershipReturns
-	fake.recordInvocation("AcquireCleanupLeadership", []interface{}{arg1, arg2})
+	fake.recordInvocation("AcquireCleanupLeadership", []interface{}{arg1})
 	fake.acquireCleanupLeadershipMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -85,17 +83,17 @@ func (fake *Storage) AcquireCleanupLeadershipCallCount() int {
 	return len(fake.acquireCleanupLeadershipArgsForCall)
 }
 
-func (fake *Storage) AcquireCleanupLeadershipCalls(stub func(context.Context, int64) (cleanup.Leadership, bool, error)) {
+func (fake *Storage) AcquireCleanupLeadershipCalls(stub func(context.Context) (cleanup.Leadership, bool, error)) {
 	fake.acquireCleanupLeadershipMutex.Lock()
 	defer fake.acquireCleanupLeadershipMutex.Unlock()
 	fake.AcquireCleanupLeadershipStub = stub
 }
 
-func (fake *Storage) AcquireCleanupLeadershipArgsForCall(i int) (context.Context, int64) {
+func (fake *Storage) AcquireCleanupLeadershipArgsForCall(i int) context.Context {
 	fake.acquireCleanupLeadershipMutex.RLock()
 	defer fake.acquireCleanupLeadershipMutex.RUnlock()
 	argsForCall := fake.acquireCleanupLeadershipArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1
 }
 
 func (fake *Storage) AcquireCleanupLeadershipReturns(result1 cleanup.Leadership, result2 bool, result3 error) {

--- a/token/services/storage/services/cleanup/service.go
+++ b/token/services/storage/services/cleanup/service.go
@@ -112,7 +112,7 @@ func (p *tmsKeystoreProvider) Keystore(tmsID token.TMSID) (Keystore, error) {
 }
 
 type cleanupStorage interface {
-	AcquireCleanupLeadership(ctx context.Context, lockID int64) (dbdriver.CleanupLeadership, bool, error)
+	AcquireCleanupLeadership(ctx context.Context) (dbdriver.CleanupLeadership, bool, error)
 	GetDeletedTokensPendingSKICleanup(ctx context.Context, olderThan time.Duration, limit int) ([]dbdriver.DeletedToken, error)
 	MarkTokenCleaned(ctx context.Context, txID string, index uint64, cleanedBy string) error
 }
@@ -122,8 +122,8 @@ type cleanupStorageAdapter struct {
 	storage cleanupStorage
 }
 
-func (a *cleanupStorageAdapter) AcquireCleanupLeadership(ctx context.Context, lockID int64) (Leadership, bool, error) {
-	leadership, acquired, err := a.storage.AcquireCleanupLeadership(ctx, lockID)
+func (a *cleanupStorageAdapter) AcquireCleanupLeadership(ctx context.Context) (Leadership, bool, error) {
+	leadership, acquired, err := a.storage.AcquireCleanupLeadership(ctx)
 	if err != nil || !acquired {
 		return nil, acquired, err
 	}

--- a/token/services/storage/services/cleanup/testdata/stalecfg/core.yaml
+++ b/token/services/storage/services/cleanup/testdata/stalecfg/core.yaml
@@ -1,0 +1,16 @@
+token:
+  enabled: true
+  tms:
+    n1c1ns1:
+      network: n1
+      channel: c1
+      namespace: ns1
+      services:
+        storage:
+          cleanup:
+            enabled: true
+            ttl: 45s
+            # advisoryLockID was removed when the lock id became per-TMS. An operator
+            # upgrading from an older release still has it in their config, so loading
+            # must ignore it rather than fail.
+            advisoryLockID: 8389190333894887286

--- a/token/services/storage/services/recovery/config.go
+++ b/token/services/storage/services/recovery/config.go
@@ -10,12 +10,15 @@ import (
 	"time"
 
 	"github.com/LFDT-Panurus/panurus/token/services/config"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
 )
 
 const (
 	// ConfigKeyRecovery is the configuration key for recovery settings
 	ConfigKeyRecovery = "services.network.fabric.recovery"
 )
+
+var logger = logging.MustGetLogger()
 
 // Config holds the configuration for the recovery manager
 type Config struct {
@@ -31,8 +34,6 @@ type Config struct {
 	WorkerCount int
 	// LeaseDuration is the duration of the recovery claim lease.
 	LeaseDuration time.Duration
-	// AdvisoryLockID is the PostgreSQL advisory lock ID used for leader election.
-	AdvisoryLockID int64
 	// InstanceID identifies the current replica as the lease owner.
 	InstanceID string
 	// NotFoundGracePeriod: when GetTransactionStatus returns a NotFound error and
@@ -52,7 +53,6 @@ func DefaultConfig() Config {
 		BatchSize:           defaultBatchSize,
 		WorkerCount:         defaultWorkers,
 		LeaseDuration:       defaultLeaseDuration,
-		AdvisoryLockID:      defaultLockID,
 		NotFoundGracePeriod: 30 * time.Minute,
 	}
 }
@@ -90,9 +90,6 @@ func LoadConfig(cfg *config.Configuration) (Config, error) {
 	if config.LeaseDuration > 0 {
 		result.LeaseDuration = config.LeaseDuration
 	}
-	if config.AdvisoryLockID != 0 {
-		result.AdvisoryLockID = config.AdvisoryLockID
-	}
 	if config.InstanceID != "" {
 		result.InstanceID = config.InstanceID
 	}
@@ -102,6 +99,15 @@ func LoadConfig(cfg *config.Configuration) (Config, error) {
 	// to the 30 min default and the documented opt-out would be unreachable.
 	if cfg.IsSet(ConfigKeyRecovery + ".notFoundGracePeriod") {
 		result.NotFoundGracePeriod = config.NotFoundGracePeriod
+	}
+	// advisoryLockID used to let an operator keep multiple independent recovery
+	// managers on the same database from colliding. The lock id is now derived
+	// per TMS automatically, so the key is silently ignored rather than failing
+	// the load - warn so an operator who relied on it to isolate managers
+	// notices the setting stopped doing anything, instead of finding out only
+	// when leases start colliding.
+	if cfg.IsSet(ConfigKeyRecovery + ".advisoryLockID") {
+		logger.Warnf("%s.advisoryLockID is no longer used; the recovery lock id is now derived per TMS", ConfigKeyRecovery)
 	}
 
 	return result, nil

--- a/token/services/storage/services/recovery/config_test.go
+++ b/token/services/storage/services/recovery/config_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package recovery_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/config"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/services/recovery"
+	fscconfig "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An operator upgrading from a release that still had services.network.fabric.recovery.advisoryLockID
+// keeps that key in their config. The lock id is now derived per TMS and the field is gone, so the
+// key must simply be ignored rather than failing the load.
+func TestLoadConfig_IgnoresStaleAdvisoryLockID(t *testing.T) {
+	cp, err := fscconfig.NewProvider("./testdata/stalecfg")
+	require.NoError(t, err)
+
+	cfg := config.NewConfiguration(cp, "n1c1ns1", driver.TMSID{Network: "n1", Channel: "c1", Namespace: "ns1"})
+
+	loaded, err := recovery.LoadConfig(cfg)
+	require.NoError(t, err, "a stale advisoryLockID key must not fail the load")
+
+	assert.True(t, loaded.Enabled)
+	assert.Equal(t, 45*time.Second, loaded.TTL, "the rest of the block must still be applied")
+}

--- a/token/services/storage/services/recovery/manager.go
+++ b/token/services/storage/services/recovery/manager.go
@@ -22,17 +22,16 @@ import (
 )
 
 const (
-	defaultLockID        int64 = 0x74746b7265636f76
-	defaultBatchSize           = 100
-	defaultWorkers             = 4
-	defaultLeaseDuration       = 30 * time.Second
+	defaultBatchSize     = 100
+	defaultWorkers       = 4
+	defaultLeaseDuration = 30 * time.Second
 )
 
 //go:generate counterfeiter -o mock/storage.go -fake-name Storage . Storage
 
 // Storage defines the interface for querying pending transactions and transaction details
 type Storage interface {
-	AcquireRecoveryLeadership(ctx context.Context, lockID int64) (Leadership, bool, error)
+	AcquireRecoveryLeadership(ctx context.Context) (Leadership, bool, error)
 	ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*ttxdb.RecoveryClaim, error)
 	ReleaseRecoveryClaim(ctx context.Context, txID string, owner string, message string) error
 	// SetStatus updates a transaction's status row. Used by the recovery loop to
@@ -117,8 +116,8 @@ func (m *Manager) Start() error {
 	m.wg.Add(1)
 	go m.recoveryLoop()
 
-	m.logger.Infof("transaction recovery manager started (TTL: %s, Scan Interval: %s, Batch Size: %d, Workers: %d, Lease Duration: %s, Lock ID: %d, Instance ID: %s)",
-		m.config.TTL, m.config.ScanInterval, m.config.BatchSize, m.config.WorkerCount, m.config.LeaseDuration, m.config.AdvisoryLockID, m.config.InstanceID)
+	m.logger.Infof("transaction recovery manager started (TTL: %s, Scan Interval: %s, Batch Size: %d, Workers: %d, Lease Duration: %s, Instance ID: %s)",
+		m.config.TTL, m.config.ScanInterval, m.config.BatchSize, m.config.WorkerCount, m.config.LeaseDuration, m.config.InstanceID)
 
 	return nil
 }
@@ -214,7 +213,7 @@ func (m *Manager) validateConfig() error {
 }
 
 func (m *Manager) runSweep(ctx context.Context) error {
-	leadership, acquired, err := m.storage.AcquireRecoveryLeadership(ctx, m.config.AdvisoryLockID)
+	leadership, acquired, err := m.storage.AcquireRecoveryLeadership(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "failed to acquire recovery leadership")
 	}

--- a/token/services/storage/services/recovery/manager_test.go
+++ b/token/services/storage/services/recovery/manager_test.go
@@ -28,14 +28,13 @@ func TestNewManager(t *testing.T) {
 	mockDB := &mock2.Storage{}
 	mockHandler := &mock2.Handler{}
 	config := recovery2.Config{
-		Enabled:        true,
-		TTL:            30 * time.Second,
-		ScanInterval:   30 * time.Second,
-		BatchSize:      100,
-		WorkerCount:    1,
-		LeaseDuration:  30 * time.Second,
-		AdvisoryLockID: 1,
-		InstanceID:     "test-instance",
+		Enabled:       true,
+		TTL:           30 * time.Second,
+		ScanInterval:  30 * time.Second,
+		BatchSize:     100,
+		WorkerCount:   1,
+		LeaseDuration: 30 * time.Second,
+		InstanceID:    "test-instance",
 	}
 
 	manager := recovery2.NewManager(
@@ -53,14 +52,13 @@ func TestManager_StartStop(t *testing.T) {
 	mockDB := &mock2.Storage{}
 	mockHandler := &mock2.Handler{}
 	config := recovery2.Config{
-		Enabled:        true,
-		TTL:            100 * time.Millisecond,
-		ScanInterval:   100 * time.Millisecond,
-		BatchSize:      100,
-		WorkerCount:    1,
-		LeaseDuration:  time.Second,
-		AdvisoryLockID: 1,
-		InstanceID:     "test-instance",
+		Enabled:       true,
+		TTL:           100 * time.Millisecond,
+		ScanInterval:  100 * time.Millisecond,
+		BatchSize:     100,
+		WorkerCount:   1,
+		LeaseDuration: time.Second,
+		InstanceID:    "test-instance",
 	}
 
 	leadership := &mock2.Leadership{}
@@ -99,14 +97,13 @@ func TestManager_RecoverTransaction(t *testing.T) {
 	mockDB := &mock2.Storage{}
 	mockHandler := &mock2.Handler{}
 	config := recovery2.Config{
-		Enabled:        true,
-		TTL:            100 * time.Millisecond,
-		ScanInterval:   100 * time.Millisecond,
-		BatchSize:      100,
-		WorkerCount:    1,
-		LeaseDuration:  time.Second,
-		AdvisoryLockID: 1,
-		InstanceID:     "test-instance",
+		Enabled:       true,
+		TTL:           100 * time.Millisecond,
+		ScanInterval:  100 * time.Millisecond,
+		BatchSize:     100,
+		WorkerCount:   1,
+		LeaseDuration: time.Second,
+		InstanceID:    "test-instance",
 	}
 
 	// Create a pending transaction claim
@@ -155,14 +152,13 @@ func TestManager_SkipAlreadyRecovered(t *testing.T) {
 	mockDB := &mock2.Storage{}
 	mockHandler := &mock2.Handler{}
 	config := recovery2.Config{
-		Enabled:        true,
-		TTL:            50 * time.Millisecond,
-		ScanInterval:   50 * time.Millisecond,
-		BatchSize:      100,
-		WorkerCount:    1,
-		LeaseDuration:  time.Second,
-		AdvisoryLockID: 1,
-		InstanceID:     "test-instance",
+		Enabled:       true,
+		TTL:           50 * time.Millisecond,
+		ScanInterval:  50 * time.Millisecond,
+		BatchSize:     100,
+		WorkerCount:   1,
+		LeaseDuration: time.Second,
+		InstanceID:    "test-instance",
 	}
 
 	// Create a pending transaction claim
@@ -222,7 +218,6 @@ func TestManager_PromoteOrphanOnNotFoundPastGracePeriod(t *testing.T) {
 		BatchSize:           100,
 		WorkerCount:         1,
 		LeaseDuration:       time.Second,
-		AdvisoryLockID:      1,
 		InstanceID:          "test-instance",
 		NotFoundGracePeriod: 10 * time.Millisecond,
 	}
@@ -278,7 +273,6 @@ func TestManager_NoPromotionWhenGracePeriodDisabled(t *testing.T) {
 		BatchSize:           100,
 		WorkerCount:         1,
 		LeaseDuration:       time.Second,
-		AdvisoryLockID:      1,
 		InstanceID:          "test-instance",
 		NotFoundGracePeriod: 0,
 	}
@@ -334,14 +328,13 @@ func TestManager_StopDuringFanOutDoesNotDeadlock(t *testing.T) {
 	mockDB := &mock2.Storage{}
 	mockHandler := &mock2.Handler{}
 	config := recovery2.Config{
-		Enabled:        true,
-		TTL:            10 * time.Millisecond,
-		ScanInterval:   10 * time.Millisecond,
-		BatchSize:      100,
-		WorkerCount:    1,
-		LeaseDuration:  time.Second,
-		AdvisoryLockID: 1,
-		InstanceID:     "test-instance",
+		Enabled:       true,
+		TTL:           10 * time.Millisecond,
+		ScanInterval:  10 * time.Millisecond,
+		BatchSize:     100,
+		WorkerCount:   1,
+		LeaseDuration: time.Second,
+		InstanceID:    "test-instance",
 	}
 
 	// Step 1: many more claims than workers, so the fan-out loop is guaranteed to
@@ -424,7 +417,6 @@ func TestManager_PromoteOrphanOnNoSuchTransactionID(t *testing.T) {
 		BatchSize:           100,
 		WorkerCount:         1,
 		LeaseDuration:       time.Second,
-		AdvisoryLockID:      1,
 		InstanceID:          "test-instance",
 		NotFoundGracePeriod: 10 * time.Millisecond,
 	}

--- a/token/services/storage/services/recovery/mock/storage.go
+++ b/token/services/storage/services/recovery/mock/storage.go
@@ -12,11 +12,10 @@ import (
 )
 
 type Storage struct {
-	AcquireRecoveryLeadershipStub        func(context.Context, int64) (recovery.Leadership, bool, error)
+	AcquireRecoveryLeadershipStub        func(context.Context) (recovery.Leadership, bool, error)
 	acquireRecoveryLeadershipMutex       sync.RWMutex
 	acquireRecoveryLeadershipArgsForCall []struct {
 		arg1 context.Context
-		arg2 int64
 	}
 	acquireRecoveryLeadershipReturns struct {
 		result1 recovery.Leadership
@@ -77,19 +76,18 @@ type Storage struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Storage) AcquireRecoveryLeadership(arg1 context.Context, arg2 int64) (recovery.Leadership, bool, error) {
+func (fake *Storage) AcquireRecoveryLeadership(arg1 context.Context) (recovery.Leadership, bool, error) {
 	fake.acquireRecoveryLeadershipMutex.Lock()
 	ret, specificReturn := fake.acquireRecoveryLeadershipReturnsOnCall[len(fake.acquireRecoveryLeadershipArgsForCall)]
 	fake.acquireRecoveryLeadershipArgsForCall = append(fake.acquireRecoveryLeadershipArgsForCall, struct {
 		arg1 context.Context
-		arg2 int64
-	}{arg1, arg2})
+	}{arg1})
 	stub := fake.AcquireRecoveryLeadershipStub
 	fakeReturns := fake.acquireRecoveryLeadershipReturns
-	fake.recordInvocation("AcquireRecoveryLeadership", []interface{}{arg1, arg2})
+	fake.recordInvocation("AcquireRecoveryLeadership", []interface{}{arg1})
 	fake.acquireRecoveryLeadershipMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -103,17 +101,17 @@ func (fake *Storage) AcquireRecoveryLeadershipCallCount() int {
 	return len(fake.acquireRecoveryLeadershipArgsForCall)
 }
 
-func (fake *Storage) AcquireRecoveryLeadershipCalls(stub func(context.Context, int64) (recovery.Leadership, bool, error)) {
+func (fake *Storage) AcquireRecoveryLeadershipCalls(stub func(context.Context) (recovery.Leadership, bool, error)) {
 	fake.acquireRecoveryLeadershipMutex.Lock()
 	defer fake.acquireRecoveryLeadershipMutex.Unlock()
 	fake.AcquireRecoveryLeadershipStub = stub
 }
 
-func (fake *Storage) AcquireRecoveryLeadershipArgsForCall(i int) (context.Context, int64) {
+func (fake *Storage) AcquireRecoveryLeadershipArgsForCall(i int) context.Context {
 	fake.acquireRecoveryLeadershipMutex.RLock()
 	defer fake.acquireRecoveryLeadershipMutex.RUnlock()
 	argsForCall := fake.acquireRecoveryLeadershipArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1
 }
 
 func (fake *Storage) AcquireRecoveryLeadershipReturns(result1 recovery.Leadership, result2 bool, result3 error) {

--- a/token/services/storage/services/recovery/testdata/stalecfg/core.yaml
+++ b/token/services/storage/services/recovery/testdata/stalecfg/core.yaml
@@ -1,0 +1,17 @@
+token:
+  enabled: true
+  tms:
+    n1c1ns1:
+      network: n1
+      channel: c1
+      namespace: ns1
+      services:
+        network:
+          fabric:
+            recovery:
+              enabled: true
+              ttl: 45s
+              # advisoryLockID was removed when the lock id became per-TMS. An operator
+              # upgrading from an older release still has it in their config, so loading
+              # must ignore it rather than fail.
+              advisoryLockID: 8389190333894887286

--- a/token/services/storage/ttxdb/store.go
+++ b/token/services/storage/ttxdb/store.go
@@ -306,8 +306,8 @@ func (d *StoreService) GetTransactionEndorsementAcks(ctx context.Context, txID s
 }
 
 // AcquireRecoveryLeadership tries to acquire the DB-backed recovery leadership lease.
-func (d *StoreService) AcquireRecoveryLeadership(ctx context.Context, lockID int64) (dbdriver.RecoveryLeadership, bool, error) {
-	leadership, acquired, err := d.db.AcquireRecoveryLeadership(ctx, lockID)
+func (d *StoreService) AcquireRecoveryLeadership(ctx context.Context) (dbdriver.RecoveryLeadership, bool, error) {
+	leadership, acquired, err := d.db.AcquireRecoveryLeadership(ctx)
 	if err != nil {
 		return nil, false, errors.Wrapf(err, "failed to acquire recovery leadership")
 	}

--- a/token/services/tokens/mock/token_store.go
+++ b/token/services/tokens/mock/token_store.go
@@ -13,11 +13,10 @@ import (
 )
 
 type FakeTokenStore struct {
-	AcquireCleanupLeadershipStub        func(context.Context, int64) (driver.CleanupLeadership, bool, error)
+	AcquireCleanupLeadershipStub        func(context.Context) (driver.CleanupLeadership, bool, error)
 	acquireCleanupLeadershipMutex       sync.RWMutex
 	acquireCleanupLeadershipArgsForCall []struct {
 		arg1 context.Context
-		arg2 int64
 	}
 	acquireCleanupLeadershipReturns struct {
 		result1 driver.CleanupLeadership
@@ -512,19 +511,18 @@ type FakeTokenStore struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeTokenStore) AcquireCleanupLeadership(arg1 context.Context, arg2 int64) (driver.CleanupLeadership, bool, error) {
+func (fake *FakeTokenStore) AcquireCleanupLeadership(arg1 context.Context) (driver.CleanupLeadership, bool, error) {
 	fake.acquireCleanupLeadershipMutex.Lock()
 	ret, specificReturn := fake.acquireCleanupLeadershipReturnsOnCall[len(fake.acquireCleanupLeadershipArgsForCall)]
 	fake.acquireCleanupLeadershipArgsForCall = append(fake.acquireCleanupLeadershipArgsForCall, struct {
 		arg1 context.Context
-		arg2 int64
-	}{arg1, arg2})
+	}{arg1})
 	stub := fake.AcquireCleanupLeadershipStub
 	fakeReturns := fake.acquireCleanupLeadershipReturns
-	fake.recordInvocation("AcquireCleanupLeadership", []interface{}{arg1, arg2})
+	fake.recordInvocation("AcquireCleanupLeadership", []interface{}{arg1})
 	fake.acquireCleanupLeadershipMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -538,17 +536,17 @@ func (fake *FakeTokenStore) AcquireCleanupLeadershipCallCount() int {
 	return len(fake.acquireCleanupLeadershipArgsForCall)
 }
 
-func (fake *FakeTokenStore) AcquireCleanupLeadershipCalls(stub func(context.Context, int64) (driver.CleanupLeadership, bool, error)) {
+func (fake *FakeTokenStore) AcquireCleanupLeadershipCalls(stub func(context.Context) (driver.CleanupLeadership, bool, error)) {
 	fake.acquireCleanupLeadershipMutex.Lock()
 	defer fake.acquireCleanupLeadershipMutex.Unlock()
 	fake.AcquireCleanupLeadershipStub = stub
 }
 
-func (fake *FakeTokenStore) AcquireCleanupLeadershipArgsForCall(i int) (context.Context, int64) {
+func (fake *FakeTokenStore) AcquireCleanupLeadershipArgsForCall(i int) context.Context {
 	fake.acquireCleanupLeadershipMutex.RLock()
 	defer fake.acquireCleanupLeadershipMutex.RUnlock()
 	argsForCall := fake.acquireCleanupLeadershipArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1
 }
 
 func (fake *FakeTokenStore) AcquireCleanupLeadershipReturns(result1 driver.CleanupLeadership, result2 bool, result3 error) {


### PR DESCRIPTION
Follow-up to #1982, where you asked for the same fix on the other locks.

Recovery managers are created per TMS but all took the same advisory lock id from config, so
several TMSes on one postgres competed for a single lock and every one but the winner skipped
its sweep. Pending transactions on those TMSes just never got recovered.

The id now derives from the requests table name, which already carries network, channel and
namespace. Worth flagging that the table prefix on its own is not enough here: TMSes normally
share a persistence config and are told apart only by those params, so a prefix-derived id
still collides. `TestRecoveryLockID_DistinctPerTMSOnSharedPrefix` pins exactly that, and I
checked it fails against the prefix version.

`AcquireRecoveryLeadership` no longer takes a lockID, the factory is bound to its id when the
store is built. `AdvisoryLockID` is dropped from the config since there is nothing left to keep
unique by hand. Extra yaml keys are ignored on load so existing configs won't break, the setting
just stops doing anything. Happy to keep it as an override instead if you'd rather.

One thing I left alone: `AuditTransactionStore` passes a nil recovery factory, so its
`AcquireRecoveryLeadership` always grants locally and audit recovery has no cross-replica
coordination at all. That is pre-existing and looked like its own issue rather than widening
this one.

### Breaking change

This changes exported interfaces, so out-of-tree implementors will not compile until they drop the
`lockID` parameter: `driver.TransactionStore`, `driver.AuditTransactionStore`, `driver.TokenStore`,
`recovery.Storage`, `cleanup.Storage`. `recovery.Config` and `cleanup.Config` also lose their
`AdvisoryLockID` field. Existing yaml keeps working, a stale `advisoryLockID:` is simply ignored,
which `TestLoadConfig_IgnoresStaleAdvisoryLockID` covers.

Keystore cleanup is fixed here too, same shape, since it had the identical bug and is started per
TMS right beside recovery.

No separate tracking issue for this one, it's the direct follow-up requested in #1982's comments
rather than a fresh report, so there isn't a standalone bug report to link.

