### PR TITLE
fix(token): keep request-carried audit info when the local lookup is empty

### DIFF
--- a/token/request.go
+++ b/token/request.go
@@ -1470,7 +1470,12 @@ func (r *Request) AuditRecord(ctx context.Context) (*AuditRecord, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed getting audit info for owner [%s]", toks[i].Owner)
 		}
-		in.OwnerAuditInfo = ownerAuditInfo
+		// The wallet service only knows the identities registered on this node
+		// and returns nil for the others, so keep the audit info the request
+		// metadata already carries when the local lookup finds nothing.
+		if len(ownerAuditInfo) != 0 {
+			in.OwnerAuditInfo = ownerAuditInfo
+		}
 	}
 
 	return &AuditRecord{

--- a/token/request_test.go
+++ b/token/request_test.go
@@ -1105,3 +1105,89 @@ func TestRequest_PublicParamsHash(t *testing.T) {
 	hash := r.PublicParamsHash()
 	assert.Equal(t, expectedHash, hash)
 }
+
+// TestRequest_AuditRecord_OwnerAuditInfo checks how AuditRecord fills the audit
+// info of an input: the local wallet service wins when it knows the owner, and
+// the audit info carried by the request metadata survives when it does not.
+func TestRequest_AuditRecord_OwnerAuditInfo(t *testing.T) {
+	ctx := t.Context()
+	owner := Identity("owner1")
+	metadataAuditInfo := []byte("audit-info-from-metadata")
+
+	newRequest := func(localAuditInfo []byte) *Request {
+		// A transfer with one input and no output: AuditRecord only reads back
+		// the inputs, and no output keeps the action deobfuscation out of play.
+		transferAction := &driver2.TransferAction{}
+		transferAction.NumInputsReturns(1)
+		transferAction.NumOutputsReturns(0)
+
+		transferService := &driver2.TransferService{}
+		transferService.DeserializeTransferActionReturns(transferAction, nil)
+
+		walletService := &driver2.WalletService{}
+		walletService.GetAuditInfoReturns(localAuditInfo, nil)
+
+		pp := &driver2.PublicParameters{}
+		pp.PrecisionReturns(64)
+		ppm := &driver2.PublicParamsManager{}
+		ppm.PublicParametersReturns(pp)
+
+		tms := &driver2.TokenManagerService{}
+		tms.TransferServiceReturns(transferService)
+		tms.WalletServiceReturns(walletService)
+		tms.PublicParamsManagerReturns(ppm)
+
+		qe := &driver2.QueryEngine{}
+		qe.ListAuditTokensReturns([]*token.Token{{Owner: owner, Type: "USD", Quantity: "0x64"}}, nil)
+		vault := &driver2.Vault{}
+		vault.QueryEngineReturns(qe)
+
+		logger := logging.MustGetLogger()
+
+		return &Request{
+			Anchor: "test-anchor",
+			Actions: &driver.TokenRequest{
+				Actions: []*driver.TypedAction{
+					{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: []byte("transfer1")},
+				},
+			},
+			Metadata: &driver.TokenRequestMetadata{
+				Actions: []*driver.ActionMetadataEntry{
+					{
+						ActionID: 0,
+						TransferMetadata: &driver.TransferMetadata{
+							Inputs: []*driver.TransferInputMetadata{
+								{
+									TokenID: &token.ID{TxId: "tx1", Index: 0},
+									Senders: []*driver.AuditableIdentity{
+										{Identity: owner, AuditInfo: metadataAuditInfo},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			TokenService: &ManagementService{
+				tms:    tms,
+				logger: logger,
+				vault:  &Vault{v: vault, logger: logger},
+			},
+		}
+	}
+
+	t.Run("local wallet service knows the owner", func(t *testing.T) {
+		localAuditInfo := []byte("audit-info-from-wallet-service")
+		record, err := newRequest(localAuditInfo).AuditRecord(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, record.Inputs.Count())
+		assert.Equal(t, localAuditInfo, record.Inputs.At(0).OwnerAuditInfo)
+	})
+
+	t.Run("local wallet service does not know the owner", func(t *testing.T) {
+		record, err := newRequest(nil).AuditRecord(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, record.Inputs.Count())
+		assert.Equal(t, metadataAuditInfo, record.Inputs.At(0).OwnerAuditInfo)
+	})
+}


### PR DESCRIPTION
Refs #2087.

`Request.AuditRecord` replaced the owner audit info of every input with the result of a local wallet-service lookup:

```go
ownerAuditInfo, err := r.TokenService.tms.WalletService().GetAuditInfo(ctx, toks[i].Owner)
...
in.OwnerAuditInfo = ownerAuditInfo
```

`Provider.GetAuditInfo` returns nil for identities that were never registered on this node, and an auditor has no reason to have registered the owner of a transfer it is auditing. So the audit info the request carried — filled a few frames earlier in `extractTransferInputs` from `metadata.Inputs[j].Senders[k].AuditInfo` — was discarded and replaced with nothing.

x509 owners never surfaced this. Their enrollment ID is resolved while the metadata audit info is still intact and kept in a separate field, and the identity embeds a certificate the value can be re-read from. Owners whose audit info cannot be recomputed from the identity have neither fallback: `boolpolicy.AuditInfo.EnrollmentID()` returns `""` by design, and an idemix nym carries no transparent material.

This keeps the local result when it is non-empty and falls back to what the request carries otherwise. For every owner registered on the auditing node the behavior is unchanged; when neither source has anything, consumers still see an empty field and can fail closed as before.

Keeping the request-carried value also holds up better across policy versions: the request carries the material that matched the owner when the transaction was created, whereas the local lookup reflects the current registration.

`TestRequest_AuditRecord_OwnerAuditInfo` covers both directions and fails on the pre-patch code (the metadata audit info comes back nil).

Verified with `gofmt`, `go build ./token/...`, `go vet`, `go test -race ./token/`, and golangci-lint v2.12.2 with the repo configuration.
