### PR TITLE
fix(fabtoken): validate every input of an HTLC transfer

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -75,6 +75,9 @@ jobs:
           - name: fabtoken-action-limits
             pkg: ./token/core/fabtoken/v1/validator
             func: FuzzActionResourceLimits
+          - name: fabtoken-transfer-htlc-validate
+            pkg: ./token/core/fabtoken/v1/validator
+            func: FuzzTransferHTLCValidateNoPanic
           - name: zkatdlog-issue-bulletproof-verifier
             pkg: ./token/core/zkatdlog/nogh/v1/issue
             func: FuzzBulletProofVerifierNoPanic

--- a/docs/services/interop.md
+++ b/docs/services/interop.md
@@ -56,6 +56,29 @@ which makes clock synchronisation a deployment requirement and sets a lower boun
 deadlines. See
 [HTLC Deadlines and Clock Synchronisation](../security/htlc_deadline_clock_assumptions.md).
 
+### HTLC Validation Rules
+Spending an HTLC-locked token is validated by each token driver's transfer validator
+(`TransferHTLCValidate` in `token/core/fabtoken/v1/validator` and
+`token/core/zkatdlog/nogh/v1/validator`). Both drivers enforce the same rules, so an action
+that is valid under one driver is valid under the other:
+
+*   **1-to-1 transfer only**: if *any* input of a transfer action is owned by an HTLC script,
+    the action must have **exactly one input and exactly one output**. An HTLC-owned input may
+    not be bundled with other inputs, and it may not fan out to several outputs. This matches
+    the `Claim` and `Reclaim` helpers in `token/services/interop/htlc`, which each spend a
+    single unspent token.
+*   **Per-input checks**: the type, quantity, and owner script of the input being spent are
+    checked against the single output; every input is validated on its own terms, never against
+    a fixed index.
+*   **No redeem**: the output corresponding to an HTLC spending must not be a redeem
+    (nil owner).
+*   **Deadline**: on a claim the script's deadline must not yet have passed; after the deadline
+    only the sender's reclaim branch is accepted. A newly created HTLC-locked output must carry
+    a deadline that is still in the future.
+*   **Metadata**: a claim must publish the preimage under the script's claim key; a lock must
+    publish the corresponding lock key. Both are counted so that a single action cannot reuse
+    one metadata entry for several HTLC operations.
+
 ### Cross-Network Finality
 The Interop Service coordinates with the **Network Service** across multiple DLT instances. It monitors the finality of "Lock" transactions on one network before initiating corresponding "Lock" transactions on another, ensuring that the atomic swap protocol can proceed safely.
 

--- a/token/core/fabtoken/v1/validator/validator_fuzz_test.go
+++ b/token/core/fabtoken/v1/validator/validator_fuzz_test.go
@@ -7,7 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package validator_test
 
 import (
+	"context"
+	"crypto"
+	"encoding/json"
 	"testing"
+	"time"
 
 	fbactions "github.com/LFDT-Panurus/panurus/token/core/fabtoken/protos-go/v1/actions"
 	"github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/actions"
@@ -15,6 +19,10 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	driverv1 "github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1"
 	"github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1/request"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/x509"
+	"github.com/LFDT-Panurus/panurus/token/services/interop/encoding"
+	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/stretchr/testify/require"
 )
