### PR TITLE
lint: enable lll

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - importas # Enforces consistent import aliases. [auto-fix]
     - intrange # Intrange is a linter to find places where for loops could make use of an integer range. [auto-fix]
     - loggercheck # Checks key value pairs for common logger libraries (kitlog,klog,logr,slog,zap).
+    - lll # Reports long lines. [fast]
     - mirror # Reports wrong mirror patterns of bytes/strings usage. [auto-fix]
     - misspell # Finds commonly misspelled English words. [fast, auto-fix]
     - nakedret # Checks that functions with naked returns are not longer than a maximum size (can be zero). [fast, auto-fix]

--- a/cmd/tokengen/main_test.go
+++ b/cmd/tokengen/main_test.go
@@ -306,7 +306,10 @@ func TestGenFailure(t *testing.T) {
 				"--idemix", "./testdata/idemix",
 				"--issuers", "Error: failed to generate public parameters: failed to get issuer identity [aOrg1MSP]: invalid input [aOrg1MSP]",
 			},
-			ErrMsg: "Error: failed to generate public parameters: failed to setup issuer and auditors: failed to get issuer identity [Error: failed to generate public parameters: failed to get issuer identity [aOrg1MSP]: invalid input [aOrg1MSP]]: failed to load certificates from Error: failed to generate public parameters: failed to get issuer identity [aOrg1MSP]: invalid input [aOrg1MSP]/signcerts: stat Error: failed to generate public parameters: failed to get issuer identity [aOrg1MSP]: invalid input [aOrg1MSP]/signcerts: no such file or directory",
+			ErrMsg: "Error: failed to generate public parameters: failed to setup issuer and auditors: failed to get issuer identity [Error: failed to generate public " +
+				"parameters: failed to get issuer identity [aOrg1MSP]: invalid input [aOrg1MSP]]: failed to load certificates from Error: failed to generate public " +
+				"parameters: failed to get issuer identity [aOrg1MSP]: invalid input [aOrg1MSP]/signcerts: stat Error: failed to generate public parameters: failed to " +
+				"get issuer identity [aOrg1MSP]: invalid input [aOrg1MSP]/signcerts: no such file or directory",
 		},
 	}...,
 	)

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -98,19 +98,60 @@ func getFabricTopology(network *integration.Infrastructure) *topology2.Topology 
 	return nil
 }
 
