### PR TITLE
fix(auditdb): reject an empty postgres locker owner at construction

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -850,7 +850,9 @@ Default values:
 - postgres.acquireBackoff: 100ms
 - postgres.acquireDeadline: 1m
 - postgres.heartbeat: 10s
-- postgres.owner: empty, defaults to the FSC node ID (`config.Provider.ID()`)
+- postgres.owner: empty, defaults to the FSC node ID (`config.Provider.ID()`). Required
+  when `backend: postgres` — if both this value and `fsc.id` are empty or blank, the
+  locker fails to start with `auditor locker owner is required` (see the note below).
 
 **Backend Selection:**
 
@@ -864,3 +866,4 @@ Default values:
 - The `memory` backend uses in-process semaphores and provides no cross-replica coordination. It is suitable for single-node or development setups.
 - When using `postgres`, all auditor replicas must share the same PostgreSQL database so that EID locks are globally visible.
 - Set `heartbeat` to roughly `ttl / 3` to ensure leases are renewed well before expiry.
+- `owner` identifies the replica holding each lease and **must be non-empty and unique per replica**: every lease query (acquire, release, renew, and the pre-write `AssertLocksHeld` check) is scoped by it. If several replicas shared one owner value, those predicates would match each other's rows and mutual exclusion would be lost cluster-wide, so an empty or blank resolved owner is rejected at startup rather than tolerated. A typical cause is a templated node configuration with `fsc.id` left unset. No owner is synthesized as a fallback, because an owner that changed on each restart would leave a replica unable to renew or release the leases it still holds. The `memory` backend has no owner and is unaffected.

--- a/docs/services/auditor.md
+++ b/docs/services/auditor.md
@@ -82,7 +82,7 @@ token:
             acquireBackoff: 100ms
             acquireDeadline: 1m
             heartbeat: 10s