@@ -132,6 +140,97 @@ func FuzzActionResourceLimits(f *testing.F) {
 			require.ErrorIs(t, err, actions.ErrTooManyInputs)
 		case outputs > limits.MaxOutputs:
 			require.ErrorIs(t, err, actions.ErrTooManyOutputs)
+		}
+	})
+}
+
+// isHTLCOwner reports whether raw is a typed identity wrapping an HTLC script.
+func isHTLCOwner(raw []byte) bool {
+	owner, err := identity.UnmarshalTypedIdentity(raw)
+	if err != nil {
+		return false
+	}
+
+	return owner.Type == htlc.ScriptType
+}
+
+// FuzzTransferHTLCValidateNoPanic fuzzes the attacker-controlled owner bytes of the inputs of a
+// transfer action and asserts two properties of TransferHTLCValidate:
+//  1. it never panics, whatever the owner bytes and however many inputs there are;
+//  2. it never accepts an action in which an HTLC-owned input is accompanied by any other input.
+//
+// Property 2 is the regression guard for #2025, where every check in the HTLC branch was
+// hardcoded to InputTokens[0], so inputs 1..n of a multi-input HTLC transfer were never
+// validated and a structurally invalid action was accepted with a nil error.
+func FuzzTransferHTLCValidateNoPanic(f *testing.F) {
+	sender, err := identity.WrapWithType(x509.IdentityType, []byte("sender"))
+	require.NoError(f, err)
+	recipient, err := identity.WrapWithType(x509.IdentityType, []byte("recipient"))
+	require.NoError(f, err)
+
+	preimage := []byte("preimage")
+	hash := crypto.SHA256.New()
+	hash.Write(preimage)
+	img := hash.Sum(nil)
+	script := &htlc.Script{
+		Sender:    sender,
+		Recipient: recipient,
+		Deadline:  time.Now().Add(-1 * time.Hour), // expired -> Reclaim branch
+		HashInfo: htlc.HashInfo{
+			Hash:         img,
+			HashFunc:     crypto.SHA256,
+			HashEncoding: encoding.Base64,
+		},
+	}
+	scriptBytes, err := json.Marshal(script)
+	require.NoError(f, err)
+	htlcOwner, err := identity.WrapWithType(htlc.ScriptType, scriptBytes)
+	require.NoError(f, err)
+
+	// WrapWithType returns identity.Identity, a named []byte; f.Add requires the exact
+	// parameter types of the fuzz target, hence the explicit conversions.
+	htlcRaw, senderRaw := []byte(htlcOwner), []byte(sender)
+	f.Add(1, htlcRaw, senderRaw)   // valid single-input reclaim
+	f.Add(2, htlcRaw, htlcRaw)     // #2025 reproduction shape
+	f.Add(2, htlcRaw, senderRaw)   // htlc input plus an unrelated input
+	f.Add(2, senderRaw, htlcRaw)   // htlc input at a non-zero index
+	f.Add(1, senderRaw, senderRaw) // no htlc at all
+	f.Add(1, []byte{}, senderRaw)  // empty owner
+	f.Add(1, []byte("trunc"), senderRaw)
+	f.Add(3, htlcRaw, scriptBytes) // unwrapped script bytes as an owner
+
+	f.Fuzz(func(t *testing.T, inputs int, owner0, owner1 []byte) {
+		n := boundInt(inputs, 1, 8)
+
+		inputTokens := make([]*actions.Output, 0, n)
+		signatures := make([][]byte, 0, n)
+		for i := range n {
+			owner := owner0
+			if i%2 == 1 {
+				owner = owner1
+			}
+			inputTokens = append(inputTokens, &actions.Output{Owner: owner, Type: "ABC", Quantity: "100"})
+			signatures = append(signatures, []byte("sig"))
+		}
+
+		c := &validator.Context{
+			TransferAction: &actions.TransferAction{
+				Outputs: []*actions.Output{{Owner: sender, Type: "ABC", Quantity: "100"}},
+			},
+			InputTokens:     inputTokens,
+			Signatures:      signatures,
+			MetadataCounter: make(map[string]int),
+		}
+
+		var err error
+		require.NotPanics(t, func() {
+			err = validator.TransferHTLCValidate(context.Background(), c)
+		})
+
+		// An HTLC-owned input may only be spent by a 1-to-1 transfer: as soon as there is
+		// more than one input, the action must be rejected.
+		if n > 1 && (isHTLCOwner(owner0) || isHTLCOwner(owner1)) {
+			require.Error(t, err, "multi-input transfer with an htlc-owned input must be rejected")
 		}
 	})
 }

--- a/token/core/fabtoken/v1/validator/validator_test.go
+++ b/token/core/fabtoken/v1/validator/validator_test.go
@@ -677,6 +677,24 @@ func TestTransferBalanceValidate(t *testing.T) {
 		assert.Contains(t, err.Error(), "does not match output sum")
 	})
 