-func IssueCash(network *integration.Infrastructure, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
+func IssueCash(
+	network *integration.Infrastructure,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	receiver *token3.NodeReference,
+	auditor *token3.NodeReference,
+	anonymous bool,
+	issuer *token3.NodeReference,
+	expectedErrorMsgs ...string,
+) string {
 	return IssueCashForTMSID(network, wallet, typ, amount, receiver, auditor, anonymous, issuer, nil, expectedErrorMsgs...)
 }
 
-func IssueSuccessfulCash(network *integration.Infrastructure, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, finalities ...*token3.NodeReference) string {
+func IssueSuccessfulCash(
+	network *integration.Infrastructure,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	receiver *token3.NodeReference,
+	auditor *token3.NodeReference,
+	anonymous bool,
+	issuer *token3.NodeReference,
+	finalities ...*token3.NodeReference,
+) string {
 	return issueCashForTMSID(network, wallet, typ, amount, receiver, auditor, anonymous, issuer, nil, finalities, false, []string{})
 }
 
-func IssueCashForTMSID(network *integration.Infrastructure, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
+func IssueCashForTMSID(
+	network *integration.Infrastructure,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	receiver *token3.NodeReference,
+	auditor *token3.NodeReference,
+	anonymous bool,
+	issuer *token3.NodeReference,
+	tmsId *token2.TMSID,
+	expectedErrorMsgs ...string,
+) string {
 	return issueCashForTMSID(network, wallet, typ, amount, receiver, auditor, anonymous, issuer, tmsId, []*token3.NodeReference{}, false, expectedErrorMsgs)
 }
 
-func IssueCashWithNoAuditorSigVerification(network *integration.Infrastructure, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
+func IssueCashWithNoAuditorSigVerification(
+	network *integration.Infrastructure,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	receiver *token3.NodeReference,
+	auditor *token3.NodeReference,
+	anonymous bool,
+	issuer *token3.NodeReference,
+	expectedErrorMsgs ...string,
+) string {
 	return issueCashForTMSID(network, wallet, typ, amount, receiver, auditor, anonymous, issuer, nil, []*token3.NodeReference{}, true, expectedErrorMsgs)
 }
 
@@ -463,7 +504,17 @@ func TransferCash(network *integration.Infrastructure, sender *token3.NodeRefere
 	return TransferCashForTMSID(network, sender, wallet, typ, amount, receiver, auditor, nil, expectedErrorMsgs...)
 }
 
-func TransferCashForTMSID(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
+func TransferCashForTMSID(
+	network *integration.Infrastructure,
+	sender *token3.NodeReference,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	receiver *token3.NodeReference,
+	auditor *token3.NodeReference,
+	tmsId *token2.TMSID,
+	expectedErrorMsgs ...string,
+) string {
 	txidBoxed, err := network.Client(sender.ReplicaName()).CallView("transfer", common.JSONMarshall(&views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -515,7 +566,18 @@ func TransferCashNoFinalityCheck(network *integration.Infrastructure, sender *to
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
-func TransferCashFromExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, websSocket bool, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
+func TransferCashFromExternalWallet(
+	network *integration.Infrastructure,
+	wmp *WalletManagerProvider,
+	websSocket bool,
+	sender *token3.NodeReference,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	receiver *token3.NodeReference,
+	auditor *token3.NodeReference,
+	expectedErrorMsgs ...string,
+) string {
 	// obtain the recipient for the rest
 	restRecipient := wmp.RecipientData(sender.Id(), wallet)
 	// start the call as a stream
@@ -573,7 +635,18 @@ func TransferCashFromExternalWallet(network *integration.Infrastructure, wmp *Wa
 	return ""
 }
 
-func TransferCashToExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, receiverWallet string, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
+func TransferCashToExternalWallet(
+	network *integration.Infrastructure,
+	wmp *WalletManagerProvider,
+	sender *token3.NodeReference,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	receiver *token3.NodeReference,
+	receiverWallet string,
+	auditor *token3.NodeReference,
+	expectedErrorMsgs ...string,
+) string {
 	// obtain the recipient data for the recipient and register it
 	recipientData := wmp.RecipientData(receiver.Id(), receiverWallet)
 	RegisterRecipientData(network, receiver, receiverWallet, recipientData)
@@ -621,7 +694,19 @@ func TransferCashToExternalWallet(network *integration.Infrastructure, wmp *Wall
 	return ""
 }
 
-func TransferCashFromAndToExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, websSocket bool, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, receiverWallet string, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
+func TransferCashFromAndToExternalWallet(
+	network *integration.Infrastructure,
+	wmp *WalletManagerProvider,
+	websSocket bool,
+	sender *token3.NodeReference,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	receiver *token3.NodeReference,
+	receiverWallet string,
+	auditor *token3.NodeReference,
+	expectedErrorMsgs ...string,
+) string {
 	// obtain the recipient for the rest
 	restRecipient := wmp.RecipientData(sender.Id(), wallet)
 
@@ -685,7 +770,17 @@ func TransferCashFromAndToExternalWallet(network *integration.Infrastructure, wm
 	return ""
 }
 
-func TransferCashMultiActions(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.Type, amounts []uint64, receivers []*token3.NodeReference, auditor *token3.NodeReference, tokenID *token.ID, expectedErrorMsgs ...string) string {
+func TransferCashMultiActions(
+	network *integration.Infrastructure,
+	sender *token3.NodeReference,
+	wallet string,
+	typ token.Type,
+	amounts []uint64,
+	receivers []*token3.NodeReference,
+	auditor *token3.NodeReference,
+	tokenID *token.ID,
+	expectedErrorMsgs ...string,
+) string {
 	gomega.Expect(len(amounts)).To(gomega.BeNumerically(">", 1))
 	gomega.Expect(len(receivers)).To(gomega.BeEquivalentTo(len(amounts)))
 	transfer := &views.Transfer{
@@ -755,7 +850,17 @@ func TransferCashMultiActions(network *integration.Infrastructure, sender *token
 	return strErr[s+4 : e]
 }
 
-func MaliciousTransferCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
+func MaliciousTransferCash(
+	network *integration.Infrastructure,
+	id *token3.NodeReference,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	receiver *token3.NodeReference,
+	auditor *token3.NodeReference,
+	tmsId *token2.TMSID,
+	expectedErrorMsgs ...string,
+) string {
 	txidBoxed, err := network.Client(id.ReplicaName()).CallView("MaliciousTransfer", common.JSONMarshall(&views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -782,7 +887,18 @@ func MaliciousTransferCash(network *integration.Infrastructure, id *token3.NodeR
 	return ""
 }
 
-func PrepareTransferCash(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tokenID *token.ID, expectedErrorMsgs ...string) (string, []byte) {
+func PrepareTransferCash(
+	network *integration.Infrastructure,
+	sender *token3.NodeReference,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	receiver *token3.NodeReference,
+	auditor *token3.NodeReference,
+	tokenID *token.ID,
+	expectedErrorMsgs ...string) (string,
+	[]byte,
+) {
 	transferInput := &views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -882,7 +998,17 @@ func GetTransactionInfoForTMSID(network *integration.Infrastructure, id *token3.
 	return info
 }
 
-func TransferCashByIDs(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, ids []*token.ID, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, failToRelease bool, expectedErrorMsgs ...string) string {
+func TransferCashByIDs(
+	network *integration.Infrastructure,
+	ref *token3.NodeReference,
+	wallet string,
+	ids []*token.ID,
+	amount uint64,
+	receiver *token3.NodeReference,
+	auditor *token3.NodeReference,
+	failToRelease bool,
+	expectedErrorMsgs ...string,
+) string {
 	txIDBoxed, err := network.Client(ref.ReplicaName()).CallView("transfer", common.JSONMarshall(&views.Transfer{
 		Auditor:       auditor.Id(),
 		Wallet:        wallet,
@@ -934,7 +1060,17 @@ func TransferCashWithSelector(network *integration.Infrastructure, sender *token
 	}
 }
 
-func RedeemCashForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.Type, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference, tmsID *token2.TMSID, expectedErrorMsgs ...string) {
+func RedeemCashForTMSID(
+	network *integration.Infrastructure,
+	id *token3.NodeReference,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	auditor *token3.NodeReference,
+	issuer *token3.NodeReference,
+	tmsID *token2.TMSID,
+	expectedErrorMsgs ...string,
+) {
 	issuerName := ""
 	var issuerPublicParamsPublicKey view.Identity = nil
 	if issuer != nil && tmsID != nil {
@@ -1409,7 +1545,18 @@ func SetSpendableFlag(network *integration.Infrastructure, user *token3.NodeRefe
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
-func Withdraw(network *integration.Infrastructure, wpm *WalletManagerProvider, webSocket bool, user *token3.NodeReference, wallet string, typ token.Type, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
+func Withdraw(
+	network *integration.Infrastructure,
+	wpm *WalletManagerProvider,
+	webSocket bool,
+	user *token3.NodeReference,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	auditor *token3.NodeReference,
+	issuer *token3.NodeReference,
+	expectedErrorMsgs ...string,
+) string {
 	var recipientData *token2.RecipientData
 	if wpm != nil {
 		recipientData = wpm.RecipientData(user.Id(), wallet)
@@ -1507,7 +1654,16 @@ func CheckPrometheusMetrics(ii *integration.Infrastructure, viewName string) {
 	}
 }
 
-func TokensUpgrade(network *integration.Infrastructure, wpm *WalletManagerProvider, user *token3.NodeReference, wallet string, typ token.Type, auditor *token3.NodeReference, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
+func TokensUpgrade(
+	network *integration.Infrastructure,
+	wpm *WalletManagerProvider,
+	user *token3.NodeReference,
+	wallet string,
+	typ token.Type,
+	auditor *token3.NodeReference,
+	issuer *token3.NodeReference,
+	expectedErrorMsgs ...string,
+) string {
 	var recipientData *token2.RecipientData
 	if wpm != nil {
 		recipientData = wpm.RecipientData(user.Id(), wallet)
@@ -1589,7 +1745,17 @@ func PolicyLockCash(network *integration.Infrastructure, sender *token3.NodeRefe
 }
 
 // PolicyLockCashForTMSID is like PolicyLockCash but pins a specific TMSID.
-func PolicyLockCashForTMSID(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, policy string, receivers []*token3.NodeReference, auditor *token3.NodeReference, tmsID *token2.TMSID) string {
+func PolicyLockCashForTMSID(
+	network *integration.Infrastructure,
+	sender *token3.NodeReference,
+	wallet string,
+	typ token.Type,
+	amount uint64,
+	policy string,
+	receivers []*token3.NodeReference,
+	auditor *token3.NodeReference,
+	tmsID *token2.TMSID,
+) string {
 	parties := make([]view.Identity, len(receivers))
 	for i, r := range receivers {
 		parties[i] = network.Identity(r.Id())

--- a/integration/token/interop/support.go
+++ b/integration/token/interop/support.go
@@ -167,7 +167,17 @@ func CheckBalanceAndHolding(network *integration.Infrastructure, id *token3.Node
 }
 
 // #nosec G115
-func CheckBalanceWithLockedAndHolding(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.Type, expectedBalance uint64, expectedLocked uint64, expectedExpired uint64, expectedHolding int64, opts ...token.ServiceOption) {
+func CheckBalanceWithLockedAndHolding(
+	network *integration.Infrastructure,
+	id *token3.NodeReference,
+	wallet string,
+	typ token2.Type,
+	expectedBalance uint64,
+	expectedLocked uint64,
+	expectedExpired uint64,
+	expectedHolding int64,
+	opts ...token.ServiceOption,
+) {
 	CheckBalanceWithLocked(network, id, wallet, typ, expectedBalance, expectedLocked, expectedExpired, opts...)
 	if expectedHolding == -1 {
 		expectedHolding = int64(expectedBalance + expectedLocked + expectedExpired)
@@ -266,7 +276,22 @@ func Restart(network *integration.Infrastructure, ids ...*token3.NodeReference) 
 	time.Sleep(10 * time.Second)
 }
 
-func HTLCLock(network *integration.Infrastructure, tmsID token.TMSID, id *token3.NodeReference, wallet string, typ token2.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, deadline time.Duration, hash []byte, hashFunc crypto.Hash, errorMsgs ...string) (string, []byte, []byte) {
+func HTLCLock(
+	network *integration.Infrastructure,
+	tmsID token.TMSID,
+	id *token3.NodeReference,
+	wallet string,
+	typ token2.Type,
+	amount uint64,
+	receiver *token3.NodeReference,
+	auditor *token3.NodeReference,
+	deadline time.Duration,
+	hash []byte,
+	hashFunc crypto.Hash,
+	errorMsgs ...string) (string,
+	[]byte,
+	[]byte,
+) {
 	result, err := network.Client(id.ReplicaName()).CallView("htlc.lock", common.JSONMarshall(&htlc.Lock{
 		TMSID:               tmsID,
 		ReclamationDeadline: deadline,
@@ -398,7 +423,18 @@ func htlcClaim(network *integration.Infrastructure, tmsID token.TMSID, id *token
 	}
 }
 
-func fastExchange(network *integration.Infrastructure, id *token3.NodeReference, recipient *token3.NodeReference, tmsID1 token.TMSID, typ1 token2.Type, amount1 uint64, tmsID2 token.TMSID, typ2 token2.Type, amount2 uint64, deadline time.Duration) {
+func fastExchange(
+	network *integration.Infrastructure,
+	id *token3.NodeReference,
+	recipient *token3.NodeReference,
+	tmsID1 token.TMSID,
+	typ1 token2.Type,
+	amount1 uint64,
+	tmsID2 token.TMSID,
+	typ2 token2.Type,
+	amount2 uint64,
+	deadline time.Duration,
+) {
 	_, err := network.Client(id.ReplicaName()).CallView("htlc.fastExchange", common.JSONMarshall(&htlc.FastExchange{
 		Recipient:           network.Identity(recipient.Id()),
 		TMSID1:              tmsID1,

--- a/token/core/common/encoding/asn1/asn1_test.go
+++ b/token/core/common/encoding/asn1/asn1_test.go
@@ -179,7 +179,9 @@ func TestMarshal(t *testing.T) {
 	// test failures
 	err = Unmarshal[Serializer]([]byte{0, 1, 2})
 	require.Error(t, err)
-	require.EqualError(t, err, "failed to unmarshal values: asn1: structure error: tags don't match (16 vs {class:0 tag:0 length:1 isCompound:false}) {optional:false explicit:false application:false private:false defaultValue:<nil> tag:<nil> stringType:0 timeType:0 set:false omitEmpty:false} Values @2")
+	require.EqualError(t, err,
+		"failed to unmarshal values: asn1: structure error: tags don't match (16 vs {class:0 tag:0 length:1 isCompound:false}) "+
+			"{optional:false explicit:false application:false private:false defaultValue:<nil> tag:<nil> stringType:0 timeType:0 set:false omitEmpty:false} Values @2")
 	err = Unmarshal[Serializer](raw, a1)
 	require.Error(t, err)
 	require.EqualError(t, err, "number of values does not match number of values")
@@ -208,7 +210,9 @@ func TestUnmarshaller(t *testing.T) {
 	// some errors
 	err = p1.Deserialize([]byte{0, 1, 2})
 	require.Error(t, err)
-	require.EqualError(t, err, "failed to deserialize: failed to unmarshal values: asn1: structure error: tags don't match (16 vs {class:0 tag:0 length:1 isCompound:false}) {optional:false explicit:false application:false private:false defaultValue:<nil> tag:<nil> stringType:0 timeType:0 set:false omitEmpty:false} Values @2")
+	require.EqualError(t, err,
+		"failed to deserialize: failed to unmarshal values: asn1: structure error: tags don't match (16 vs {class:0 tag:0 length:1 isCompound:false}) "+
+			"{optional:false explicit:false application:false private:false defaultValue:<nil> tag:<nil> stringType:0 timeType:0 set:false omitEmpty:false} Values @2")
 	// success
 	err = p1.Deserialize(raw)
 	require.NoError(t, err)

--- a/token/core/common/metrics/transfer.go
+++ b/token/core/common/metrics/transfer.go
@@ -52,7 +52,16 @@ func NewTransferService(inner driver.TransferService, p Provider) *TransferServi
 	}
 }
 
-func (w *TransferService) Transfer(ctx context.Context, anchor driver.TokenRequestAnchor, wallet driver.OwnerWallet, ids []*token.ID, outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+func (w *TransferService) Transfer(
+	ctx context.Context,
+	anchor driver.TokenRequestAnchor,
+	wallet driver.OwnerWallet,
+	ids []*token.ID,
+	outputs []*token.Token,
+	opts *driver.TransferOptions) (driver.TransferAction,
+	*driver.TransferMetadata,
+	error,
+) {
 	w.calls.With("method", "Transfer").Add(1)
 	start := time.Now()
 	action, meta, err := w.inner.Transfer(ctx, anchor, wallet, ids, outputs, opts)

--- a/token/core/fabtoken/v1/transfer.go
+++ b/token/core/fabtoken/v1/transfer.go
@@ -45,7 +45,16 @@ func NewTransferService(
 
 // Transfer returns a TransferAction as a function of the passed arguments
 // It also returns the corresponding TransferMetadata
-func (s *TransferService) Transfer(ctx context.Context, anchor driver.TokenRequestAnchor, wallet driver.OwnerWallet, ids []*token.ID, outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+func (s *TransferService) Transfer(
+	ctx context.Context,
+	anchor driver.TokenRequestAnchor,
+	wallet driver.OwnerWallet,
+	ids []*token.ID,
+	outputs []*token.Token,
+	opts *driver.TransferOptions) (driver.TransferAction,
+	*driver.TransferMetadata,
+	error,
+) {
 	// select inputs
 	inputTokens, err := s.TokenLoader.GetTokens(ctx, ids)
 	if err != nil {

--- a/token/core/zkatdlog/nogh/v1/audit/auditor_test.go
+++ b/token/core/zkatdlog/nogh/v1/audit/auditor_test.go
@@ -50,7 +50,13 @@ func TestAuditor(t *testing.T) {
 		// Build auditTokens map from inputs
 		auditTokens := buildAuditTokensFromInputs(t, metadata, inputs)
 
-		err = auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}}, "1", auditTokens)
+		err = auditor.Check(
+			t.Context(),
+			&driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}},
+			&driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}},
+			"1",
+			auditTokens,
+		)
 		require.NoError(t, err)
 	})
 
@@ -89,7 +95,13 @@ func TestAuditor(t *testing.T) {
 		// Build auditTokens map from inputs
 		auditTokens := buildAuditTokensFromInputs(t, metadata, inputs)
 
-		err = auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}}, "1", auditTokens)
+		err = auditor.Check(
+			t.Context(),
+			&driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}},
+			&driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}},
+			"1",
+			auditTokens,
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "owner at index [0] does not match the provided opening")
 		require.NotContains(t, err.Error(), "attribute mistmatch")
@@ -119,7 +131,13 @@ func TestAuditor(t *testing.T) {
 
 		auditTokens := buildAuditTokensFromInputs(t, metadata, inputs)
 
-		err = auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}}, "1", auditTokens)
+		err = auditor.Check(
+			t.Context(),
+			&driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}},
+			&driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}},
+			"1",
+			auditTokens,
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "does not match the provided opening")
 	})
@@ -138,7 +156,13 @@ func TestAuditor(t *testing.T) {
 		// Build auditTokens map from inputs
 		auditTokens := buildAuditTokensFromInputs(t, metadata, inputs)
 
-		err = auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}}, "1", auditTokens)
+		err = auditor.Check(
+			t.Context(),
+			&driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}},
+			&driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}},
+			"1",
+			auditTokens,
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "owner at index [0] does not match the provided opening")
 		require.Contains(t, err.Error(), "does not match the provided opening")
@@ -152,7 +176,13 @@ func TestAuditor(t *testing.T) {
 		raw, err := ia.Serialize()
 		require.NoError(t, err)
 		// Issues have no inputs, so pass empty map
-		err = auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, IssueMetadata: metadata}}}, "1", map[string]*token3.Token{})
+		err = auditor.Check(
+			t.Context(),
+			&driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: raw}}},
+			&driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, IssueMetadata: metadata}}},
+			"1",
+			map[string]*token3.Token{},
+		)
 		require.NoError(t, err)
 	})
 
@@ -167,7 +197,13 @@ func TestAuditor(t *testing.T) {
 
 		auditTokens := buildAuditTokensFromInputs(t, metadata, inputs)
 
-		err = auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}}, "1", auditTokens)
+		err = auditor.Check(
+			t.Context(),
+			&driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}},
+			&driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}},
+			"1",
+			auditTokens,
+		)
 		require.NoError(t, err)
 	})
 
@@ -183,7 +219,13 @@ func TestAuditor(t *testing.T) {
 
 		auditTokens := buildAuditTokensFromInputs(t, metadata, inputs)
 
-		err = auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}}, "1", auditTokens)
+		err = auditor.Check(
+			t.Context(),
+			&driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}},
+			&driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}},
+			"1",
+			auditTokens,
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "is not a recognized issuer")
 	})
