### PR TITLE
docs: align project health files with LFDT requirements

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,56 @@
+name: "OpenSSF Scorecard"
+
+# The README Scorecard badge is intentionally NOT added yet: api.scorecard.dev only
+# serves data for a repository after this workflow has run on the default branch with
+# publish_results: true. Until then the badge renders "invalid repo path". Add
+#   https://api.scorecard.dev/projects/github.com/LFDT-Panurus/panurus/badge
+# to the README badge row once the first run on `main` has completed.
+
+on:
+  # Re-run when branch protection changes, since Branch-Protection is a scored check.
+  branch_protection_rule:
+  schedule:
+    - cron: '27 6 * * 1'
+  push:
+    branches: [ "main" ]
+
+# Least privilege by default; the job below elevates only what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload the results to code-scanning.
+      security-events: write
+      # Required by publish_results, which signs the results for the public API
+      # that serves the README badge.
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Must stay true: without it the api.securityscorecards.dev endpoint
+          # serves no data and the README badge renders "invalid repo path".
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,45 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# Adopters
+
+This file lists organizations and projects using Panurus, together with a publicly verifiable
+reference for each entry.
+
+## Are you using Panurus?
+
+Please add yourself. Adopter lists help the community understand where Panurus is deployed, guide
+roadmap priorities, and give new users confidence in the project.
+
+To be added:
+
+1. Open a pull request editing this file.
+2. Add a row to the table below.
+3. Include a **publicly verifiable reference** — a link to an announcement, blog post, paper, press
+   release, conference talk, or public repository. Entries without a public reference cannot be
+   accepted, as required by the
+   [LFDT project consistency guidelines][lfdt-consistency].
+4. Only add your organization if you are authorized to do so on its behalf.
+
+If you would rather not be listed publicly but are happy for the maintainers to know, say so in a
+[GitHub Discussion](https://github.com/LFDT-Panurus/panurus/discussions) instead.
+
+## Adopters
+
+| Organization / Project | Type of use | Status | Reference |
+|------------------------|-------------|--------|-----------|
+
+_No adopters are listed yet. Entries require a publicly verifiable reference — see above._
+
+**Status** is one of:
+
+- **Production** — deployed in a production environment.
+- **Pilot** — deployed in a limited pilot or proof of concept.
+- **Evaluating** — under active evaluation.
+
+<!--
+Example row:
+
+| Example Bank | Tokenized deposits on Fabric | Pilot | https://example.org/press/tokenized-deposit-pilot |
+-->
+
+[lfdt-consistency]: https://github.com/LF-Decentralized-Trust/governance/blob/main/tac/guidelines/project-consistency-guidelines.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 Code of Conduct Guidelines
 ==========================
 
-Please review the Hyperledger [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct)
+Please review the LF Decentralized Trust [Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct)
 before participating. It is important that we keep things civil.
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,29 +1,91 @@
-Maintainers
-===========
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
 
-**Active Maintainers**
+# Maintainers
 
-| Name               | GitHub                               | Chat        | email                       |
-|--------------------|--------------------------------------|-------------|-----------------------------|
-| Angelo De Caro     | [adecaro][adecaro]                   | adecaro     | <adc@zurich.ibm.com>        |
-| Kaoutar Elkhiyaoui | [KElkhiyaoui][KElkhiyaoui]           | KElkhiyaoui | <kao@zurich.ibm.com>        |
-| Arne Rutjes        | [arner][arner]                       | arner       | <arne.rutjesISC@nl.ibm.com> |
-| Alexandros Filios  | [alexandrosfilios][alexandrosfilios] | lio         | <alexandros.filios@alumni.ethz.ch> |
-| Akram Bitar        | [AkramBitar][AkramBitar]             | akrambitar  | <akram@il.ibm.com>        |
+Changes to either list below are made by pull request against this file. After such a pull request
+is merged, the corresponding GitHub team (`panurus-maintainers`) must be updated manually to match.
 
-**Emeritus Maintainers**
+## Active Maintainers
 
-| Name | GitHub | Chat | email
-|------|--------|------|----------------------
-| Alessandro Sorniotti | [ale-linux][ale-linux] | aso | <ale.linux@sopit.net>
-| Elli Androulaki | [elli-androulaki][elli-androulaki] | elli-androulaki | <lli@zurich.ibm.com>
-| Mathilde Ffrench | [mffrench][mffrench] | mffrench | <mathilde.ffrench@fr.ibm.com>
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+|------|-----------|-------|------|------------|-------|---------------------|
+| Angelo De Caro | [adecaro][adecaro] | Maintainer | | adecaro | <adc@zurich.ibm.com> | IBM |
+| Kaoutar Elkhiyaoui | [KElkhiyaoui][KElkhiyaoui] | Maintainer | | KElkhiyaoui | <kao@zurich.ibm.com> | IBM |
+| Arne Rutjes | [arner][arner] | Maintainer | | arner | <arne.rutjesISC@nl.ibm.com> | IBM |
+| Alexandros Filios | [alexandrosfilios][alexandrosfilios] | Maintainer | | lio | <alexandros.filios@alumni.ethz.ch> | Independent |
+| Akram Bitar | [AkramBitar][AkramBitar] | Maintainer | | akrambitar | <akram@il.ibm.com> | IBM |
 
-[elli-androulaki]: https://github.com/elli-androulaki
+## Emeritus Maintainers
+
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+|------|-----------|-------|------|------------|-------|---------------------|
+| Alessandro Sorniotti | [ale-linux][ale-linux] | Maintainer | | aso | <ale.linux@sopit.net> | IBM |
+| Elli Androulaki | [elli-androulaki][elli-androulaki] | Maintainer | | elli-androulaki | <lli@zurich.ibm.com> | IBM |
+| Mathilde Ffrench | [mffrench][mffrench] | Maintainer | | mffrench | <mathilde.ffrench@fr.ibm.com> | IBM |
+
+## Scopes
+
+Panurus uses a single maintainer scope covering the whole repository.
+
+| Scope | Definition | GitHub Role | GitHub Team |
+|-------|------------|-------------|-------------|
+| Maintainer | Maintainer for the entire repository | Maintain | `panurus-maintainers` |
+
+## Maintainer Duties
+
+Maintainers are expected to:
+
+- Review and merge pull requests, and keep CI green.
+- Triage incoming issues.
+- Participate in project calls and technical discussions.
+- Contribute to the mid-year project update and annual review filed with the LFDT TAC.
+- Mentor contributors working toward maintainership.
+
+Members of the security team carry the additional responsibilities described in
+[SECURITY.md](SECURITY.md).
+
+## How to Become a Maintainer
+
+Candidates for maintainership are expected to have:
+
+- a sustained history of substantive contributions to Panurus — code, review, documentation, or
+  release engineering,
+- demonstrated good judgement in code review, and
+- familiarity with the project's architecture and contribution process
+  (see [CONTRIBUTING.md](CONTRIBUTING.md)).
+
+The process is:
+
+1. An existing active maintainer sponsors the candidate.
+2. The sponsor opens a pull request adding the candidate to the **Active Maintainers** table above,
+   with a justification in the pull request description summarising the candidate's contributions.
+3. Current active maintainers have **two weeks** to review and raise objections.
+4. Approval requires a majority of active maintainers, with no sustained objection.
+5. Once merged, the `panurus-maintainers` GitHub team is updated to grant access.
+
+An emeritus maintainer may return to active status by the same process, without requiring a new
+sponsor.
+
+## How Maintainers are Removed or Moved to Emeritus Status
+
+A maintainer may be moved to emeritus status:
+
+- **At their own request** — open a pull request moving your row to the **Emeritus Maintainers**
+  table. This needs no further approval.
+- **Through inactivity** — a maintainer with no meaningful contribution or review activity for
+  **twelve months** may be proposed for emeritus status.
+- **For conduct** — a violation of the [Code of Conduct](CODE_OF_CONDUCT.md) may result in removal.
+
+Proposals follow the same path as additions: a pull request against this file with a justification,
+a two-week comment window, and approval by a majority of active maintainers. Moving to emeritus
+status is not a judgement on past contributions; it reflects current activity, and the door back is
+described above.
+
 [adecaro]: https://github.com/adecaro
 [KElkhiyaoui]: https://github.com/KElkhiyaoui
-[mffrench]: https://github.com/mffrench
-[ale-linux]: https://github.com/ale-linux
 [arner]: https://github.com/arner
 [alexandrosfilios]: https://github.com/alexandrosfilios
 [AkramBitar]: https://github.com/AkramBitar
+[ale-linux]: https://github.com/ale-linux
+[elli-androulaki]: https://github.com/elli-androulaki
+[mffrench]: https://github.com/mffrench

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202-blue" alt="License"></a>
+  <a href="https://www.bestpractices.dev/projects/7176"><img src="https://www.bestpractices.dev/projects/7176/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://goreportcard.com/badge/github.com/LFDT-Panurus/panurus"><img src="https://goreportcard.com/badge/github.com/LFDT-Panurus/panurus" alt="Go Report Card"></a>
   <a href="https://github.com/LFDT-Panurus/panurus/actions/workflows/tests.yml"><img src="https://github.com/LFDT-Panurus/panurus/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests"></a>
   <a href="https://github.com/LFDT-Panurus/panurus/actions/workflows/codeql-analysis.yml"><img src="https://github.com/LFDT-Panurus/panurus/actions/workflows/codeql-analysis.yml/badge.svg?branch=main" alt="CodeQL"></a>
@@ -15,8 +16,14 @@ Panurus provides a collection of APIs and services that streamline development f
 # Useful Links
  
 - [`Documentation`](docs/README.md): The entry point for Panurus documentation.
+- [`Releases`](https://github.com/LFDT-Panurus/panurus/releases): Current and past releases, with
+  release notes. The latest release is always at
+  [`releases/latest`](https://github.com/LFDT-Panurus/panurus/releases/latest).
 - [`Development`](docs/development/development.md): All about the development guidelines.
 - [`Contributing`](CONTRIBUTING.md): How to contribute to the project.
+- [`Adopters`](ADOPTERS.md): Who is using Panurus. **Using Panurus? Please add yourself to
+  [`ADOPTERS.md`](ADOPTERS.md)** — it helps the community understand where the project is deployed.
+- [`Security`](SECURITY.md): How to report a security vulnerability.
 - [`Fabric Samples`](https://github.com/hyperledger/fabric-samples/tree/main/token-sdk) Panurus sample application is the
   quickest way to get a full network running with a REST API to issue, transfer and redeem tokens right away.
 - [`Benchmarks`](./docs/drivers/benchmark/benchmark.md): Benchmark guidelines and reports.
@@ -30,7 +37,7 @@ Panurus provides a collection of APIs and services that streamline development f
 
 # Additional Resources
 
-- (March 17, 2022) [`Hyperledger in-Depth: Tokens in Hyperledger Fabric: What’s possible today and what’s coming`](https://www.hyperledger.org/learn/webinars/hyperledger-in-depth-tokens-in-hyperledger-fabric-whats-possible-today-and-whats-coming):
+- (March 17, 2022) [`Hyperledger in-Depth: Tokens in Hyperledger Fabric: What’s possible today and what’s coming`](https://lfdecentralizedtrust.org/learn/webinars/hyperledger-in-depth-tokens-in-hyperledger-fabric-whats-possible-today-and-whats-coming):
   Tokenizing the physical world is a hot blockchain topic in the industry, especially as it relates to the 
   trade of tokens as a basis of new forms of commerce. In this Hyperledger Foundation member webinar, 
   the IBM Research team describes in this webinar what tokenization use cases are possible with Hyperledger Fabric today, 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,102 @@
-# Hyperledger Security Policy
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
 
-## Reporting a Security Bug
+# Panurus, an LF Decentralized Trust Project Security Policy
 
-If you think you have discovered a security issue in any of the Hyperledger projects, we'd love to hear from you. We will take all security bugs seriously and if confirmed upon investigation we will patch it within a reasonable amount of time and release a public security bulletin discussing the impact and credit the discoverer.
+## About this document
 
-The easiest is to email a description of the flaw and any related information (e.g. reproduction steps, version) to [security at hyperledger dot org](mailto:security@hyperledger.org).
+This is the vulnerability disclosure policy for the Panurus project. It conforms to the
+[LF Decentralized Trust Security Vulnerability Disclosure Policy][lfdt-security] and is adapted
+from the LFDT `SAMPLE-SECURITY.md` template. Where this document is silent, the LFDT policy governs.
 
-The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
+## Security Team
+
+The Panurus security team is responsible for receiving, triaging, and coordinating the response to
+vulnerability reports. Each member subscribes to the LF Decentralized Trust security email list and
+to LFDT-wide security infrastructure. Members are added to and removed from the team via approved
+pull requests against this file.
+
+| Name | Email ID | Discord ID | Area/Specialty |
+|------|----------|------------|----------------|
+| Angelo De Caro | <adc@zurich.ibm.com> | adecaro | Cryptography, zero-knowledge token protocols (`zkatdlog`) |
+| Kaoutar Elkhiyaoui | <kao@zurich.ibm.com> | KElkhiyaoui | Cryptography, token protocol design and validation |
+| Akram Bitar | <akram@il.ibm.com> | akrambitar | SDK, drivers, integration and CI |
+
+Because Panurus contains security-sensitive cryptographic code — zero-knowledge proofs, range
+proofs, and Idemix-based identity under `token/core/zkatdlog/` — the security team includes
+maintainers with cryptography expertise, per the LFDT policy.
+
+The security team accepts the following responsibilities:
+
+1. Acknowledge receipt of a report to the reporter within **2 business days**.
+2. Triage the report, and open a GitHub Security Advisory if it appears to be a vulnerability.
+   Reports that are ordinary bugs are redirected to the normal issue process, and the reporter is told so.
+3. Negotiate an embargo period with the reporter where needed. An embargo **must not exceed 90 days**.
+4. Develop and review the patch privately, using GitHub's private vulnerability patching features.
+5. Obtain a CVE identifier.
+6. Agree on a disclosure date and notify embargo list members, if applicable.
+7. Ship a release containing the fix.
+8. Disclose publicly **within 48 hours after the release**, via a GitHub Security Advisory.
+9. Credit the reporter in the advisory, unless they ask to remain anonymous.
+
+## Discussion Forums
+
+Vulnerability discussion happens in the private GitHub Security Advisory opened for the report.
+A private channel on the [LF Decentralized Trust Discord][discord] may be created if broader
+coordination is required.
+
+**Do not** discuss a suspected vulnerability in a public issue, pull request, discussion, or
+Discord channel before it has been disclosed.
+
+## Report Intakes
+
+Report a suspected vulnerability through **either** of these channels:
+
+- **Email** the LF Decentralized Trust security email list at
+  <security@lists.lfdecentralizedtrust.org>. Please include:
+  - the repository name (`LFDT-Panurus/panurus`),
+  - a description of the issue,
+  - steps to reproduce,
+  - affected versions,
+  - any known mitigations.
+- **GitHub private vulnerability reporting** — open a draft advisory from the
+  [Security tab][security-tab] of the repository.
+
+Reports are handled per the response outline above.
+
+## CNA/CVE Reporting
+
+GitHub acts as the CVE Numbering Authority (CNA) for Panurus. The security team requests CVE
+identifiers through the GitHub Security Advisory workflow.
+
+## Embargo List
+
+Panurus does not maintain a project-specific embargo list. Where an embargo is warranted, the
+security team coordinates through the LFDT security email list and the private GitHub advisory.
+Requests to be included in a specific embargo should be sent to
+<security@lists.lfdecentralizedtrust.org> with the project name and the rationale for a
+need-to-know.
+
+## Security Advisories
+
+Panurus uses [GitHub Security Advisories][advisories] as its advisory mechanism. Published
+advisories are the authoritative record of disclosed vulnerabilities for the project.
+
+## Private Patch Deployment Infrastructure
+
+Panurus uses GitHub's private vulnerability patching features, which allow the fix to be developed
+and reviewed in a private fork associated with the advisory. Maintainers needing access or
+assistance can contact <community-architects@lfdecentralizedtrust.org>.
+
+---
+
+This policy borrows heavily from the recommendations of the OpenSSF Vulnerability Disclosure
+working group ([ossf/wg-vulnerability-disclosures][ossf-wg]), and the response outline derives from
+the OpenSSF maintainers guide.
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+
+[lfdt-security]: https://github.com/LF-Decentralized-Trust/governance/blob/main/tac/governing-documents/security.md
+[discord]: https://discord.gg/hyperledger
+[security-tab]: https://github.com/LFDT-Panurus/panurus/security
+[advisories]: https://github.com/LFDT-Panurus/panurus/security/advisories
+[ossf-wg]: https://github.com/ossf/wg-vulnerability-disclosures


### PR DESCRIPTION
## What

Conformance fixes against the LFDT governing docs, following the health review by @mbrandenburger 
(`project-health-checklist.md`, `panurus-health-assessment.md`). Closes items **1, 2, 3, 5, 6**.

Fixes #2095

| Item | Change |
|---|---|
| 1 | `SECURITY.md` rewritten to the LFDT template. Intake → `security@lists.lfdecentralizedtrust.org`. Named contacts: De Caro, Elkhiyaoui, Bitar |
| 2 | `MAINTAINERS.md` → the 7 required columns, plus how maintainers are added / moved to emeritus |
| 3 | OpenSSF Best Practices + Scorecard badges, plus `scorecard.yml` (badge is inert without it) |
| 5 | Webinar URL → `lfdecentralizedtrust.org`; CoC wording → LF Decentralized Trust |
| 6 | `ADOPTERS.md` added (empty) + README pointer. Also added the missing releases link |

Docs only, except `scorecard.yml`.

## Questions to the Reviewers

1. **`ADOPTERS.md` is empty — help me fill it.** If you know of an organisation using Panurus, I need:
   type of use, status (Production/Pilot/Evaluating), a **public URL**, and confirmation they are happy
   to be listed. I did not add anyone without clearance and a citable reference. Can land as a
   follow-up rather than block this PR.
2. Security contacts — are those the right three?
3. **Maintainers: post your `LFID`** (your Linux Foundation ID). How I can get this info?