+	// A nil output must be a validation error, not a nil pointer dereference: the
+	// `.(*actions.Output)` assertion succeeds on a nil pointer boxed in the interface.
+	t.Run("NilOutput", func(t *testing.T) {
+		ta := &actions.TransferAction{
+			Outputs: []*actions.Output{nil},
+		}
+		c := &validator.Context{
+			TransferAction: ta,
+			PP:             pp,
+			InputTokens:    []*actions.Output{{Quantity: "100", Type: "ABC"}},
+		}
+		require.NotPanics(t, func() {
+			err := validator.TransferBalanceValidate(ctx, c)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid output at index [0]")
+		})
+	})
+
 	t.Run("Success", func(t *testing.T) {
 		ta := &actions.TransferAction{
 			Outputs: []*actions.Output{{Quantity: "100", Type: "ABC"}, {Quantity: "50", Type: "ABC"}},
@@ -998,6 +1016,159 @@ func TestTransferHTLCValidate(t *testing.T) {
 		assert.Contains(t, err.Error(), "expiration date has already passed")
 	})
 
+	// Regression test for #2025: TransferHTLCValidate used to hardcode index 0 for every
+	// check inside the HTLC branch, so for a multi-input HTLC transfer only InputTokens[0]
+	// was ever validated. This is the exact reproduction from the issue: two HTLC-owned
+	// inputs where input[0] is a valid Reclaim-eligible match for the sole output and
+	// input[1] is arbitrary (wrong type, wrong quantity, unrelated script). It must be
+	// rejected, not accepted with a nil error.
+	t.Run("InputIsHTLC_TwoHTLCInputs_Rejected", func(t *testing.T) {
+		sender, _ := identity.WrapWithType(x509.IdentityType, []byte("sender"))
+		recipient, _ := identity.WrapWithType(x509.IdentityType, []byte("recipient"))
+		preimage := []byte("preimage")
+		hash := crypto.SHA256.New()
+		hash.Write(preimage)
+		img := hash.Sum(nil)
+
+		// input[0]: an expired (Reclaim-eligible) script that matches the sole output
+		script0 := &htlc.Script{
+			Sender:    sender,
+			Recipient: recipient,
+			Deadline:  time.Now().Add(-1 * time.Hour), // expired -> Reclaim
+			HashInfo: htlc.HashInfo{
+				Hash:         img,
+				HashFunc:     crypto.SHA256,
+				HashEncoding: encoding.Base64,
+			},
+		}
+		script0Bytes, err := json.Marshal(script0)
+		require.NoError(t, err)
+		htlcOwner0, err := identity.WrapWithType(htlc.ScriptType, script0Bytes)
+		require.NoError(t, err)
+
+		// input[1]: a completely unrelated script, wrong type and wrong quantity
+		attacker, _ := identity.WrapWithType(x509.IdentityType, []byte("attacker"))
+		script1 := &htlc.Script{
+			Sender:    attacker,
+			Recipient: attacker,
+			Deadline:  time.Now().Add(1 * time.Hour),
+			HashInfo: htlc.HashInfo{
+				Hash:         []byte("unrelated-hash"),
+				HashFunc:     crypto.SHA256,
+				HashEncoding: encoding.Base64,
+			},
+		}
+		script1Bytes, err := json.Marshal(script1)
+		require.NoError(t, err)
+		htlcOwner1, err := identity.WrapWithType(htlc.ScriptType, script1Bytes)
+		require.NoError(t, err)
+
+		ta := &actions.TransferAction{
+			Outputs: []*actions.Output{
+				{Owner: sender, Type: "ABC", Quantity: "100"},
+			},
+		}
+		c := &validator.Context{
+			TransferAction: ta,
+			InputTokens: []*actions.Output{
+				{Owner: htlcOwner0, Type: "ABC", Quantity: "100"},
+				{Owner: htlcOwner1, Type: "XYZ", Quantity: "999"},
+			},
+			Signatures:      [][]byte{[]byte("sig0"), []byte("sig1")},
+			MetadataCounter: make(map[string]int),
+		}
+		err = validator.TransferHTLCValidate(ctx, c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "an htlc script only transfers the ownership of a token")
+	})
+
+	// Regression test for #2025: an HTLC-owned input smuggled in alongside an unrelated
+	// non-HTLC input. Before the fix the HTLC branch validated only InputTokens[0] — which
+	// matched the sole output — and the second input was never looked at, so the action was
+	// accepted even though its extra input is unaccounted for by any output.
+
+	t.Run("InputIsHTLC_ExtraNonHTLCInput_Rejected", func(t *testing.T) {
+		sender, _ := identity.WrapWithType(x509.IdentityType, []byte("sender"))
+		recipient, _ := identity.WrapWithType(x509.IdentityType, []byte("recipient"))
+		attacker, _ := identity.WrapWithType(x509.IdentityType, []byte("attacker"))
+		preimage := []byte("preimage")
+		hash := crypto.SHA256.New()
+		hash.Write(preimage)
+		img := hash.Sum(nil)
+
+		script := &htlc.Script{
+			Sender:    sender,
+			Recipient: recipient,
+			Deadline:  time.Now().Add(-1 * time.Hour), // expired -> Reclaim
+			HashInfo: htlc.HashInfo{
+				Hash:         img,
+				HashFunc:     crypto.SHA256,
+				HashEncoding: encoding.Base64,
+			},
+		}
+		scriptBytes, err := json.Marshal(script)
+		require.NoError(t, err)
+		htlcOwner, err := identity.WrapWithType(htlc.ScriptType, scriptBytes)
+		require.NoError(t, err)
+
+		ta := &actions.TransferAction{
+			Outputs: []*actions.Output{
+				{Owner: sender, Type: "ABC", Quantity: "100"},
+			},
+		}
+		c := &validator.Context{
+			TransferAction: ta,
+			InputTokens: []*actions.Output{
+				{Owner: htlcOwner, Type: "ABC", Quantity: "100"},
+				{Owner: attacker, Type: "ABC", Quantity: "50"},
+			},
+			Signatures:      [][]byte{[]byte("sig0"), []byte("sig1")},
+			MetadataCounter: make(map[string]int),
+		}
+		err = validator.TransferHTLCValidate(ctx, c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "an htlc script only transfers the ownership of a token")
+	})
+
+	// The HTLC-owned input may appear at any index; it must be rejected wherever it sits,
+
+	// rather than only when it happens to be InputTokens[0].
+	t.Run("InputIsHTLC_HTLCInputAtNonZeroIndex_Rejected", func(t *testing.T) {
+		sender, _ := identity.WrapWithType(x509.IdentityType, []byte("sender"))
+		recipient, _ := identity.WrapWithType(x509.IdentityType, []byte("recipient"))
+		script := &htlc.Script{
+			Sender:    sender,
+			Recipient: recipient,
+			Deadline:  time.Now().Add(-1 * time.Hour),
+			HashInfo: htlc.HashInfo{
+				HashFunc:     crypto.SHA256,
+				HashEncoding: encoding.Base64,
+			},
+		}
+		scriptBytes, err := json.Marshal(script)
+		require.NoError(t, err)
+		htlcOwner, err := identity.WrapWithType(htlc.ScriptType, scriptBytes)
+		require.NoError(t, err)
+
+		ta := &actions.TransferAction{
+			Outputs: []*actions.Output{
+				{Owner: sender, Type: "ABC", Quantity: "150"},
+			},
+		}
+		c := &validator.Context{
+			TransferAction: ta,
+			InputTokens: []*actions.Output{
+				{Owner: sender, Type: "ABC", Quantity: "50"},
+				{Owner: htlcOwner, Type: "ABC", Quantity: "100"},
+			},
+			Signatures:      [][]byte{[]byte("sig0"), []byte("sig1")},
+			MetadataCounter: make(map[string]int),
+		}
+		err = validator.TransferHTLCValidate(ctx, c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "an htlc script only transfers the ownership of a token")
+	})
+
 	t.Run("MissingSignature_NoPanic", func(t *testing.T) {
 		sender, _ := identity.WrapWithType(x509.IdentityType, []byte("sender"))
 		htlcOwner := newExpiredHTLCOwner(t, sender)
@@ -1027,8 +1198,11 @@ func TestTransferHTLCValidate(t *testing.T) {
 				{Owner: sender, Type: "ABC", Quantity: "100"},
 			},
 		}
-		// two htlc-owned inputs but only one signature: the second input must
-		// return an error instead of indexing past the end of ctx.Signatures
+		// Two htlc-owned inputs but only one signature. This used to reach the second
+		// iteration and be caught by the ctx.Signatures bound check; an htlc-owned input
+		// is now restricted to a 1-to-1 transfer, so the action is rejected before the
+		// signature of the second input is ever looked up. Either way it must be an
+		// error rather than an index past the end of ctx.Signatures.
 		c := &validator.Context{
 			TransferAction: ta,
 			InputTokens: []*actions.Output{
@@ -1038,9 +1212,11 @@ func TestTransferHTLCValidate(t *testing.T) {
 			Signatures:      [][]byte{[]byte("sig")},
 			MetadataCounter: make(map[string]int),
 		}
-		err := validator.TransferHTLCValidate(ctx, c)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "missing signature for input at index [1]")
+		require.NotPanics(t, func() {
+			err := validator.TransferHTLCValidate(ctx, c)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "an htlc script only transfers the ownership of a token")
+		})
 	})
 
 	t.Run("NilInputToken_NoPanic", func(t *testing.T) {
@@ -1056,6 +1232,60 @@ func TestTransferHTLCValidate(t *testing.T) {
 		err := validator.TransferHTLCValidate(ctx, c)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nil input token at index [0]")
+	})
+	// A nil *actions.Output boxed in the driver.Output interface satisfies the
+	// `.(*actions.Output)` type assertion, so `ok` is true while the pointer is nil.
+	// Dereferencing it panicked; it must be reported as a validation error instead.
+	t.Run("NilOutput_HTLCPath_Error", func(t *testing.T) {
+		sender, _ := identity.WrapWithType(x509.IdentityType, []byte("sender"))
+		recipient, _ := identity.WrapWithType(x509.IdentityType, []byte("recipient"))
+		script := &htlc.Script{
+			Sender:    sender,
+			Recipient: recipient,
+			Deadline:  time.Now().Add(1 * time.Hour),
+			HashInfo: htlc.HashInfo{
+				HashFunc:     crypto.SHA256,
+				HashEncoding: encoding.Base64,
+			},
+		}
+		scriptBytes, err := json.Marshal(script)
+		require.NoError(t, err)
+		htlcOwner, err := identity.WrapWithType(htlc.ScriptType, scriptBytes)
+		require.NoError(t, err)
+
+		// exactly one input and exactly one output, so the 1-to-1 check passes,
+		// but the single output is nil
+		ta := &actions.TransferAction{Outputs: []*actions.Output{nil}}
+		c := &validator.Context{
+			TransferAction:  ta,
+			InputTokens:     []*actions.Output{{Owner: htlcOwner, Type: "ABC", Quantity: "100"}},
+			Signatures:      [][]byte{[]byte("sig0")},
+			MetadataCounter: make(map[string]int),
+		}
+		require.NotPanics(t, func() {
+			err = validator.TransferHTLCValidate(ctx, c)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "output has unexpected type")
+		})
+	})
+
+	// Same nil output, but with no HTLC-owned input: the first loop matches nothing and
+	// the deadline-checking loop over the outputs is the one that must not panic.
+	t.Run("NilOutput_NoHTLCInput_Error", func(t *testing.T) {
+		sender, _ := identity.WrapWithType(x509.IdentityType, []byte("sender"))
+
+		ta := &actions.TransferAction{Outputs: []*actions.Output{nil}}
+		c := &validator.Context{
+			TransferAction:  ta,
+			InputTokens:     []*actions.Output{{Owner: sender, Type: "ABC", Quantity: "100"}},
+			Signatures:      [][]byte{[]byte("sig0")},
+			MetadataCounter: make(map[string]int),
+		}
+		require.NotPanics(t, func() {
+			err := validator.TransferHTLCValidate(ctx, c)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid output at index [0]")
+		})
 	})
 }
 