-            owner:            # optional; defaults to the FSC node ID
+            owner:            # required; defaults to the FSC node ID
 ```
 
 **Backend selection:**
@@ -92,4 +92,30 @@ token:
 | `memory` | Single replica | Any |
 | `postgres` | Multi-replica | PostgreSQL only |
 
-The Postgres backend creates an `eid_leases` table (prefixed per TMS persistence settings) and uses lease rows with heartbeat renewal. The replica owner defaults to the FSC config provider node `ID()` when `owner` is empty.
+The Postgres backend creates an `eid_leases` table (prefixed per TMS persistence settings) and uses lease rows with heartbeat renewal.
+
+### Replica owner identity
+
+Every lease row carries an `owner` column, and each replica scopes all of its lease
+queries by it — the acquire upsert, the release, the heartbeat renewal, and
+`AssertLocksHeld`. The owner must therefore be **non-empty and unique per replica**.
+
+Resolution order:
+
+1. `token.tms.<name>.auditor.locker.postgres.owner`, when set.
+2. Otherwise the FSC node ID (`fsc.id`, via the config provider's `ID()`).
+
+If both are empty or blank, the locker **fails to start** with
+`auditor locker owner is required`, and the audit store for that TMS is never
+created. This is deliberate: a shared empty owner would make every owner-scoped
+lease predicate match on rows belonging to *other* replicas, so a replica could
+release or renew leases it does not hold and `AssertLocksHeld` could be satisfied
+by another replica's row — silently removing mutual exclusion across the whole
+cluster. Failing at startup surfaces the misconfiguration instead.
+
+A common way to hit this is a templated or cloned node configuration where `fsc.id`
+was left unset. Note that no owner is synthesized as a fallback: an owner that
+changed on every restart would leave a restarted replica unable to renew or release
+the leases it still holds in the table.
+
+The `memory` backend has no owner concept and is unaffected.

--- a/token/services/storage/auditdb/locker.go
+++ b/token/services/storage/auditdb/locker.go
@@ -25,10 +25,11 @@ const (
 )
 
 var (
-	ErrLockContention     = locker.ErrLockContention
-	ErrLockAcquireTimeout = locker.ErrLockAcquireTimeout
-	ErrLockLost           = locker.ErrLockLost
-	ErrLockNotHeld        = locker.ErrLockNotHeld
+	ErrLockContention      = locker.ErrLockContention
+	ErrLockAcquireTimeout  = locker.ErrLockAcquireTimeout
+	ErrLockLost            = locker.ErrLockLost
+	ErrLockNotHeld         = locker.ErrLockNotHeld
+	ErrLockerOwnerRequired = locker.ErrLockerOwnerRequired
 )
 
 // DefaultLockerConfig returns the default auditor locker configuration.

--- a/token/services/storage/auditdb/locker/errs/errors.go
+++ b/token/services/storage/auditdb/locker/errs/errors.go
@@ -13,4 +13,9 @@ var (
 	ErrLockAcquireTimeout = errors.New("auditor enrollment id lock acquire timeout")
 	ErrLockLost           = errors.New("auditor enrollment id lock lost")
 	ErrLockNotHeld        = errors.New("auditor enrollment id locks not held")
+	// ErrLockerOwnerRequired signals that a distributed locker was configured
+	// without a usable owner identity. The owner identifies the replica holding
+	// each lease, so an empty value shared by every replica would make all
+	// owner-scoped lease queries match across the whole cluster.
+	ErrLockerOwnerRequired = errors.New("auditor locker owner is required")
 )

--- a/token/services/storage/auditdb/locker/factory_test.go
+++ b/token/services/storage/auditdb/locker/factory_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package locker_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/services/storage/auditdb/locker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubReplicaID struct{ id string }
+
+func (s stubReplicaID) ID() string { return s.id }
+
+// writeDBOnly satisfies locker.WriteDBProvider but not driver.AuditTransactionStore.
+type writeDBOnly struct{}
+
+func (writeDBOnly) WriteDB() *sql.DB { return nil }
+
+func TestNewFromConfig_MemoryBackends(t *testing.T) {
+	// the memory backend has no owner concept, so an empty replica id must
+	// keep working — the owner requirement is postgres-only
+	for _, backend := range []locker.Backend{locker.BackendMemory, ""} {
+		t.Run(string(backend), func(t *testing.T) {
+			l, err := locker.NewFromConfig(locker.Config{Backend: backend}, nil, stubReplicaID{id: ""})
+			require.NoError(t, err)
+			assert.NotNil(t, l)
+		})
+	}
+}
+
+func TestNewFromConfig_DefaultConfigIsMemory(t *testing.T) {
+	cfg := locker.DefaultConfig()
+	assert.Equal(t, locker.BackendMemory, cfg.Backend)
+
+	l, err := locker.NewFromConfig(cfg, nil, stubReplicaID{id: ""})
+	require.NoError(t, err)
+	assert.NotNil(t, l)
+}
+
+func TestNewFromConfig_UnknownBackend(t *testing.T) {
+	l, err := locker.NewFromConfig(locker.Config{Backend: "nosuchbackend"}, nil, stubReplicaID{id: "r1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown locker backend")
+	assert.Nil(t, l)
+}
+
+func TestNewFromConfig_PostgresRequiresSQLStore(t *testing.T) {
+	cfg := locker.Config{Backend: locker.BackendPostgres}
+
+	// a store exposing no *sql.DB
+	l, err := locker.NewFromConfig(cfg, struct{}{}, stubReplicaID{id: "r1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WriteDBProvider")
+	assert.Nil(t, l)
+
+	// a store exposing a *sql.DB but not an AuditTransactionStore
+	l, err = locker.NewFromConfig(cfg, writeDBOnly{}, stubReplicaID{id: "r1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AuditTransactionStore")
+	assert.Nil(t, l)
+}

--- a/token/services/storage/auditdb/locker/locker.go
+++ b/token/services/storage/auditdb/locker/locker.go
@@ -24,8 +24,9 @@ type Locker interface {
 type ReplicaIDProvider = id.ReplicaIDProvider
 
 var (
-	ErrLockContention     = errs.ErrLockContention
-	ErrLockAcquireTimeout = errs.ErrLockAcquireTimeout
-	ErrLockLost           = errs.ErrLockLost
-	ErrLockNotHeld        = errs.ErrLockNotHeld
+	ErrLockContention      = errs.ErrLockContention
+	ErrLockAcquireTimeout  = errs.ErrLockAcquireTimeout
+	ErrLockLost            = errs.ErrLockLost
+	ErrLockNotHeld         = errs.ErrLockNotHeld
+	ErrLockerOwnerRequired = errs.ErrLockerOwnerRequired
 )

--- a/token/services/storage/auditdb/locker/postgres/config.go
+++ b/token/services/storage/auditdb/locker/postgres/config.go
@@ -6,7 +6,13 @@ SPDX-License-Identifier: Apache-2.0
 
 package postgres
 
-import "time"
+import (
+	"strings"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/storage/auditdb/locker/errs"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
 
 const (
 	defaultTTL             = 30 * time.Second
@@ -25,7 +31,10 @@ type Config struct {
 	AcquireDeadline time.Duration `yaml:"acquireDeadline"`
 	// Heartbeat is the interval at which held leases are renewed (~TTL/3).
 	Heartbeat time.Duration `yaml:"heartbeat"`
-	// Owner identifies this replica. Defaults to the FSC node ID when empty.
+	// Owner identifies this replica and is required: it scopes every lease
+	// query, so two replicas sharing one owner value share their leases.
+	// Defaults to the FSC node ID when empty; locker construction fails when
+	// both this field and the node ID are empty or blank.
 	Owner string `yaml:"owner"`
 }
 
@@ -42,9 +51,30 @@ func (c Config) withDefaults(owner string) Config {
 	if c.Heartbeat <= 0 {
 		c.Heartbeat = defaultHeartbeat
 	}
+	c.Owner = strings.TrimSpace(c.Owner)
 	if c.Owner == "" {
-		c.Owner = owner
+		c.Owner = strings.TrimSpace(owner)
 	}
 
 	return c
+}
+
+// validate reports whether the defaulted configuration is usable. Only Owner is
+// checked: it is the identity every lease query is scoped by (the acquire
+// upsert, releaseAnchor, AssertLocksHeld and renewLeases all compare against
+// it), so a blank value shared by every replica would make those predicates
+// match cluster-wide and silently turn the distributed lock into a no-op.
+// Failing here is deliberate — synthesizing an owner instead would make lease
+// ownership unstable across restarts, so a restarted replica could no longer
+// renew or release the leases it still holds.
+func (c Config) validate() error {
+	if strings.TrimSpace(c.Owner) == "" {
+		return errors.WithMessage(
+			errs.ErrLockerOwnerRequired,
+			"resolved owner is empty: set token.tms.<name>.auditor.locker.postgres.owner "+
+				"to a value unique per replica, or set fsc.id so the replica ID is non-empty and unique per node",
+		)
+	}
+
+	return nil
 }

--- a/token/services/storage/auditdb/locker/postgres/config_test.go
+++ b/token/services/storage/auditdb/locker/postgres/config_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/storage/auditdb/locker/errs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_WithDefaults(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfg           Config
+		replicaID     string
+		expected      Config
+		expectedOwner string
+	}{
+		{
+			name:          "all empty, defaults applied and owner taken from replica id",
+			cfg:           Config{},
+			replicaID:     "replica-1",
+			expectedOwner: "replica-1",
+			expected: Config{
+				TTL:             defaultTTL,
+				AcquireBackoff:  defaultAcquireBackoff,
+				AcquireDeadline: defaultAcquireDeadline,
+				Heartbeat:       defaultHeartbeat,
+				Owner:           "replica-1",
+			},
+		},
+		{
+			name: "explicit values preserved",
+			cfg: Config{
+				TTL:             time.Minute,
+				AcquireBackoff:  time.Second,
+				AcquireDeadline: 2 * time.Minute,
+				Heartbeat:       20 * time.Second,
+				Owner:           "cfg-owner",
+			},
+			replicaID:     "replica-1",
+			expectedOwner: "cfg-owner",
+			expected: Config{
+				TTL:             time.Minute,
+				AcquireBackoff:  time.Second,
+				AcquireDeadline: 2 * time.Minute,
+				Heartbeat:       20 * time.Second,
+				Owner:           "cfg-owner",
+			},
+		},
+		{
+			name:          "configured owner wins over replica id",
+			cfg:           Config{Owner: "cfg-owner"},
+			replicaID:     "replica-1",
+			expectedOwner: "cfg-owner",
+			expected: Config{
+				TTL:             defaultTTL,
+				AcquireBackoff:  defaultAcquireBackoff,
+				AcquireDeadline: defaultAcquireDeadline,
+				Heartbeat:       defaultHeartbeat,
+				Owner:           "cfg-owner",
+			},
+		},
+		{
+			name:          "negative durations replaced by defaults",
+			cfg:           Config{TTL: -time.Second, AcquireBackoff: -time.Second, AcquireDeadline: -time.Second, Heartbeat: -time.Second, Owner: "o"},
+			replicaID:     "replica-1",
+			expectedOwner: "o",
+			expected: Config{
+				TTL:             defaultTTL,
+				AcquireBackoff:  defaultAcquireBackoff,
+				AcquireDeadline: defaultAcquireDeadline,
+				Heartbeat:       defaultHeartbeat,
+				Owner:           "o",
+			},
+		},
+		{
+			name:          "empty replica id leaves the owner empty",
+			cfg:           Config{},
+			replicaID:     "",
+			expectedOwner: "",
+			expected: Config{
+				TTL:             defaultTTL,
+				AcquireBackoff:  defaultAcquireBackoff,
+				AcquireDeadline: defaultAcquireDeadline,
+				Heartbeat:       defaultHeartbeat,
+				Owner:           "",
+			},
+		},
+		{
+			name:          "blank config owner falls back to replica id",
+			cfg:           Config{Owner: "   "},
+			replicaID:     "replica-1",
+			expectedOwner: "replica-1",
+			expected: Config{
+				TTL:             defaultTTL,
+				AcquireBackoff:  defaultAcquireBackoff,
+				AcquireDeadline: defaultAcquireDeadline,
+				Heartbeat:       defaultHeartbeat,
+				Owner:           "replica-1",
+			},
+		},
+		{
+			name:          "blank config owner and blank replica id both normalised to empty",
+			cfg:           Config{Owner: "   "},
+			replicaID:     "  ",
+			expectedOwner: "",
+			expected: Config{
+				TTL:             defaultTTL,
+				AcquireBackoff:  defaultAcquireBackoff,
+				AcquireDeadline: defaultAcquireDeadline,
+				Heartbeat:       defaultHeartbeat,
+				Owner:           "",
+			},
+		},
+		{
+			name:          "config owner with surrounding whitespace is trimmed",
+			cfg:           Config{Owner: "  cfg-owner  "},
+			replicaID:     "replica-1",
+			expectedOwner: "cfg-owner",
+			expected: Config{
+				TTL:             defaultTTL,
+				AcquireBackoff:  defaultAcquireBackoff,
+				AcquireDeadline: defaultAcquireDeadline,
+				Heartbeat:       defaultHeartbeat,
+				Owner:           "cfg-owner",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.cfg.withDefaults(test.replicaID)
+			assert.Equal(t, test.expected, got)
+			assert.Equal(t, test.expectedOwner, got.Owner)
+		})
+	}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		owner   string
+		wantErr bool
+	}{
+		{name: "non-empty owner", owner: "replica-1", wantErr: false},
+		{name: "owner with inner spaces", owner: "replica 1", wantErr: false},
+		{name: "empty owner", owner: "", wantErr: true},
+		{name: "blank owner", owner: "   ", wantErr: true},
+		{name: "tab and newline owner", owner: "\t\n", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := Config{Owner: test.owner}.validate()
+			if !test.wantErr {
+				require.NoError(t, err)
+
+				return
+			}
+			require.ErrorIs(t, err, errs.ErrLockerOwnerRequired)
+			// the message must point the operator at both remedies
+			assert.Contains(t, err.Error(), "auditor.locker.postgres.owner")
+			assert.Contains(t, err.Error(), "fsc.id")
+		})
+	}
+}

--- a/token/services/storage/auditdb/locker/postgres/postgres.go
+++ b/token/services/storage/auditdb/locker/postgres/postgres.go
@@ -46,6 +46,13 @@ type lockSession struct {
 
 // New creates a Postgres-backed distributed Locker.
 // The table is created if it does not exist. db must be a *sql.DB connected to Postgres.
+//
+// cfg.Owner defaults to the identifier reported by replicaID (the FSC node ID in
+// production). It returns an error wrapping errs.ErrLockerOwnerRequired when the
+// resolved owner is empty or blank — including when replicaID is nil or reports
+// an empty ID — because an owner shared by several replicas disables mutual
+// exclusion across all of them. That check runs before the table is created, so
+// a misconfigured node fails without touching the database.
 func New(db *sql.DB, table string, cfg Config, replicaID id.ReplicaIDProvider) (*Locker, error) {
 	if db == nil {
 		return nil, errors.New("postgres locker requires a non-nil *sql.DB")
@@ -55,6 +62,9 @@ func New(db *sql.DB, table string, cfg Config, replicaID id.ReplicaIDProvider) (
 		owner = replicaID.ID()
 	}
 	cfg = cfg.withDefaults(owner)
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
 	l := &Locker{
 		db:       db,
 		table:    table,
@@ -65,6 +75,7 @@ func New(db *sql.DB, table string, cfg Config, replicaID id.ReplicaIDProvider) (
 	if err := l.createSchema(); err != nil {
 		return nil, err
 	}
+	logger.Infof("postgres auditor locker for table [%s] locking as owner [%s]", table, cfg.Owner)
 
 	return l, nil
 }

--- a/token/services/storage/auditdb/locker/postgres/postgres_test.go
+++ b/token/services/storage/auditdb/locker/postgres/postgres_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/LFDT-Panurus/panurus/token/services/storage/auditdb/locker/errs"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/auditdb/locker/id"
 	lockerpostgres "github.com/LFDT-Panurus/panurus/token/services/storage/auditdb/locker/postgres"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/postgres"
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -24,6 +25,18 @@ import (
 type stubReplicaID struct{ id string }
 
 func (s stubReplicaID) ID() string { return s.id }
+
+// unconnectedDB returns a valid, non-nil *sql.DB that is never dialled: the
+// DSN parses but points nowhere. Owner validation happens before any query, so
+// construction-time failures can be asserted without a live database.
+func unconnectedDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("pgx", "postgres://user:pass@127.0.0.1:1/none")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	return db
+}
 
 func startPostgres(t *testing.T) *sql.DB {
 	t.Helper()
@@ -128,7 +141,82 @@ func TestLocker_ConcurrentNonOverlapping(t *testing.T) {
 	wg.Wait()
 }
 
+func TestLocker_OwnerScopingAcrossReplicas(t *testing.T) {
+	db := startPostgres(t)
+	table := "test_eid_lease_os"
+	cleanTable(t, db, table)
+	t.Cleanup(func() { cleanTable(t, db, table) })
+
+	cfg := lockerpostgres.Config{
+		TTL: 30 * time.Second, AcquireBackoff: 50 * time.Millisecond,
+		AcquireDeadline: 200 * time.Millisecond, Heartbeat: 10 * time.Second,
+	}
+	cfg.Owner = "owner-1"
+	l1 := newLocker(t, db, table, cfg)
+	cfg.Owner = "owner-2"
+	l2 := newLocker(t, db, table, cfg)
+
+	ctx := context.Background()
+	require.NoError(t, l1.AcquireLocks(ctx, "anchor1", "alice"))
+
+	// owner-2 must not be able to release owner-1's leases, even for the same anchor
+	l2.ReleaseLocks(ctx, "anchor1")
+
+	var count int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM "+table+" WHERE anchor = $1 AND owner = $2", "anchor1", "owner-1").Scan(&count))
+	assert.Equal(t, 1, count, "owner-2 released a lease it does not own")
+	require.NoError(t, l1.AssertLocksHeld(ctx, "anchor1"))
+
+	l1.ReleaseLocks(ctx, "anchor1")
+}
+
 func TestLocker_NilDB(t *testing.T) {
 	_, err := lockerpostgres.New(nil, "t", lockerpostgres.Config{}, stubReplicaID{id: "owner"})
 	require.Error(t, err)
+}
+
+func TestLocker_OwnerRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfgOwner  string
+		replicaID id.ReplicaIDProvider
+	}{
+		{name: "empty config owner and empty replica id", cfgOwner: "", replicaID: stubReplicaID{id: ""}},
+		{name: "nil replica id provider", cfgOwner: "", replicaID: nil},
+		{name: "blank config owner and blank replica id", cfgOwner: "   ", replicaID: stubReplicaID{id: "  "}},
+		{name: "blank replica id", cfgOwner: "", replicaID: stubReplicaID{id: " \t"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			l, err := lockerpostgres.New(
+				unconnectedDB(t),
+				"test_eid_lease_owner",
+				lockerpostgres.Config{Owner: test.cfgOwner},
+				test.replicaID,
+			)
+			require.ErrorIs(t, err, errs.ErrLockerOwnerRequired)
+			assert.Nil(t, l)
+		})
+	}
+}
+
+func TestLocker_OwnerFromReplicaID(t *testing.T) {
+	db := startPostgres(t)
+	table := "test_eid_lease_orid"
+	cleanTable(t, db, table)
+	t.Cleanup(func() { cleanTable(t, db, table) })
+
+	// no cfg.Owner: the replica id is used as the lease owner
+	l, err := lockerpostgres.New(db, table, lockerpostgres.Config{
+		TTL: 5 * time.Second, Heartbeat: 2 * time.Second,
+	}, stubReplicaID{id: "replica-7"})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, l.AcquireLocks(ctx, "anchor1", "alice"))
+	t.Cleanup(func() { l.ReleaseLocks(ctx, "anchor1") })
+
+	var owner string
+	require.NoError(t, db.QueryRow("SELECT owner FROM "+table+" WHERE eid = $1", "alice").Scan(&owner))
+	assert.Equal(t, "replica-7", owner)
 }


### PR DESCRIPTION
Fixes #2035

## What

The Postgres audit locker resolved its lease `owner` with no validation. `Config.withDefaults` fell back to the replica ID without checking the result was non-empty, and `New` accepted a nil `ReplicaIDProvider` or one reporting `""`. In production that provider is the FSC config provider, whose `ID()` is a bare `fsc.id` lookup — so a templated or cloned node config with `fsc.id` unset left every replica with `owner = ""`.

The owner scopes **every** lease query — the acquire upsert, `releaseAnchor`, `AssertLocksHeld` and `renewLeases` all compare against it. A shared empty owner therefore makes those predicates match rows belonging to *other* replicas: a replica can release or renew leases it does not hold, and `AssertLocksHeld` can be satisfied by a foreign row. Mutual exclusion is lost cluster-wide with no error, warning, or log line.

## Change

- Validate the resolved owner in `postgres.New`, **before** the lease table is created, returning an error wrapping the new `errs.ErrLockerOwnerRequired` and naming both remedies (`...auditor.locker.postgres.owner` or `fsc.id`).
- Blank-after-`TrimSpace` counts as empty — a whitespace-only `fsc.id` is just as broken and just as silent.
- Log the resolved owner once at construction, so a healthy replica leaves a positive trace of the identity it locks under.
- Docs: `docs/services/auditor.md` gains a *Replica owner identity* section (resolution order, failure mode, rationale); `docs/configuration.md` records the requirement and the exact error string.

Deliberately **not** synthesizing a fallback owner (UUID/hostname): an owner that changed on each restart would leave a restarted replica unable to renew or release the leases it still holds, trading a loud misconfiguration for a quiet correctness bug.

## ⚠️ Behaviour change

A node running `backend: postgres` with an empty resolved owner starts today and will now fail to build its audit store. That is the intended fix — such a node is already broken, it just fails silently — but it is worth calling out for operators. The `memory` backend (the default) has no owner concept and is unaffected.

## Out of scope

- #2033 — the `owner = excluded.owner` self-theft in the acquire `WHERE` clause. That predicate is untouched here; the new owner-scoping test is written so it stays valid either way.
- #2040 — empty-EID semantics, memory-locker key namespacing, doubled retry loops.

## Tests

New, all passing:
- `postgres/config_test.go` — table-driven `withDefaults` (defaulting, precedence, negative durations) and `validate` (empty / blank / tab-newline / inner-spaces).
- `postgres/postgres_test.go` — `TestLocker_OwnerRequired` (empty owner, nil provider, blank owner, blank replica ID), `TestLocker_OwnerFromReplicaID`, and `TestLocker_OwnerScopingAcrossReplicas`, which pins the property the empty-owner default destroyed: owner-2 cannot release owner-1's lease. The validation cases need no live Postgres, since validation precedes `createSchema`.
- `locker/factory_test.go` — new file; confirms the owner requirement stays Postgres-only (memory / `""` / `DefaultConfig` still build with an empty replica ID) and pins the existing backend-selection errors.

`make checks`, `make lint`, and `make lint-auto-fix` all clean. `go test ./token/services/storage/auditdb/...` passes, including the Docker-backed Postgres suite (9/9).