@@ -204,7 +246,13 @@ func TestAuditor(t *testing.T) {
 		raw, err := ia.Serialize()
 		require.NoError(t, err)
 
-		err = auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, IssueMetadata: metadata}}}, "1", map[string]*token3.Token{})
+		err = auditor.Check(
+			t.Context(),
+			&driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: raw}}},
+			&driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, IssueMetadata: metadata}}},
+			"1",
+			map[string]*token3.Token{},
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "is not a recognized issuer")
 	})
@@ -269,7 +317,13 @@ func TestAuditor_Check_Errors(t *testing.T) {
 	// issues cannot be retrieved.
 	t.Run("Check issue audit info error", func(t *testing.T) {
 		_, _, auditor := setupAuditorTest(t)
-		err := auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: []byte{1, 2, 3}}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, IssueMetadata: &driver.IssueMetadata{}}}}, "1", map[string]*token3.Token{})
+		err := auditor.Check(
+			t.Context(),
+			&driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: []byte{1, 2, 3}}}},
+			&driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, IssueMetadata: &driver.IssueMetadata{}}}},
+			"1",
+			map[string]*token3.Token{},
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to deserialize")
 	})
@@ -281,7 +335,13 @@ func TestAuditor_Check_Errors(t *testing.T) {
 		ia, meta := createIssue(t, pp)
 		ia.Outputs[0].Data = pp.PedersenGenerators[0] // wrong data
 		raw, _ := ia.Serialize()
-		err := auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, IssueMetadata: meta}}}, "1", map[string]*token3.Token{})
+		err := auditor.Check(
+			t.Context(),
+			&driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: raw}}},
+			&driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, IssueMetadata: meta}}},
+			"1",
+			map[string]*token3.Token{},
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "output at index [0] does not match the provided opening")
 	})