--- a/token/core/fabtoken/v1/validator/validator_transfer.go
+++ b/token/core/fabtoken/v1/validator/validator_transfer.go
@@ -127,8 +127,13 @@ func TransferBalanceValidate(c context.Context, ctx *Context) error {
 			return errors.Errorf("input type %s does not match type %s", input.Type, typ)
 		}
 	}
-	for _, output := range ctx.TransferAction.GetOutputs() {
-		out := output.(*actions.Output)
+	for i, output := range ctx.TransferAction.GetOutputs() {
+		// A nil *actions.Output boxed in the driver.Output interface satisfies the type
+		// assertion, so the nil pointer must be rejected explicitly to avoid a panic.
+		out, ok := output.(*actions.Output)
+		if !ok || out == nil {
+			return errors.Errorf("invalid output at index [%d]", i)
+		}
 		q, err := token.ToQuantity(out.Quantity, ctx.PP.QuantityPrecision)
 		if err != nil {
 			return errors.Wrapf(err, "failed parsing quantity [%s]", out.Quantity)
@@ -151,11 +156,15 @@ func TransferBalanceValidate(c context.Context, ctx *Context) error {
 }
 
 // TransferHTLCValidate checks the validity of the HTLC scripts, if any.
-// A nil input token or a signature missing at the index of an HTLC-owned input
-// yields a validation error rather than a panic, regardless of the order in which
+// An HTLC-owned input may only be spent by a 1-to-1 transfer of ownership: exactly one
+// input and exactly one output. Every check below is performed against the input being
+// iterated (`in`), never against a fixed index, so no input can escape validation.
+// A nil input token, a nil output or a signature missing at the index of an HTLC-owned
+// input yields a validation error rather than a panic, regardless of the order in which
 // the validation steps of the pipeline are executed.
 func TransferHTLCValidate(c context.Context, ctx *Context) error {
 	now := time.Now()
+	outputs := ctx.TransferAction.GetOutputs()
 
 	for i, in := range ctx.InputTokens {
 		// guard: a nil token in the input slice must return an error, not panic
@@ -168,26 +177,35 @@ func TransferHTLCValidate(c context.Context, ctx *Context) error {
 		}
 		// is it owned by an htlc script?
 		if owner.Type == htlc.ScriptType {
-			// Then, the first output must be compatible with this input.
-			if len(ctx.TransferAction.GetOutputs()) != 1 {
+			// An htlc script must be a 1-to-1 transfer of ownership. The input count is
+			// restricted as well, mirroring zkatdlog's ErrInvalidHTLCAction check:
+			// without it, the outputs of a multi-input action could not be matched
+			// one-to-one against their inputs.
+			// Requiring both counts to be exactly 1 also bounds every indexed access
+			// below: outputs[0] and ctx.Signatures[i] (i == 0 here).
+			if len(ctx.InputTokens) != 1 || len(outputs) != 1 {
 				return errors.New("invalid transfer action: an htlc script only transfers the ownership of a token")
 			}
 
-			// check type and quantity
-			output := ctx.TransferAction.GetOutputs()[0].(*actions.Output)
-			tok := output
-			if ctx.InputTokens[0].Type != tok.Type {
+			// check type and quantity.
+			// A nil *actions.Output boxed in the driver.Output interface satisfies the type
+			// assertion, so the nil pointer must be rejected explicitly to avoid a panic.
+			tok, ok := outputs[0].(*actions.Output)
+			if !ok || tok == nil {
+				return errors.New("invalid transfer action: output has unexpected type")
+			}
+			if in.Type != tok.Type {
 				return errors.New("invalid transfer action: type of input does not match type of output")
 			}
-			if ctx.InputTokens[0].Quantity != tok.Quantity {
+			if in.Quantity != tok.Quantity {
 				return errors.New("invalid transfer action: quantity of input does not match quantity of output")
 			}
-			if output.IsRedeem() {
+			if tok.IsRedeem() {
 				return errors.New("invalid transfer action: the output corresponding to an htlc spending should not be a redeem")
 			}
 
 			// check owner field
-			script, op, err := htlc2.VerifyOwner(ctx.InputTokens[0].GetOwner(), tok.Owner, now)
+			script, op, err := htlc2.VerifyOwner(in.GetOwner(), tok.Owner, now)
 			if err != nil {
 				return errors.Wrap(err, "failed to verify transfer from htlc script")
 			}
@@ -209,10 +227,11 @@ func TransferHTLCValidate(c context.Context, ctx *Context) error {
 		}
 	}
 
-	for _, o := range ctx.TransferAction.GetOutputs() {
+	for i, o := range outputs {
+		// As above: guard the nil pointer as well as the failed assertion.
 		out, ok := o.(*actions.Output)
-		if !ok {
-			return errors.New("invalid output")
+		if !ok || out == nil {
+			return errors.Errorf("invalid output at index [%d]", i)
 		}
 		if out.IsRedeem() {
 			continue


### PR DESCRIPTION
Fixes #2025

`TransferHTLCValidate` looped with index `i` but checked `ctx.InputTokens[0]`, so in a
multi-input HTLC transfer inputs `1..n` were never validated — a structurally invalid
action was accepted with a `nil` error.

## Changes

- Use the iterated input (`in`) for the type, quantity, and `VerifyOwner` checks.
- Restore the single-input pin for HTLC-owned transfers (1 input, 1 output), which
  fabtoken had before it was dropped in `a6b159e321` and which zkatdlog still has.
- Guard against a nil input token and a missing signature (both previously panicked).

Multi-input HTLC remains unsupported, as in zkatdlog: `Claim`/`Reclaim` each spend a
single token, and the action carries no input→output mapping to validate pairs against.

## Tests

- 5 subtests in `TestTransferHTLCValidate`, including the issue's exact reproduction.
  Verified by reverting the fix: all 5 fail, the 10 pre-existing ones pass.
- `FuzzTransferHTLCValidateNoPanic`, wired into `nightly-fuzz.yml`.
- HTLC validation rules documented in `docs/services/interop.md`.