@@ -293,7 +353,13 @@ func TestAuditor_Check_Errors(t *testing.T) {
 		ia, meta := createIssue(t, pp)
 		meta.Issuer.AuditInfo = []byte("wrong")
 		raw, _ := ia.Serialize()
-		err := auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, IssueMetadata: meta}}}, "1", map[string]*token3.Token{})
+		err := auditor.Check(
+			t.Context(),
+			&driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: raw}}},
+			&driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, IssueMetadata: meta}}},
+			"1",
+			map[string]*token3.Token{},
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed checking issuer identity")
 	})
@@ -302,7 +368,13 @@ func TestAuditor_Check_Errors(t *testing.T) {
 	// transfers cannot be retrieved.
 	t.Run("Check transfer audit info error", func(t *testing.T) {
 		_, _, auditor := setupAuditorTest(t)
-		err := auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: []byte{1, 2, 3}}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: &driver.TransferMetadata{}}}}, "1", map[string]*token3.Token{})
+		err := auditor.Check(
+			t.Context(),
+			&driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: []byte{1, 2, 3}}}},
+			&driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: &driver.TransferMetadata{}}}},
+			"1",
+			map[string]*token3.Token{},
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to deserialize")
 	})

--- a/token/core/zkatdlog/nogh/v1/issue/verifier.go
+++ b/token/core/zkatdlog/nogh/v1/issue/verifier.go
@@ -27,7 +27,17 @@ type BulletProofVerifier struct {
 func NewBulletProofVerifier(tokens []*math.G1, pp *v1.PublicParams) *BulletProofVerifier {
 	v := &BulletProofVerifier{curveID: pp.Curve}
 	v.SameType = NewSameTypeVerifier(tokens, pp.PedersenGenerators, math.Curves[pp.Curve])
-	v.RangeCorrectness = bulletproof.NewRangeCorrectnessVerifier(pp.PedersenGenerators[1:], pp.RangeProofParams.LeftGenerators, pp.RangeProofParams.RightGenerators, pp.RangeProofParams.P, pp.RangeProofParams.Q, pp.RangeProofParams.BitLength, pp.RangeProofParams.NumberOfRounds, math.Curves[pp.Curve], pp.ExecutorProvider)
+	v.RangeCorrectness = bulletproof.NewRangeCorrectnessVerifier(
+		pp.PedersenGenerators[1:],
+		pp.RangeProofParams.LeftGenerators,
+		pp.RangeProofParams.RightGenerators,
+		pp.RangeProofParams.P,
+		pp.RangeProofParams.Q,
+		pp.RangeProofParams.BitLength,
+		pp.RangeProofParams.NumberOfRounds,
+		math.Curves[pp.Curve],
+		pp.ExecutorProvider,
+	)
 
 	return v
 }

--- a/token/core/zkatdlog/nogh/v1/testutils/env.go
+++ b/token/core/zkatdlog/nogh/v1/testutils/env.go
@@ -687,7 +687,16 @@ func prepareIssueRequestWithAttrs(pp *v1setup.PublicParams, auditor *audit.Audit
 	return issuer, ir, requestMetadata, nil
 }
 
-func prepareRedeemRequest(benchCase *benchmark2.Case, pp *v1setup.PublicParams, auditor *audit.Auditor, setupConfig *benchmark.SetupConfiguration) (*transfer.Sender, *driver.TokenRequest, *driver.TokenRequestMetadata, map[string]*token2.Token, error) {
+func prepareRedeemRequest(
+	benchCase *benchmark2.Case,
+	pp *v1setup.PublicParams,
+	auditor *audit.Auditor,
+	setupConfig *benchmark.SetupConfiguration) (*transfer.Sender,
+	*driver.TokenRequest,
+	*driver.TokenRequestMetadata,
+	map[string]*token2.Token,
+	error,
+) {
 	benchCaseRedeem := &benchmark2.Case{
 		Workers:    benchCase.Workers,
 		Bits:       benchCase.Bits,
@@ -729,7 +738,16 @@ func prepareRedeemRequest(benchCase *benchmark2.Case, pp *v1setup.PublicParams, 
 // at its zero value (None) so that audit/auditor.go's validateRedeemIssuer -
 // which, unlike its issue-side counterpart validateIssuer, has no open-policy
 // bypass - is never invoked.
-func prepareOpenPolicyRedeemRequest(benchCase *benchmark2.Case, pp *v1setup.PublicParams, auditor *audit.Auditor, setupConfig *benchmark.SetupConfiguration) (*transfer.Sender, *driver.TokenRequest, *driver.TokenRequestMetadata, map[string]*token2.Token, error) {
+func prepareOpenPolicyRedeemRequest(
+	benchCase *benchmark2.Case,
+	pp *v1setup.PublicParams,
+	auditor *audit.Auditor,
+	setupConfig *benchmark.SetupConfiguration) (*transfer.Sender,
+	*driver.TokenRequest,
+	*driver.TokenRequestMetadata,
+	map[string]*token2.Token,
+	error,
+) {
 	benchCaseRedeem := &benchmark2.Case{
 		Workers:    benchCase.Workers,
 		Bits:       benchCase.Bits,
@@ -757,7 +775,17 @@ func prepareOpenPolicyRedeemRequest(benchCase *benchmark2.Case, pp *v1setup.Publ
 	)
 }
 
-func prepareTransferRequest(benchCase *benchmark2.Case, pp *v1setup.PublicParams, auditor *audit.Auditor, signer *benchmark.Signer, oID *benchmark.OwnerIdentity) (*transfer.Sender, *driver.TokenRequest, *driver.TokenRequestMetadata, map[string]*token2.Token, error) {
+func prepareTransferRequest(
+	benchCase *benchmark2.Case,
+	pp *v1setup.PublicParams,
+	auditor *audit.Auditor,
+	signer *benchmark.Signer,
+	oID *benchmark.OwnerIdentity) (*transfer.Sender,
+	*driver.TokenRequest,
+	*driver.TokenRequestMetadata,
+	map[string]*token2.Token,
+	error,
+) {
 	owners := make([][]byte, benchCase.NumOutputs)
 	for i := range benchCase.NumOutputs {
 		owners[i] = oID.ID
@@ -781,7 +809,16 @@ func prepareTransferRequest(benchCase *benchmark2.Case, pp *v1setup.PublicParams
 // transfer whose sole input is loaded as a Fabtoken output, so that
 // TransferUpgradeWitnessValidate's non-nil-witness branch is exercised
 // end-to-end (see prepareTransferWithOpts).
-func prepareUpgradeWitnessTransferRequest(pp *v1setup.PublicParams, auditor *audit.Auditor, signer *benchmark.Signer, oID *benchmark.OwnerIdentity) (*transfer.Sender, *driver.TokenRequest, *driver.TokenRequestMetadata, map[string]*token2.Token, error) {
+func prepareUpgradeWitnessTransferRequest(
+	pp *v1setup.PublicParams,
+	auditor *audit.Auditor,
+	signer *benchmark.Signer,
+	oID *benchmark.OwnerIdentity) (*transfer.Sender,
+	*driver.TokenRequest,
+	*driver.TokenRequestMetadata,
+	map[string]*token2.Token,
+	error,
+) {
 	benchCase := &benchmark2.Case{NumInputs: 1, NumOutputs: 1}
 	owners := [][]byte{oID.ID}
 
@@ -801,7 +838,17 @@ func prepareUpgradeWitnessTransferRequest(pp *v1setup.PublicParams, auditor *aud
 	)
 }
 
-func prepareSwapRequest(benchCase *benchmark2.Case, pp *v1setup.PublicParams, auditor *audit.Auditor, auditorSigner *benchmark.Signer, oID *benchmark.OwnerIdentity) (*transfer.Sender, *driver.TokenRequest, *driver.TokenRequestMetadata, map[string]*token2.Token, error) {
+func prepareSwapRequest(
+	benchCase *benchmark2.Case,
+	pp *v1setup.PublicParams,
+	auditor *audit.Auditor,
+	auditorSigner *benchmark.Signer,
+	oID *benchmark.OwnerIdentity) (*transfer.Sender,
+	*driver.TokenRequest,
+	*driver.TokenRequestMetadata,
+	map[string]*token2.Token,
+	error,
+) {
 	sender1, tr1, trmetadata1, inputsForTransfer1, err := prepareTransferRequest(benchCase, pp, auditor, auditorSigner, oID)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -912,7 +959,16 @@ func prepareTransfer(
 // transfer carrying a "pub."-prefixed application metadata attribute, so that
 // TransferApplicationDataValidate's metadata-claiming branch is exercised
 // end-to-end.
-func preparePublicMetadataTransferRequest(pp *v1setup.PublicParams, auditor *audit.Auditor, signer *benchmark.Signer, oID *benchmark.OwnerIdentity) (*transfer.Sender, *driver.TokenRequest, *driver.TokenRequestMetadata, map[string]*token2.Token, error) {
+func preparePublicMetadataTransferRequest(
+	pp *v1setup.PublicParams,
+	auditor *audit.Auditor,
+	signer *benchmark.Signer,
+	oID *benchmark.OwnerIdentity) (*transfer.Sender,
+	*driver.TokenRequest,
+	*driver.TokenRequestMetadata,
+	map[string]*token2.Token,
+	error,
+) {
 	benchCase := &benchmark2.Case{NumInputs: 1, NumOutputs: 1}
 	owners := [][]byte{oID.ID}
 	attrs := map[string]any{
@@ -946,7 +1002,16 @@ func preparePublicMetadataTransferRequest(pp *v1setup.PublicParams, auditor *aud
 // checks structural correspondence via TransferMetadata.Match, not metadata
 // content), so the failure must be observed by re-running the real validator
 // stack over the returned bytes.
-func prepareUnclaimedMetadataTransferRequest(pp *v1setup.PublicParams, auditor *audit.Auditor, signer *benchmark.Signer, oID *benchmark.OwnerIdentity) (*transfer.Sender, *driver.TokenRequest, *driver.TokenRequestMetadata, map[string]*token2.Token, error) {
+func prepareUnclaimedMetadataTransferRequest(
+	pp *v1setup.PublicParams,
+	auditor *audit.Auditor,
+	signer *benchmark.Signer,
+	oID *benchmark.OwnerIdentity) (*transfer.Sender,
+	*driver.TokenRequest,
+	*driver.TokenRequestMetadata,
+	map[string]*token2.Token,
+	error,
+) {
 	benchCase := &benchmark2.Case{NumInputs: 1, NumOutputs: 1}
 	owners := [][]byte{oID.ID}
 	attrs := map[string]any{
@@ -975,7 +1040,16 @@ func prepareUnclaimedMetadataTransferRequest(pp *v1setup.PublicParams, auditor *
 // AuditorSigner. AuditingSignaturesValidate implements a 1-of-N policy over
 // PP.Auditors(), so this exercises the "signed by a non-first configured
 // auditor key" path end-to-end while remaining a POSITIVE fixture.
-func prepareMultiAuditorTransferRequest(pp *v1setup.PublicParams, auditor *audit.Auditor, secondAuditorSigner *benchmark.Signer, oID *benchmark.OwnerIdentity) (*transfer.Sender, *driver.TokenRequest, *driver.TokenRequestMetadata, map[string]*token2.Token, error) {
+func prepareMultiAuditorTransferRequest(
+	pp *v1setup.PublicParams,
+	auditor *audit.Auditor,
+	secondAuditorSigner *benchmark.Signer,
+	oID *benchmark.OwnerIdentity) (*transfer.Sender,
+	*driver.TokenRequest,
+	*driver.TokenRequestMetadata,
+	map[string]*token2.Token,
+	error,
+) {
 	benchCase := &benchmark2.Case{NumInputs: 1, NumOutputs: 1}
 	owners := [][]byte{oID.ID}
 
@@ -1004,7 +1078,17 @@ func prepareMultiAuditorTransferRequest(pp *v1setup.PublicParams, auditor *audit
 // request is re-validated. This is a NEGATIVE fixture: auditor.Check inside
 // prepareTransfer still succeeds, since the auditor never inspects signature
 // counts.
-func prepareExtraSignatureTransferRequest(benchCase *benchmark2.Case, pp *v1setup.PublicParams, auditor *audit.Auditor, auditorSigner *benchmark.Signer, oID *benchmark.OwnerIdentity) (*transfer.Sender, *driver.TokenRequest, *driver.TokenRequestMetadata, map[string]*token2.Token, error) {
+func prepareExtraSignatureTransferRequest(
+	benchCase *benchmark2.Case,
+	pp *v1setup.PublicParams,
+	auditor *audit.Auditor,
+	auditorSigner *benchmark.Signer,
+	oID *benchmark.OwnerIdentity) (*transfer.Sender,
+	*driver.TokenRequest,
+	*driver.TokenRequestMetadata,
+	map[string]*token2.Token,
+	error,
+) {
 	sender, tr, trMetadata, trInputs, err := prepareTransferRequest(benchCase, pp, auditor, auditorSigner, oID)
 	if err != nil {
 		return nil, nil, nil, nil, err

--- a/token/core/zkatdlog/nogh/v1/transfer.go
+++ b/token/core/zkatdlog/nogh/v1/transfer.go
@@ -114,7 +114,16 @@ func NewTransferService(
 
 // Transfer generates a new TransferAction based on the provided arguments.
 // It returns the TransferAction, the corresponding TransferMetadata, or an error if the operation fails.
-func (s *TransferService) Transfer(ctx context.Context, anchor driver.TokenRequestAnchor, wallet driver.OwnerWallet, ids []*token2.ID, outputs []*token2.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+func (s *TransferService) Transfer(
+	ctx context.Context,
+	anchor driver.TokenRequestAnchor,
+	wallet driver.OwnerWallet,
+	ids []*token2.ID,
+	outputs []*token2.Token,
+	opts *driver.TransferOptions) (driver.TransferAction,
+	*driver.TransferMetadata,
+	error,
+) {
 	s.Logger.DebugfContext(ctx, "Prepare Transfer Action [%s,%v]", anchor, ids)
 	if common.IsAnyNil(ids...) {
 		return nil, nil, errors.New("failed to prepare transfer action: nil token id")

--- a/token/core/zkatdlog/nogh/v1/transfer/bftransfer.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/bftransfer.go
@@ -75,7 +75,17 @@ func NewBulletProofVerifier(inputs, outputs []*math.G1, pp *v1.PublicParams) *Bu
 	// if so, skip range proof as well-formedness proof is sufficient.
 	var rangeCorrectness *bulletproof.RangeCorrectnessVerifier
 	if len(inputs) != 1 || len(outputs) != 1 {
-		rangeCorrectness = bulletproof.NewRangeCorrectnessVerifier(pp.PedersenGenerators[1:], pp.RangeProofParams.LeftGenerators, pp.RangeProofParams.RightGenerators, pp.RangeProofParams.P, pp.RangeProofParams.Q, pp.RangeProofParams.BitLength, pp.RangeProofParams.NumberOfRounds, math.Curves[pp.Curve], pp.ExecutorProvider)
+		rangeCorrectness = bulletproof.NewRangeCorrectnessVerifier(
+			pp.PedersenGenerators[1:],
+			pp.RangeProofParams.LeftGenerators,
+			pp.RangeProofParams.RightGenerators,
+			pp.RangeProofParams.P,
+			pp.RangeProofParams.Q,
+			pp.RangeProofParams.BitLength,
+			pp.RangeProofParams.NumberOfRounds,
+			math.Curves[pp.Curve],
+			pp.ExecutorProvider,
+		)
 	}
 
 	return &BulletProofVerifier{

--- a/token/services/selector/benchmark_test.go
+++ b/token/services/selector/benchmark_test.go
@@ -177,8 +177,16 @@ func NewSelector(qs *testutils.MockQueryService, walletIDByRawIdentity WalletIDB
 
 func NewSherdSelector(qs *testutils.MockQueryService, _ WalletIDByRawIdentityFunc, lock selector.Locker) (ExtendedSelector, CleanupFunction) {
 	return &extendedSelector{
-		Selector: sherdlock.NewSherdSelector(testutils.TxID, sherdlock.NewLazyFetcher(qs), inmemory2.NewLocker(lock), testutils.TokenQuantityPrecision, sherdlock.NoBackoff, testutils.SelectorNumRetries, sherdlock.NewMetrics(&disabled.Provider{})),
-		Lock:     nil,
+		Selector: sherdlock.NewSherdSelector(
+			testutils.TxID,
+			sherdlock.NewLazyFetcher(qs),
+			inmemory2.NewLocker(lock),
+			testutils.TokenQuantityPrecision,
+			sherdlock.NoBackoff,
+			testutils.SelectorNumRetries,
+			sherdlock.NewMetrics(&disabled.Provider{}),
+		),
+		Lock: nil,
 	}, nil
 }
 

--- a/token/services/selector/sherdlock/selector.go
+++ b/token/services/selector/sherdlock/selector.go
@@ -76,7 +76,10 @@ func (m *StubbornSelector) Select(ctx context.Context, ownerFilter token.OwnerFi
 		if m.backoffInterval > 0 {
 			backoffDuration = time.Duration(rand.Int64N(int64(m.backoffInterval)))
 		}
-		m.logger.DebugfContext(ctx, "Token selection aborted, so that other procs can retry. Release tokens and backoff for %v before retrying to select. In the meantime maybe some other process releases token locks or adds tokens.", backoffDuration)
+		m.logger.DebugfContext(ctx,
+			"Token selection aborted, so that other procs can retry. Release tokens and backoff for %v before retrying to select. "+
+				"In the meantime maybe some other process releases token locks or adds tokens.",
+			backoffDuration)
 		select {
 		case <-time.After(backoffDuration):
 		case <-ctx.Done():

--- a/token/services/storage/db/sql/common/tokens.go
+++ b/token/services/storage/db/sql/common/tokens.go
@@ -1640,7 +1640,26 @@ func (t *TokenTransaction) StoreToken(ctx context.Context, tr driver.TokenRecord
 	// Store token
 	query, args := q.InsertInto(t.table.Tokens).
 		Fields("tx_id", "idx", "issuer_raw", "owner_raw", "owner_type", "owner_identity", "owner_wallet_id", "ledger", "ledger_type", "ledger_metadata", "token_type", "quantity", "amount", "stored_at", "owner", "auditor", "issuer", "redeemed").
-		Row(tr.TxID, tr.Index, tr.IssuerRaw, tr.OwnerRaw, tr.OwnerType, tr.OwnerIdentity, tr.OwnerWalletID, tr.Ledger, tr.LedgerFormat, tr.LedgerMetadata, tr.Type, tr.Quantity, tr.Amount, time.Now().UTC(), tr.Owner, tr.Auditor, tr.Issuer, tr.Redeemed).
+		Row(
+			tr.TxID,
+			tr.Index,
+			tr.IssuerRaw,
+			tr.OwnerRaw,
+			tr.OwnerType,
+			tr.OwnerIdentity,
+			tr.OwnerWalletID,
+			tr.Ledger,
+			tr.LedgerFormat,
+			tr.LedgerMetadata,
+			tr.Type,
+			tr.Quantity,
+			tr.Amount,
+			time.Now().UTC(),
+			tr.Owner,
+			tr.Auditor,
+			tr.Issuer,
+			tr.Redeemed,
+		).
 		OnConflictDoNothing().
 		Format()
 	logging.Debug(logger, query, args)

--- a/token/services/ttx/upgrade.go
+++ b/token/services/ttx/upgrade.go
@@ -60,7 +60,17 @@ func RequestTokensUpgrade(context view.Context, issuer view.Identity, wallet str
 
 // RequestTokensUpgradeForRecipient runs UpgradeTokensInitiatorView with the passed arguments.
 // The view will send the passed recipient data to the issuer.
-func RequestTokensUpgradeForRecipient(context view.Context, issuer view.Identity, wallet string, tokens []token2.LedgerToken, notAnonymous bool, recipientData *RecipientData, opts ...token.ServiceOption) (view.Identity, view.Session, error) {
+func RequestTokensUpgradeForRecipient(
+	context view.Context,
+	issuer view.Identity,
+	wallet string,
+	tokens []token2.LedgerToken,
+	notAnonymous bool,
+	recipientData *RecipientData,
+	opts ...token.ServiceOption) (view.Identity,
+	view.Session,
+	error,
+) {
 	options, err := CompileServiceOptions(opts...)
 	if err != nil {
 		return nil, nil, errors.WithMessagef(err, "failed to compile options")


### PR DESCRIPTION
Next step of #1991, after #2001.

`lll` had a 240 char limit configured but was never enabled, so nothing enforced it. 32 lines
were over. Most are long function signatures and call expressions and are just wrapped. Four are
long string literals, split with `+`, and I checked the values are unchanged (two of them are
expected-error assertions in the asn1 tests, so a silent change there would have been a real
bug).

Touches 16 files across the root, integration and tokengen modules.

### A correction on the numbers

The table I put on #2001 said `lll` was 20 issues over 4 files. That was wrong, it is 32 over 12.

I had measured by running the remaining linters together in one `--enable-only` pass. That
under-reports: running `lll` on its own surfaced 16 issues in 8 files that the combined run never
showed. So the figures I gave for `ireturn`, `iface`, `gocognit`, `wrapcheck` and `revive` are
unreliable too, and I would not plan the remaining steps around them until each one has been
measured on its own. Happy to redo that and post a corrected table if useful.

Still open from #2001, no rush but they block the next steps:

- `maintidx` only fires on large table-driven test functions, so satisfying it means splitting
  those tests up. Excluding `_test.go` or dropping the setting seems better, your call.
- `revive` runs with `enable-all-rules: true`, which is far too much for one PR and probably
  wants a narrowed rule list first.
