### PR TITLE
fix(identity): reject trailing-byte and non-canonical DER in identity decode paths (#2071)

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -57,6 +57,12 @@ jobs:
           - name: identity-multisig-signature-from-bytes
             pkg: ./token/services/identity/multisig
             func: FuzzMultiSignatureFromBytesNoPanic
+          - name: identity-boolpolicy-identity-deserializer
+            pkg: ./token/services/identity/boolpolicy
+            func: FuzzPolicyIdentityDeserializeNoPanic
+          - name: identity-boolpolicy-signature-from-bytes
+            pkg: ./token/services/identity/boolpolicy
+            func: FuzzPolicySignatureFromBytesNoPanic
           - name: identity-idemix-audit-info-deserializer
             pkg: ./token/services/identity/idemix/crypto
             func: FuzzDeserializeAuditInfoNoPanic

--- a/docs/services/identity.md
+++ b/docs/services/identity.md
@@ -269,6 +269,46 @@ It wraps the raw identity bytes with a type label, enabling the system to verify
     - `Type` (string): The identifier of the identity scheme (e.g., `"x509"`, `"idemix"`).
     - `Identity` (bytes): The raw payload of the identity, specific to the key manager.
 
+#### Canonical encoding requirement
+
+The **DER envelopes** of an identity must be the canonical encoding of the value they decode to — exactly one byte string per logical envelope:
+
+*   `marshal.DecodeIdentity` (the `TypedIdentity` envelope decoder in `token/services/identity/marshal`) pins the outer `SEQUENCE`'s declared length to the end of the buffer, requires the read position to land exactly on the last byte after the final field (`ErrTrailingBytes`), rejects non-minimal DER length encodings — a length that fits the short form written in the long form, or a long form with leading zero bytes (`ErrNonMinimalLen`) — and rejects non-minimal `INTEGER` contents, i.e. a redundant leading `0x00`/`0xFF` in the type field (`ErrNonMinimalInt`).
+*   Envelopes decoded with `encoding/asn1` (`MultiIdentity`, `PolicyIdentity`, `MultiSignature`, `PolicySignature`) go through `marshal.UnmarshalCanonicalDER`, which rejects any bytes left over after the top-level value **and** re-encodes the decoded value to require it reproduces the input byte-for-byte (`ErrNonCanonical`). The second check is the load-bearing one: `asn1.Unmarshal`'s `rest` return only reports bytes *after* the top-level TLV, while `encoding/asn1` silently discards `SEQUENCE` elements the destination struct has no field for and accepts `T61String`/`IA5String`/`GeneralString` where a `UTF8String` was declared — neither of which leaves anything in `rest`.
+
+The reason is `Identity.UniqueID()`: it hashes the **raw** identity bytes rather than a canonicalised form of the decoded value, and it is the cache key throughout the identity and wallet layers (`role/registry.go`'s fast-path cache, `provider.go`'s signer cache, and so on). Any two byte strings that decode to the same logical identity but hash differently give that one identity two cache slots — a token paid to the second spelling still verifies, because verification works on the decoded value, but never resolves to its owner's wallet, because the lookup works on `UniqueID()`. Both producers of these bytes — `appendTLV` in the `marshal` package and `encoding/asn1.Marshal` for legacy encodings — already emit minimal lengths, minimal integers and no undeclared elements, so the stricter decode rejects nothing this tree ever writes. That last statement is about data written by *this* encoder — see **Upgrade considerations** below for bytes that are already persisted.
+
+**What this does not cover.** The guarantee is about the envelopes, not about everything reachable through them:
+
+*   **The legacy type spellings remain a `UniqueID()` split, and it is the same class of problem as the one above.** `DecodeIdentity` folds `INTEGER 2`, `UTF8String "x509"` and `PrintableString "x509"` onto the same type for compatibility with identities written by older versions of this SDK. For one x509 identity that is three accepted byte strings and therefore three `UniqueID()`s:
+
+    ```
+    3006 020102       040150   -> {Type: 2, "P"}   uid NQ5fFHOcay5c
+    3009 0c0478353039 040150   -> {Type: 2, "P"}   uid FK3RQ1kfFhZG
+    3009 1304783530 39 040150  -> {Type: 2, "P"}   uid f4VvsY1uwzTB
+    ```
+
+    A token paid to the second or third spelling of a victim's identity verifies — validation decodes type 2 and checks the payload's cert — but does not resolve to that owner's wallet. The checks above reduce this set from unbounded to exactly three; closing it to one cannot be done in the decoder, because the older spellings may exist in persisted data. It needs a rule at the validator boundary: require the `INTEGER` spelling for identities in *new* transactions while still decoding the others for reads. Out of scope here, tracked separately.
+*   **The HTLC script payload is JSON, and it is the widest remaining `UniqueID()` split.** An `htlc.Script` is JSON-encoded into the `TypedIdentity` payload and decoded with `json.Unmarshal` (`interop/htlc/deserializer.go`). That wrapper (`token/core/common/encoding/json`) does set `DisallowUnknownFields`, so an injected member is rejected — but it decodes with a single `Decoder.Decode`, which reads one value and **ignores every byte after it**. Insignificant whitespace, member reordering, equivalent string escapes, alternate `time.Time` spellings for `Deadline`, and arbitrary trailing junk all decode to the identical logical `Script` under a different `UniqueID()`:
+
+    ```
+    canonical        {"Sender":"c2VuZGVy…",…}           -> uid HtE0njeLZx3b…
+    leading space    <SP>{"Sender":"c2VuZGVy…",…}       -> uid F5+Z6ceT5HPM…
+    trailing space   {"Sender":"c2VuZGVy…",…}<SP>       -> uid awLaNBD0sGt/…
+    trailing junk    {"Sender":"c2VuZGVy…",…}GARBAGE    -> uid NA8HzwEzfcQT…
+    pretty-printed   json.MarshalIndent of that Script  -> uid xQHjVL91jwdh…
+    ```
+
+    Unlike the legacy type spellings above, this set is **unbounded** rather than capped at three, because any suffix yields another accepted spelling. The `TypedIdentity` envelope wrapping the script is covered by the checks above; its payload is not. Closing it needs the JSON equivalent of `UnmarshalCanonicalDER` — reject trailing bytes after the top-level value, and re-encode-and-compare — applied at the five `*Script` decode sites in `interop/htlc/deserializer.go` (lines 71, 103, 126, 178, 244) and the two `ScriptInfo` ones (184, 221). Out of scope here, tracked separately.
+*   The payload inside the `TypedIdentity` `OCTET STRING` is **protobuf** for x509 and idemix identities (`x509/crypto/config.go`, `idemix/crypto/deserializer.go`), not DER. Protobuf permits field reordering and redundant varints, so those payload bytes remain malleable and the checks above say nothing about them.
+
+**Upgrade considerations.** `DecodeIdentity` runs on every owner identity during validation, and `MultiSignature`/`PolicySignature.FromBytes` run inside `Verifier.Verify`, so tightening them changes *which transactions are valid*. The tightening is deliberately **ungated** — there is no public-parameters or capability flag for it, matching the precedent set by the nesting-depth and fan-out limits added alongside it. Two consequences follow from that choice:
+
+*   During a rolling upgrade, an upgraded and a non-upgraded validator can reach opposite decisions on the same transaction. For commit-time validation that is a divergence, not a fail-safe, so validators should be upgraded together rather than incrementally.
+*   A token already committed to a non-canonically-encoded owner identity becomes unspendable, because its verifier can no longer be deserialized. Before this change such bytes decoded successfully and merely resolved to the wrong `UniqueID()`. Only a producer outside this tree emits them — every encoder here is already minimal — so no token written by this SDK is affected.
+
+This applies to identity decoding only. Signature parsing (`x509/crypto/ecdsa.go`, `idemixnym/nym/signer.go`) stays deliberately lenient: those bytes come from external signers and HSMs whose DER encoders are routinely non-minimal in ways that are still valid for signature purposes. The `MultiSignature` / `PolicySignature` *envelopes* are strict, because we always produce them ourselves; the individual signatures they carry are not.
+
 ### Default Key Managers
 
 The identity service includes two primary implementations for concrete identities:
@@ -528,10 +568,16 @@ type MyNewIdentity struct {
 
 func (m *MyNewIdentity) Serialize() ([]byte, error) { return asn1.Marshal(*m) }
 func (m *MyNewIdentity) Deserialize(raw []byte) error {
-    _, err := asn1.Unmarshal(raw, m)
-    return err
+    // Never `_, err := asn1.Unmarshal(raw, m)`: discarding the "rest" return
+    // accepts trailing garbage, which breaks the canonical encoding
+    // requirement described under TypedIdentity above.
+    return marshal.UnmarshalCanonicalDER(raw, m)
 }
 ```
+
+`UnmarshalCanonicalDER` separates the two ways a decode can fail. `ErrNonCanonical`, `ErrTrailingBytes`, `ErrNonMinimalLen` and `ErrNonMinimalInt` all mean *the bytes are wrong* and are the ones worth surfacing or counting as a rejected identity. `ErrInvalidDestination` means the destination pointer was nil — a caller bug, checked before the input is looked at, and never something a peer can provoke. Branch on the first group; treat the second as a programming error.
+
+The destination is typed `*T`, not `any`, so passing a non-pointer or an untyped `nil` does not compile at all. Note also what `ErrNonCanonical` does and does not claim: the check is that the input is what `asn1.Marshal` emits for the destination type, which coincides with "canonical DER" only because the envelope types carry no `optional`, `omitempty` or `time.Time` fields. Do not point the helper at a type that does — the constraint is spelled out on the function and pinned by a test.
 
 Expose `Wrap` / `Unwrap` helpers (see `boolpolicy.WrapPolicyIdentity` / `boolpolicy.Unwrap`) that embed the serialized struct inside a `TypedIdentity` envelope with the new type tag.
 

--- a/token/services/identity/boolpolicy/boolpolicy_fuzz_test.go
+++ b/token/services/identity/boolpolicy/boolpolicy_fuzz_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package boolpolicy
+
+import (
+	"encoding/asn1"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const maxFuzzBoolPolicyBytes = 64 << 10
+
+// FuzzPolicyIdentityDeserializeNoPanic hunts for malformed ASN.1 that panics
+// PolicyIdentity.Deserialize instead of returning an error. This is the
+// deserialization entry point for policy identities across DeserializeVerifier,
+// GetAuditInfoMatcher, Recipients and Unwrap, and it mirrors
+// FuzzMultiIdentityDeserializeNoPanic in the structurally identical multisig
+// package.
+func FuzzPolicyIdentityDeserializeNoPanic(f *testing.F) {
+	valid, err := (&PolicyIdentity{
+		Policy:     "$0 OR ($1 AND $2)",
+		Identities: [][]byte{[]byte("alice"), []byte("bob"), []byte("carol")},
+	}).Bytes()
+	require.NoError(f, err)
+	f.Add(valid)
+	// Trailing bytes after the canonical encoding — the laxness this decode
+	// path was hardened against; it must now be a clean error, never a panic.
+	f.Add(append(append([]byte{}, valid...), 0xDE, 0xAD))
+	// An element smuggled *inside* the SEQUENCE rather than appended after it.
+	// A rest check cannot see this one, so it is the shape most likely to hide
+	// a regression.
+	smuggled, err := asn1.Marshal(policyIdentityWithExtra{
+		Policy:     "$0 OR ($1 AND $2)",
+		Identities: [][]byte{[]byte("alice"), []byte("bob"), []byte("carol")},
+		Extra:      42,
+	})
+	require.NoError(f, err)
+	f.Add(smuggled)
+	f.Add([]byte{})
+	f.Add([]byte("not asn1"))
+	f.Add([]byte{0x30, 0x81})
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		if len(raw) > maxFuzzBoolPolicyBytes {
+			t.Skip()
+		}
+		pi := &PolicyIdentity{}
+		var err error
+		require.NotPanics(t, func() {
+			err = pi.Deserialize(raw)
+		})
+		if err != nil {
+			return
+		}
+		// Canonicality contract: raw was accepted, so it must be the one
+		// encoding of what it decoded to — any other accepted spelling is a
+		// second Identity.UniqueID() cache slot for one identity. This is a
+		// regression guard stated in terms of the contract, not an independent
+		// check: UnmarshalCanonicalDER enforces it by re-marshalling and comparing,
+		// which is what Bytes() does, so it cannot fail against the current
+		// implementation. security_test.go carries the actual vectors.
+		reencoded, err := pi.Bytes()
+		require.NoError(t, err, "an accepted PolicyIdentity must be re-serializable")
+		require.Equal(t, raw, reencoded,
+			"accepted bytes must be the canonical encoding of the decoded identity")
+	})
+}
+
+// FuzzPolicySignatureFromBytesNoPanic hunts for malformed ASN.1 that panics
+// PolicySignature.FromBytes instead of returning an error. This is the
+// deserialization entry point invoked directly on peer-supplied signature bytes
+// in PolicyVerifier.Verify.
+func FuzzPolicySignatureFromBytesNoPanic(f *testing.F) {
+	sigs := [][]byte{[]byte("sig1"), nil, []byte("sig3")}
+	valid, err := (&PolicySignature{Signatures: sigs}).Bytes()
+	require.NoError(f, err)
+	f.Add(valid)
+	f.Add(append(append([]byte{}, valid...), 0x00))
+	smuggled, err := asn1.Marshal(policySignatureWithExtra{Signatures: sigs, Extra: 7})
+	require.NoError(f, err)
+	f.Add(smuggled)
+	f.Add([]byte{})
+	f.Add([]byte("not asn1"))
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		if len(raw) > maxFuzzBoolPolicyBytes {
+			t.Skip()
+		}
+		sig := &PolicySignature{}
+		var err error
+		require.NotPanics(t, func() {
+			err = sig.FromBytes(raw)
+		})
+		if err != nil {
+			return
+		}
+		reencoded, err := sig.Bytes()
+		require.NoError(t, err, "an accepted PolicySignature must be re-serializable")
+		// Contract-level regression guard; see FuzzPolicyIdentityDeserializeNoPanic.
+		require.Equal(t, raw, reencoded,
+			"accepted bytes must be the canonical encoding of the decoded signature")
+	})
+}

--- a/token/services/identity/boolpolicy/identity.go
+++ b/token/services/identity/boolpolicy/identity.go
@@ -39,6 +39,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/json"
 	tdriver "github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/marshal"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
@@ -74,11 +75,13 @@ func (p *PolicyIdentity) Serialize() ([]byte, error) {
 	return asn1.Marshal(*p)
 }
 
-// Deserialize decodes raw DER bytes into the receiver.
+// Deserialize decodes raw DER bytes into the receiver. It rejects trailing
+// bytes after the encoded value: raw comes off the wire, and accepting a
+// non-canonical re-encoding of an identity would make two distinct byte
+// strings decode to the same PolicyIdentity while hashing to different
+// Identity.UniqueID()s. See marshal.UnmarshalCanonicalDER.
 func (p *PolicyIdentity) Deserialize(raw []byte) error {
-	_, err := asn1.Unmarshal(raw, p)
-
-	return err
+	return marshal.UnmarshalCanonicalDER(raw, p)
 }
 
 // Bytes is an alias for Serialize, provided for symmetry with MultiIdentity.

--- a/token/services/identity/boolpolicy/security_test.go
+++ b/token/services/identity/boolpolicy/security_test.go
@@ -8,6 +8,7 @@ package boolpolicy
 
 import (
 	"context"
+	"encoding/asn1"
 	"testing"
 
 	"github.com/LFDT-Panurus/panurus/token"
@@ -98,4 +99,165 @@ func TestDuplicateIdentityRejectedAtDeserializeTime(t *testing.T) {
 
 	_, err = d.DeserializeVerifier(ctx, Policy, raw)
 	require.Error(t, err, "a policy identity with a duplicated component identity must be rejected at deserialize time")
+}
+
+// TestTrailingBytesRejectedOnIdentityDeserialize is the reproduction from the
+// issue: PolicyIdentity.Deserialize discarded encoding/asn1.Unmarshal's "rest"
+// return, so a canonical PolicyIdentity with garbage appended still
+// deserialized successfully — while hashing to a *different*
+// Identity.UniqueID(), because UniqueID() hashes the raw bytes rather than a
+// canonicalised form of the decoded value. Since UniqueID() is the cache key
+// throughout the identity/wallet layers (role/registry.go's fast path,
+// provider.go's signer cache, …), one logical identity could occupy two cache
+// slots.
+func TestTrailingBytesRejectedOnIdentityDeserialize(t *testing.T) {
+	canonical, err := (&PolicyIdentity{Policy: "$0 OR $1", Identities: [][]byte{id0, id1}}).Bytes()
+	require.NoError(t, err)
+
+	require.NoError(t, (&PolicyIdentity{}).Deserialize(canonical),
+		"the canonical encoding must still deserialize")
+
+	padded := append(append([]byte{}, canonical...), 0xDE, 0xAD, 0xBE, 0xEF)
+
+	require.Error(t, (&PolicyIdentity{}).Deserialize(padded),
+		"a PolicyIdentity with trailing bytes appended must be rejected")
+
+	// This inequality is why the lenient parse mattered: the two byte strings
+	// decoded to the same logical identity but keyed the caches differently.
+	require.NotEqual(t, token.Identity(canonical).UniqueID(), token.Identity(padded).UniqueID(),
+		"UniqueID() hashes the raw bytes, so the padded form was a distinct cache key")
+}
+
+// TestTrailingBytesRejectedOnSignatureFromBytes covers the same laxness in
+// PolicySignature.FromBytes, which is invoked directly on peer-supplied bytes
+// in PolicyVerifier.Verify. Only the policy *envelope* is tightened here; the
+// individual signatures it carries are still parsed by their own verifiers,
+// which must stay lenient for external signers and HSMs.
+func TestTrailingBytesRejectedOnSignatureFromBytes(t *testing.T) {
+	canonical, err := (&PolicySignature{Signatures: [][]byte{
+		[]byte("sig1"), []byte("sig2"),
+	}}).Bytes()
+	require.NoError(t, err)
+
+	require.NoError(t, (&PolicySignature{}).FromBytes(canonical),
+		"the canonical encoding must still deserialize")
+
+	padded := append(append([]byte{}, canonical...), 0x00)
+
+	require.Error(t, (&PolicySignature{}).FromBytes(padded),
+		"a PolicySignature with trailing bytes appended must be rejected")
+}
+
+// policyIdentityWithExtra is PolicyIdentity plus one undeclared trailing
+// element. Marshalling it is how an attacker writes the smuggled form:
+// encoding/asn1 consumes only as many SEQUENCE elements as the destination
+// struct has fields and silently drops the rest, so these bytes decode into a
+// plain PolicyIdentity with nothing left over.
+type policyIdentityWithExtra struct {
+	Policy     string `asn1:"utf8"`
+	Identities [][]byte
+	Extra      int32
+}
+
+// TestExtraElementInsideSequenceRejectedOnIdentityDeserialize covers the vector
+// the trailing-byte check alone cannot see. Appending garbage *after* the
+// top-level TLV is caught by asn1.Unmarshal's "rest"; moving that same garbage
+// *inside* the SEQUENCE, with the outer length grown to cover it, leaves rest
+// empty — so the identity decodes to the same policy over the same components
+// under raw bytes that hash to a different UniqueID(). Concretely: a token
+// transferred to the smuggled form verifies (the verifier works on the decoded
+// policy) but never resolves to a component owner's wallet (the lookup works on
+// UniqueID()), leaving a valid token none of the owners can see.
+func TestExtraElementInsideSequenceRejectedOnIdentityDeserialize(t *testing.T) {
+	const policy = "$0 OR $1"
+	ids := [][]byte{id0, id1}
+
+	canonical, err := (&PolicyIdentity{Policy: policy, Identities: ids}).Bytes()
+	require.NoError(t, err)
+	require.NoError(t, (&PolicyIdentity{}).Deserialize(canonical),
+		"the canonical encoding must still deserialize")
+
+	smuggled, err := asn1.Marshal(policyIdentityWithExtra{Policy: policy, Identities: ids, Extra: 42})
+	require.NoError(t, err)
+	require.NotEqual(t, canonical, smuggled, "the two encodings must really differ")
+
+	// Baseline: the lax decode accepts it, yields the same policy identity, and
+	// has nothing left over for a rest check to catch.
+	var lenient PolicyIdentity
+	rest, err := asn1.Unmarshal(smuggled, &lenient)
+	require.NoError(t, err)
+	require.Empty(t, rest, "the extra element is inside the SEQUENCE, so there is no tail to reject")
+	require.Equal(t, policy, lenient.Policy)
+	require.Equal(t, ids, lenient.Identities, "same logical identity, different bytes")
+
+	require.NotEqual(t, token.Identity(canonical).UniqueID(), token.Identity(smuggled).UniqueID(),
+		"UniqueID() hashes the raw bytes, so the smuggled form is a distinct cache key")
+
+	require.Error(t, (&PolicyIdentity{}).Deserialize(smuggled),
+		"a PolicyIdentity with an element smuggled inside the SEQUENCE must be rejected")
+}
+
+// TestAlternateStringTagRejectedOnIdentityDeserialize covers a third spelling,
+// unique to PolicyIdentity because it is the only one of the four envelopes
+// carrying a string field: encoding/asn1 accepts T61String, IA5String and
+// GeneralString wherever `asn1:"utf8"` was declared. Flipping that one tag byte
+// leaves the decoded Policy identical and the raw bytes — hence the UniqueID()
+// — different, with no trailing bytes and no length anomaly for either earlier
+// check to catch.
+func TestAlternateStringTagRejectedOnIdentityDeserialize(t *testing.T) {
+	canonical, err := (&PolicyIdentity{Policy: "$0 OR $1", Identities: [][]byte{id0, id1}}).Bytes()
+	require.NoError(t, err)
+
+	// The Policy field is the first element of the SEQUENCE, so its tag is the
+	// first byte of the body: [SEQUENCE, len, tag, ...].
+	require.Equal(t, byte(asn1.TagUTF8String), canonical[2],
+		"fixture assumption: canonical[2] is the Policy field's UTF8String tag")
+
+	for _, tag := range []byte{
+		byte(asn1.TagT61String),
+		byte(asn1.TagIA5String),
+		byte(asn1.TagGeneralString),
+	} {
+		retagged := append([]byte{}, canonical...)
+		retagged[2] = tag
+
+		// Baseline: same policy string, no leftovers.
+		var lenient PolicyIdentity
+		rest, err := asn1.Unmarshal(retagged, &lenient)
+		require.NoError(t, err, "tag 0x%02X: encoding/asn1 accepts this where UTF8String was declared", tag)
+		require.Empty(t, rest)
+		require.Equal(t, "$0 OR $1", lenient.Policy, "tag 0x%02X: same policy, different bytes", tag)
+
+		require.NotEqual(t, token.Identity(canonical).UniqueID(), token.Identity(retagged).UniqueID(),
+			"tag 0x%02X: the retagged form is a distinct cache key", tag)
+
+		require.Error(t, (&PolicyIdentity{}).Deserialize(retagged),
+			"tag 0x%02X: a non-UTF8String spelling of the same policy must be rejected", tag)
+	}
+}
+
+// policySignatureWithExtra is PolicySignature plus one undeclared element, the
+// signature-envelope analog of policyIdentityWithExtra.
+type policySignatureWithExtra struct {
+	Signatures [][]byte
+	Extra      int32
+}
+
+// TestExtraElementInsideSequenceRejectedOnSignatureFromBytes covers the same
+// vector in PolicySignature.FromBytes, which PolicyVerifier.Verify calls
+// directly on peer-supplied bytes. The nil slot mirrors an unsigned OR branch,
+// which must keep decoding.
+func TestExtraElementInsideSequenceRejectedOnSignatureFromBytes(t *testing.T) {
+	sigs := [][]byte{[]byte("sig1"), nil, []byte("sig3")}
+
+	canonical, err := (&PolicySignature{Signatures: sigs}).Bytes()
+	require.NoError(t, err)
+	require.NoError(t, (&PolicySignature{}).FromBytes(canonical),
+		"the canonical encoding, unsigned slot included, must still deserialize")
+
+	smuggled, err := asn1.Marshal(policySignatureWithExtra{Signatures: sigs, Extra: 7})
+	require.NoError(t, err)
+
+	require.Error(t, (&PolicySignature{}).FromBytes(smuggled),
+		"a PolicySignature with an element smuggled inside the SEQUENCE must be rejected")
 }

--- a/token/services/identity/boolpolicy/sig.go
+++ b/token/services/identity/boolpolicy/sig.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token"
 	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/marshal"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
@@ -29,11 +30,15 @@ func (s *PolicySignature) Bytes() ([]byte, error) {
 	return asn1.Marshal(*s)
 }
 
-// FromBytes deserialises raw ASN.1 DER into the receiver.
+// FromBytes deserialises raw ASN.1 DER into the receiver. It rejects trailing
+// bytes after the encoded value: raw is peer-supplied, and the envelope itself
+// is always produced by our own canonical asn1.Marshal, so leftover bytes only
+// ever mean a mangled or deliberately padded signature. (This tightens the
+// PolicySignature *envelope* only — the individual signatures it carries are
+// parsed by their own verifiers, which must stay lenient for external
+// signers/HSMs.)
 func (s *PolicySignature) FromBytes(raw []byte) error {
-	_, err := asn1.Unmarshal(raw, s)
-
-	return err
+	return marshal.UnmarshalCanonicalDER(raw, s)
 }
 
 // JoinSignatures builds a PolicySignature from a map of per-identity

--- a/token/services/identity/marshal/canonical_test.go
+++ b/token/services/identity/marshal/canonical_test.go
@@ -1,0 +1,391 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package marshal_test
+
+import (
+	"encoding/asn1"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/boolpolicy"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/marshal"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/multisig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests below cover the canonical-form requirement for identity decoding.
+//
+// DecodeIdentity used to read the outer SEQUENCE's declared length and throw it
+// away ("skip SEQUENCE length; we trust inner bounds checks"), never checking
+// that the parsed position reached the end of the buffer. Two different byte
+// strings therefore decoded to the same logical TypedIdentity — while hashing
+// to *different* Identity.UniqueID() values, because UniqueID() hashes the raw
+// bytes rather than a canonicalised form of the decoded value. Since UniqueID()
+// is the cache key throughout the identity/wallet layers (role/registry.go's
+// fast path, provider.go's signer cache, …), a lenient parse means one logical
+// identity can occupy two cache slots.
+
+// TestDecodeIdentity_RejectsTrailingBytes is the issue's reproduction at the
+// DecodeIdentity level: marshal a valid identity, append garbage, and confirm
+// the decode now fails — and that the two byte strings really did hash to
+// different UniqueID()s, which is what made the laxness matter.
+func TestDecodeIdentity_RejectsTrailingBytes(t *testing.T) {
+	canonical := marshal.EncodeIdentity(1, []byte("payload"))
+
+	res, err := marshal.DecodeIdentity(canonical)
+	require.NoError(t, err, "the canonical encoding must still decode")
+	require.Equal(t, int32(1), res.Int32)
+
+	for _, garbage := range [][]byte{
+		{0x00},
+		{0xFF, 0xFF},
+		// A second, well-formed TLV appended after the SEQUENCE — the most
+		// plausible shape of an accidental double-append.
+		{byte(asn1.TagOctetString), 0x01, 0x00},
+	} {
+		padded := append(append([]byte{}, canonical...), garbage...)
+
+		_, err := marshal.DecodeIdentity(padded)
+		require.ErrorIs(t, err, marshal.ErrTrailingBytes,
+			"bytes after the outer SEQUENCE must be rejected, not silently ignored")
+
+		// The reason the lenient parse was a problem: the two byte strings
+		// are distinct cache keys even though they decoded identically.
+		assert.NotEqual(t, token.Identity(canonical).UniqueID(), token.Identity(padded).UniqueID(),
+			"UniqueID() hashes the raw bytes, so the padded form was a distinct cache key")
+	}
+}
+
+// TestDecodeIdentity_RejectsUndeclaredExtraFieldInsideSequence covers the other
+// direction: garbage smuggled *inside* the SEQUENCE by growing its declared
+// length. The outer-length check alone would accept this, because the declared
+// length does match the buffer end — the OCTET STRING end-of-buffer check is
+// what rejects it.
+func TestDecodeIdentity_RejectsUndeclaredExtraFieldInsideSequence(t *testing.T) {
+	raw := []byte{
+		seqByte, 0x09,
+		byte(asn1.TagInteger), 0x01, 0x01,
+		byte(asn1.TagOctetString), 0x01, 0xAA,
+		// Undeclared third field, inside the SEQUENCE's declared length.
+		byte(asn1.TagOctetString), 0x01, 0xBB,
+	}
+	require.Len(t, raw, 2+0x09, "fixture must be self-consistent: outer length covers the extra field")
+
+	_, err := marshal.DecodeIdentity(raw)
+	require.ErrorIs(t, err, marshal.ErrTrailingBytes,
+		"an undeclared field after the OCTET STRING must be rejected")
+}
+
+// TestDecodeIdentity_RejectsOuterLengthOverrunningBuffer pins the *other* side
+// of the outer-length check to ErrTruncated rather than ErrTrailingBytes: a
+// declared length longer than the buffer is a short read, not padding.
+func TestDecodeIdentity_RejectsOuterLengthOverrunningBuffer(t *testing.T) {
+	raw := []byte{
+		seqByte, 0x0A, // claims 10 bytes of content
+		byte(asn1.TagInteger), 0x01, 0x01,
+		byte(asn1.TagOctetString), 0x01, 0xAA, // only 6 present
+	}
+
+	_, err := marshal.DecodeIdentity(raw)
+	require.ErrorIs(t, err, marshal.ErrTruncated,
+		"an outer length exceeding the buffer is truncation, not trailing bytes")
+}
+
+// TestDecodeIdentity_StdlibEncodingsRemainDecodable is the interop guard for the
+// tightened decoder: encoding/asn1.Marshal is the other producer of these bytes
+// (legacy TypedIdentity encodings and the ref* structs below), and it emits
+// canonical minimal-length DER, so every one of its outputs must still decode.
+func TestDecodeIdentity_StdlibEncodingsRemainDecodable(t *testing.T) {
+	// Sizes chosen to straddle the short/long-form length boundary in both
+	// the first field and the OCTET STRING.
+	for _, size := range []int{1, 0x7F, 0x80, 0x100} {
+		data := make([]byte, size)
+
+		res, err := marshal.DecodeIdentity(marshalInt(t, 42, data))
+		require.NoError(t, err, "encoding/asn1's int encoding (%d-byte payload) must remain decodable", size)
+		assert.Equal(t, int32(42), res.Int32)
+
+		res, err = marshal.DecodeIdentity(marshalUTF8(t, string(make([]byte, size)), data))
+		require.NoError(t, err, "encoding/asn1's utf8 encoding (%d-byte payload) must remain decodable", size)
+		assert.Len(t, res.Str, size)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UnmarshalCanonicalDER
+// ---------------------------------------------------------------------------
+
+// TestUnmarshalCanonicalDER_RejectsTrailingBytes covers the shared helper that the
+// four previously-lax identity call sites now route through. Each of them
+// discarded encoding/asn1.Unmarshal's "rest" return.
+func TestUnmarshalCanonicalDER_RejectsTrailingBytes(t *testing.T) {
+	canonical, err := asn1.Marshal(refInt{Value: 7, Data: []byte("body")})
+	require.NoError(t, err)
+
+	var dst refInt
+	require.NoError(t, marshal.UnmarshalCanonicalDER(canonical, &dst),
+		"the canonical encoding must still decode")
+	assert.Equal(t, int32(7), dst.Value)
+
+	padded := append(append([]byte{}, canonical...), 0xDE, 0xAD)
+
+	// Baseline: the stdlib call the four sites used happily ignores the tail.
+	rest, err := asn1.Unmarshal(padded, &refInt{})
+	require.NoError(t, err)
+	require.NotEmpty(t, rest, "encoding/asn1 reports the tail rather than rejecting it — that return was discarded")
+
+	require.ErrorIs(t, marshal.UnmarshalCanonicalDER(padded, &refInt{}), marshal.ErrTrailingBytes,
+		"UnmarshalCanonicalDER must reject what asn1.Unmarshal merely reports")
+}
+
+// TestUnmarshalCanonicalDER_PropagatesDecodeErrors makes sure the canonicality wrapper
+// does not swallow or reclassify a genuine decode failure.
+func TestUnmarshalCanonicalDER_PropagatesDecodeErrors(t *testing.T) {
+	err := marshal.UnmarshalCanonicalDER([]byte("not asn1"), &refInt{})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, marshal.ErrTrailingBytes,
+		"a malformed value must surface its own error, not be reported as trailing bytes")
+}
+
+// refIntWithExtra is refInt plus one undeclared trailing element. Marshalling
+// it produces bytes that decode into refInt cleanly — encoding/asn1 consumes
+// only as many SEQUENCE elements as the destination struct has fields and
+// silently drops the remainder — while carrying a payload refInt never
+// described. This is what an attacker writes.
+type refIntWithExtra struct {
+	Value int32
+	Data  []byte
+	Extra int32
+}
+
+// TestUnmarshalCanonicalDER_RejectsExtraElementInsideSequence covers the vector that
+// the rest check alone cannot see. Rest reports bytes *after* the top-level
+// TLV, but the malleability lives *inside* it: move the garbage into the
+// SEQUENCE body, let the outer length grow to cover it, and rest is empty
+// because the outer TLV did consume the whole input. The SEQUENCE body is then
+// an unlimited channel for garbage, and each spelling is a distinct
+// Identity.UniqueID() for one logical identity — the very bug the trailing-byte
+// check was added to close.
+func TestUnmarshalCanonicalDER_RejectsExtraElementInsideSequence(t *testing.T) {
+	canonical, err := asn1.Marshal(refInt{Value: 7, Data: []byte("body")})
+	require.NoError(t, err)
+
+	smuggled, err := asn1.Marshal(refIntWithExtra{Value: 7, Data: []byte("body"), Extra: 42})
+	require.NoError(t, err)
+	require.NotEqual(t, canonical, smuggled, "the two encodings must really differ")
+
+	// Baseline: the stdlib decodes the smuggled form into refInt without
+	// complaint and with nothing left over, so the rest check sees a clean
+	// parse. Both properties are what make this a bypass rather than noise.
+	var lenient refInt
+	rest, err := asn1.Unmarshal(smuggled, &lenient)
+	require.NoError(t, err)
+	require.Empty(t, rest, "the extra element is inside the SEQUENCE, so rest is empty — nothing for the rest check to catch")
+	require.Equal(t, refInt{Value: 7, Data: []byte("body")}, lenient,
+		"the smuggled form decodes to exactly the same value as the canonical one")
+
+	// ...and the two spellings key the caches differently, which is why it matters.
+	require.NotEqual(t, token.Identity(canonical).UniqueID(), token.Identity(smuggled).UniqueID(),
+		"UniqueID() hashes the raw bytes, so the smuggled form is a distinct cache key")
+
+	require.ErrorIs(t, marshal.UnmarshalCanonicalDER(smuggled, &refInt{}), marshal.ErrNonCanonical,
+		"an element smuggled inside the SEQUENCE must be rejected")
+}
+
+// TestUnmarshalCanonicalDER_RejectsAlternateStringTags covers a second spelling the
+// rest check cannot see: encoding/asn1 accepts T61String, IA5String and
+// GeneralString wherever a struct field asks for a UTF8String, so flipping one
+// tag byte yields identical decoded content under different raw bytes.
+func TestUnmarshalCanonicalDER_RejectsAlternateStringTags(t *testing.T) {
+	canonical, err := asn1.Marshal(refUTF8{Value: "policy", Data: []byte("body")})
+	require.NoError(t, err)
+
+	// The UTF8String tag is the first element's tag, at the first byte of the
+	// SEQUENCE body: [SEQUENCE, len, tag, ...].
+	require.Equal(t, byte(asn1.TagUTF8String), canonical[2], "fixture assumption: canonical[2] is the string tag")
+
+	for _, tag := range []byte{
+		byte(asn1.TagT61String),
+		byte(asn1.TagIA5String),
+		byte(asn1.TagGeneralString),
+	} {
+		retagged := append([]byte{}, canonical...)
+		retagged[2] = tag
+
+		// Baseline: same value, no leftovers — invisible to the rest check.
+		var lenient refUTF8
+		rest, err := asn1.Unmarshal(retagged, &lenient)
+		require.NoError(t, err, "tag 0x%02X: encoding/asn1 accepts this where UTF8String was declared", tag)
+		require.Empty(t, rest)
+		require.Equal(t, "policy", lenient.Value)
+
+		require.ErrorIs(t, marshal.UnmarshalCanonicalDER(retagged, &refUTF8{}), marshal.ErrNonCanonical,
+			"tag 0x%02X: a non-UTF8String spelling of the same string must be rejected", tag)
+	}
+}
+
+// TestUnmarshalCanonicalDER_AcceptsWhatStdlibMarshalEmits is the guard against
+// over-tightening. The canonicality check is a re-encode-and-compare, so it can
+// only ever reject what encoding/asn1.Marshal would not have produced; every
+// producer in this tree goes through that same Marshal. Values are chosen to
+// straddle the short/long-form length boundary and to cover the nil, empty and
+// multi-element slice shapes the four real call sites carry.
+func TestUnmarshalCanonicalDER_AcceptsWhatStdlibMarshalEmits(t *testing.T) {
+	for _, size := range []int{0, 1, 0x7F, 0x80, 0x100} {
+		canonical, err := asn1.Marshal(refInt{Value: 42, Data: make([]byte, size)})
+		require.NoError(t, err)
+		require.NoError(t, marshal.UnmarshalCanonicalDER(canonical, &refInt{}),
+			"a %d-byte payload written by encoding/asn1.Marshal must remain decodable", size)
+	}
+
+	// Slice-of-slice shapes: MultiIdentity, PolicyIdentity, MultiSignature and
+	// PolicySignature all carry one, and a signature slot is legitimately nil
+	// when an OR branch went unsigned.
+	type refSlices struct {
+		Items [][]byte
+	}
+	for name, items := range map[string][][]byte{
+		"nil slice":          nil,
+		"empty slice":        {},
+		"nil element":        {nil},
+		"empty element":      {{}},
+		"mixed elements":     {[]byte("a"), nil, []byte("ccc")},
+		"long-form elements": {make([]byte, 0x80), make([]byte, 0x100)},
+	} {
+		canonical, err := asn1.Marshal(refSlices{Items: items})
+		require.NoError(t, err)
+		require.NoError(t, marshal.UnmarshalCanonicalDER(canonical, &refSlices{}),
+			"%s: encoding/asn1.Marshal's own output must survive the round-trip check", name)
+	}
+}
+
+// TestUnmarshalCanonicalDER_FalseRejectsOptionalAndOmitEmpty documents the boundary of
+// what UnmarshalCanonicalDER can be pointed at, and fails if that boundary moves.
+//
+// The check establishes "b is something asn1.Marshal would have emitted for this
+// type", which is narrower than "b is valid DER". For a field tagged optional or
+// omitempty, asn1.Marshal drops the field when it holds the zero value while
+// asn1.Unmarshal accepts it explicitly present — a legal encoding the round-trip
+// then rejects. That is a false rejection, not a caught attack.
+//
+// None of the four identity envelopes carries such a field, so nothing is broken
+// today; this test exists so a fifth caller with one of these tags trips over it
+// here rather than in production. See the constraint list on UnmarshalCanonicalDER.
+func TestUnmarshalCanonicalDER_FalseRejectsOptionalAndOmitEmpty(t *testing.T) {
+	// Every field explicitly present, which is legal DER in all three cases.
+	explicitBytes, err := asn1.Marshal(struct {
+		A int32
+		B []byte
+	}{A: 1, B: []byte{}})
+	require.NoError(t, err)
+
+	explicitInt, err := asn1.Marshal(struct {
+		A int32
+		B int32
+	}{A: 1, B: 0})
+	require.NoError(t, err)
+
+	var omitEmpty struct {
+		A int32
+		B []byte `asn1:"omitempty"`
+	}
+	var optional struct {
+		A int32
+		B int32 `asn1:"optional"`
+	}
+
+	require.ErrorIs(t, marshal.UnmarshalCanonicalDER(explicitBytes, &omitEmpty), marshal.ErrNonCanonical,
+		"omitempty: an explicitly-present empty field is legal DER but not what asn1.Marshal emits — do not point UnmarshalCanonicalDER at such a type")
+	require.ErrorIs(t, marshal.UnmarshalCanonicalDER(explicitInt, &optional), marshal.ErrNonCanonical,
+		"optional: an explicitly-present zero field is legal DER but not what asn1.Marshal emits — do not point UnmarshalCanonicalDER at such a type")
+
+	// A `default:` field is the one that looks similar but is genuinely
+	// non-canonical: DER requires a value equal to the default to be absent, so
+	// rejecting the explicit spelling is correct rather than a false rejection.
+	explicitDefault, err := asn1.Marshal(struct {
+		A int32
+		B int32
+	}{A: 1, B: 7})
+	require.NoError(t, err)
+
+	var withDefault struct {
+		A int32
+		B int32 `asn1:"optional,default:7"`
+	}
+	require.ErrorIs(t, marshal.UnmarshalCanonicalDER(explicitDefault, &withDefault), marshal.ErrNonCanonical,
+		"default: DER requires a value equal to the default to be absent, so this rejection is correct")
+}
+
+// TestUnmarshalCanonicalDER_FourCallSitesHaveNoOptionalFields is the guard that keeps
+// the constraint above true of the real types, so the documented caveat cannot
+// quietly stop applying if someone adds a field.
+func TestUnmarshalCanonicalDER_FourCallSitesHaveNoOptionalFields(t *testing.T) {
+	for _, typ := range []reflect.Type{
+		reflect.TypeFor[multisig.MultiIdentity](),
+		reflect.TypeFor[multisig.MultiSignature](),
+		reflect.TypeFor[boolpolicy.PolicyIdentity](),
+		reflect.TypeFor[boolpolicy.PolicySignature](),
+	} {
+		for f := range typ.Fields() {
+			tag := f.Tag.Get("asn1")
+			for _, bad := range []string{"optional", "omitempty", "default"} {
+				assert.NotContains(t, tag, bad,
+					"%s.%s carries asn1:%q — UnmarshalCanonicalDER round-trips through asn1.Marshal and would false-reject legal encodings of this field",
+					typ.Name(), f.Name, tag)
+			}
+			assert.NotEqual(t, reflect.TypeFor[time.Time](), f.Type,
+				"%s.%s is a time.Time — UTCTime and GeneralizedTime both decode but asn1.Marshal emits only one, so UnmarshalCanonicalDER would false-reject the other",
+				typ.Name(), f.Name)
+		}
+	}
+}
+
+// TestUnmarshalCanonicalDER_RejectsInvalidDestination pins the one destination
+// misuse that is still expressible. The signature takes *T, so the other two are
+// now compile errors rather than test cases:
+//
+//	marshal.UnmarshalCanonicalDER(b, refInt{})  // non-pointer: does not compile
+//	marshal.UnmarshalCanonicalDER(b, nil)       // untyped nil: T cannot be inferred
+//
+// A typed nil pointer still type-checks, and encoding/asn1 would reject it only
+// as an untyped structure error indistinguishable from "these bytes are
+// malformed" — the distinction this package's sentinel errors exist to make.
+func TestUnmarshalCanonicalDER_RejectsInvalidDestination(t *testing.T) {
+	canonical, err := asn1.Marshal(refInt{Value: 7, Data: []byte("body")})
+	require.NoError(t, err)
+
+	var nilPtr *refInt
+	require.ErrorIs(t, marshal.UnmarshalCanonicalDER(canonical, nilPtr), marshal.ErrInvalidDestination,
+		"a nil destination is a caller bug and must not be reported as a problem with the bytes")
+
+	// The guard must not have cost the happy path: the same bytes into a proper
+	// destination still decode.
+	var dst refInt
+	require.NoError(t, marshal.UnmarshalCanonicalDER(canonical, &dst))
+	require.Equal(t, int32(7), dst.Value)
+}
+
+// TestUnmarshalCanonicalDER_InvalidDestinationIsNotAByteError is the distinction
+// the guard exists to make: ErrInvalidDestination must not be confused with any
+// of the sentinels that describe the input, so a caller branching on "was this a
+// malleability rejection?" cannot be misled by its own programming error.
+func TestUnmarshalCanonicalDER_InvalidDestinationIsNotAByteError(t *testing.T) {
+	var nilPtr *refInt
+	err := marshal.UnmarshalCanonicalDER([]byte("not asn1"), nilPtr)
+	require.ErrorIs(t, err, marshal.ErrInvalidDestination,
+		"the destination is checked before the bytes, so a bad destination wins even for garbage input")
+
+	for _, byteErr := range []error{
+		marshal.ErrNonCanonical, marshal.ErrTrailingBytes,
+		marshal.ErrNonMinimalLen, marshal.ErrNonMinimalInt,
+	} {
+		require.NotErrorIs(t, err, byteErr)
+	}
+}

--- a/token/services/identity/marshal/marshal.go
+++ b/token/services/identity/marshal/marshal.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package marshal
 
 import (
+	"bytes"
 	"encoding/asn1"
 	"errors"
 	"math"
@@ -32,7 +33,105 @@ var (
 	ErrUnexpectedTag = errors.New("asn1: unexpected tag")
 	ErrIntOverflow   = errors.New("asn1: integer overflows int32")
 	ErrInvalidLen    = errors.New("asn1: invalid length encoding")
+	ErrTrailingBytes = errors.New("asn1: trailing bytes after value")
+	ErrNonMinimalLen = errors.New("asn1: non-minimal length encoding")
+	ErrNonMinimalInt = errors.New("asn1: non-minimal integer encoding")
+	// ErrNonCanonical means the input is not the encoding asn1.Marshal produces
+	// for the destination type. For the four identity envelopes that is the same
+	// thing as "not canonical DER" — a property their field types guarantee and
+	// TestUnmarshalCanonicalDER_FourCallSitesHaveNoOptionalFields pins. For a type
+	// with an optional/omitempty/time.Time field the two would diverge, which is
+	// why UnmarshalCanonicalDER documents those as unsupported destinations.
+	ErrNonCanonical = errors.New("asn1: not the canonical encoding for this type")
+
+	// ErrInvalidDestination reports a caller programming error — a nil decode
+	// destination — as opposed to the Err* values above, which all report
+	// something wrong with the bytes being decoded. The *T parameter makes the
+	// other misuses (non-pointer, untyped nil) compile errors instead.
+	ErrInvalidDestination = errors.New("asn1: destination pointer is nil")
 )
+
+// UnmarshalCanonicalDER decodes DER-encoded data into val with encoding/asn1 and
+// accepts b only if b is the one canonical encoding of the value it decoded to.
+//
+// The destination is *T rather than any so that the compiler rejects the two
+// misuses that used to be runtime errors — a non-pointer, and an untyped nil.
+// A typed nil pointer is the only one left, and returns ErrInvalidDestination
+// without inspecting b. Every other error value this returns describes the
+// bytes, not the destination.
+//
+// This matters because Identity.UniqueID() hashes the *raw* identity bytes
+// rather than a canonicalised form of the decoded value, and it is the cache
+// key throughout the identity and wallet layers (role/registry.go's fast path,
+// provider.go's signer cache, …). Any two byte strings that decode to the same
+// logical identity but hash differently give that one identity two cache slots:
+// a token paid to the non-canonical spelling still verifies (the verifier works
+// on the decoded value) but never resolves to its owner's wallet (the lookup
+// works on UniqueID()). Use this instead of calling asn1.Unmarshal directly
+// whenever the bytes being decoded came off the wire.
+//
+// encoding/asn1.Unmarshal is lenient in two ways that both have to be closed:
+//
+//   - it reports bytes left over after the top-level value through its first
+//     return value and is happy to ignore them;
+//   - it silently discards SEQUENCE elements the destination struct has no
+//     field for. Those never appear in rest — the top-level TLV did consume the
+//     whole input — so checking rest alone leaves the SEQUENCE body itself as a
+//     free-form channel for garbage. It is similarly happy to accept
+//     T61String/IA5String/GeneralString where the struct asks for a UTF8String.
+//
+// The rest check catches the first. Re-encoding the decoded value and requiring
+// it to reproduce b byte-for-byte catches both, and generalises to any future
+// encoding/asn1 leniency, at the cost of one extra marshal of a small struct per
+// decode. The hot TypedIdentity envelope path does not come through here: it
+// uses DecodeIdentity, which walks the TLVs itself and pins every length.
+//
+// The property this establishes is precisely "b is something asn1.Marshal would
+// have emitted for this type". That is the right definition here because every
+// producer in this tree goes through asn1.Marshal, but it is narrower than "b is
+// valid DER", so it constrains what val may be:
+//
+//   - Do not use it on a type with an `asn1:"optional"` or `asn1:"omitempty"`
+//     field. asn1.Marshal omits such a field when it holds the zero value, while
+//     asn1.Unmarshal accepts it explicitly present — a legal encoding that the
+//     round-trip then rejects. (A field with `default:` is different: DER does
+//     require the default to be absent, so rejecting an explicit one is correct.)
+//   - Do not use it on a type with a time.Time field. UTCTime and
+//     GeneralizedTime both decode, but asn1.Marshal picks one by year, so the
+//     other is rejected.
+//
+// None of the four identity envelopes hit either case: they carry only int32,
+// string and [][]byte fields, with no optional, omitempty or default tags. Check
+// before adding a fifth caller.
+func UnmarshalCanonicalDER[T any](b []byte, val *T) error {
+	// asn1.Unmarshal would reject this too, but only as an untyped structure
+	// error that a caller cannot tell apart from "these bytes are malformed" —
+	// the one distinction this package's error values exist to make.
+	if val == nil {
+		return ErrInvalidDestination
+	}
+
+	rest, err := asn1.Unmarshal(b, val)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 0 {
+		return ErrTrailingBytes
+	}
+
+	// asn1.Marshal takes the value, not a pointer to it. Typing val as *T makes
+	// this a plain dereference: no reflection, and no pointer-to-pointer case to
+	// reason about, because *T is exactly one level.
+	reencoded, err := asn1.Marshal(*val)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(b, reencoded) {
+		return ErrNonCanonical
+	}
+
+	return nil
+}
 
 // Result holds the decoded payload. IsInt distinguishes the two variants.
 // Data is a zero-copy sub-slice of the input — do not modify input while using it.
@@ -52,9 +151,19 @@ func DecodeIdentity(b []byte) (Result, error) {
 	if len(b) == 0 || b[0] != tagSequence {
 		return r, ErrUnexpectedTag
 	}
-	_, pos, err := readLen(b, 1) // skip SEQUENCE length; we trust inner bounds checks
+	seqLen, pos, err := readLen(b, 1)
 	if err != nil {
 		return r, err
+	}
+	// The outer SEQUENCE must declare exactly the bytes it was given: no
+	// fewer (trailing garbage after the value) and no more (a truncated
+	// buffer). Without this, b and b+garbage decode identically while
+	// hashing to different Identity.UniqueID()s — see UnmarshalCanonicalDER.
+	if pos+seqLen > len(b) {
+		return r, ErrTruncated
+	}
+	if pos+seqLen < len(b) {
+		return r, ErrTrailingBytes
 	}
 
 	// Dispatch on first element's tag
@@ -111,6 +220,12 @@ func DecodeIdentity(b []byte) (Result, error) {
 	if np+l > len(b) {
 		return r, ErrTruncated
 	}
+	// The OCTET STRING is the last declared field, and the outer SEQUENCE's
+	// length was already pinned to len(b) above, so anything left over here
+	// is an undeclared extra field smuggled inside the SEQUENCE.
+	if np+l != len(b) {
+		return r, ErrTrailingBytes
+	}
 	r.Data = b[np : np+l] // zero-copy
 
 	if !r.IsInt {
@@ -151,6 +266,15 @@ func readLen(b []byte, pos int) (int, int, error) {
 		return 0, 0, ErrInvalidLen
 	}
 	pos++
+	// DER admits exactly one length encoding per length, and the long form
+	// must not carry leading zero bytes. Rejecting the alternatives keeps one
+	// logical identity to one byte string: a length written as 0x82 0x00 0x06
+	// instead of 0x06 decodes to the same identity but hashes to a different
+	// Identity.UniqueID(), which is the cache key across the identity and
+	// wallet layers. See UnmarshalCanonicalDER for the full reasoning.
+	if b[pos] == 0x00 {
+		return 0, 0, ErrNonMinimalLen
+	}
 	// Accumulate in uint64: at most 4 bytes, so l can never exceed
 	// 0xFFFFFFFF and this addition/shift can never overflow, regardless of
 	// the platform's native int width.
@@ -159,6 +283,14 @@ func readLen(b []byte, pos int) (int, int, error) {
 		l = l<<8 | uint64(b[pos+i])
 	}
 	pos += n
+	// ...and a length the short form could have carried must use it. Checked
+	// after accumulating so it also catches a multi-byte form whose bytes
+	// happen to encode a small value (e.g. 0x84 0x00 0x00 0x00 0x06), which
+	// the leading-zero check above already rejects but which would otherwise
+	// slip through for hypothetical wider forms.
+	if l < 0x80 {
+		return 0, 0, ErrNonMinimalLen
+	}
 	// Reject a declared length that claims more bytes than remain in the
 	// buffer here, in unsigned arithmetic, before ever converting it to
 	// int. Doing the equivalent check with a plain-int accumulator (as
@@ -174,9 +306,26 @@ func readLen(b []byte, pos int) (int, int, error) {
 }
 
 // parseInt32 decodes a DER big-endian signed integer into int32.
+//
+// Like readLen, it insists on the minimal encoding: DER admits exactly one
+// spelling per integer value, and accepting the alternatives would reintroduce
+// the malleability the length check closes one field over. 02 02 00 05 carries
+// the same 5 as 02 01 05 but hashes to a different Identity.UniqueID() — see
+// UnmarshalCanonicalDER for why that is the bug and not a cosmetic difference.
 func parseInt32(b []byte) (int32, error) {
 	if len(b) == 0 || len(b) > 5 {
 		return 0, ErrIntOverflow
+	}
+	// A leading 0x00 is redundant unless it is there to keep a positive value
+	// from being read as negative; a leading 0xFF is redundant unless it is
+	// there to keep a negative value negative.
+	if len(b) > 1 {
+		if b[0] == 0x00 && b[1]&0x80 == 0 {
+			return 0, ErrNonMinimalInt
+		}
+		if b[0] == 0xFF && b[1]&0x80 != 0 {
+			return 0, ErrNonMinimalInt
+		}
 	}
 	var v int64
 	if b[0]&0x80 != 0 {

--- a/token/services/identity/marshal/marshal_fuzz_test.go
+++ b/token/services/identity/marshal/marshal_fuzz_test.go
@@ -19,6 +19,18 @@ const maxFuzzDecodeIdentityBytes = 64 << 10
 // instead of returning an error. DecodeIdentity is the base ASN.1 parser
 // underlying every identity type's deserialization path (x509, idemix,
 // idemixnym, multisig, htlc all route through it via typed.go).
+//
+// For the integer variant it also asserts canonicality: an accepted encoding
+// must be the *only* encoding of the identity it decoded to, so re-encoding the
+// result has to reproduce the input byte-for-byte. That covers both the
+// non-minimal length and the non-minimal integer-content vectors at once, since
+// either one produces a second accepted spelling and therefore a second
+// Identity.UniqueID() cache slot for one logical identity.
+//
+// The invariant is asserted for the integer variant only, because the string
+// variant is deliberately many-to-one: DecodeIdentity folds UTF8String "x509",
+// PrintableString "x509" and INTEGER 2 onto the same identity for legacy
+// compatibility, so re-encoding a string spelling cannot reproduce its input.
 func FuzzDecodeIdentityNoPanic(f *testing.F) {
 	f.Add(marshal.EncodeIdentity(1, []byte("payload")))
 	f.Add(marshal.Encode(marshal.Result{Str: "hello", Data: []byte("data")}))
@@ -26,13 +38,28 @@ func FuzzDecodeIdentityNoPanic(f *testing.F) {
 	f.Add([]byte("not asn1"))
 	f.Add([]byte{0x30, 0x81})
 	f.Add([]byte{0x30, 0x02, 0x02, 0x84, 0xFF, 0xFF, 0xFF, 0xFF})
+	// Non-minimal length: outer SEQUENCE length 6 written as 0x81 0x06.
+	f.Add([]byte{0x30, 0x81, 0x06, 0x02, 0x01, 0x01, 0x04, 0x01, 0xAA})
+	// Non-minimal integer contents: the type field 5 written as 0x00 0x05.
+	f.Add([]byte{0x30, 0x07, 0x02, 0x02, 0x00, 0x05, 0x04, 0x01, 0xAA})
 
 	f.Fuzz(func(t *testing.T, raw []byte) {
 		if len(raw) > maxFuzzDecodeIdentityBytes {
 			t.Skip()
 		}
+		var res marshal.Result
+		var err error
 		require.NotPanics(t, func() {
-			_, _ = marshal.DecodeIdentity(raw)
+			res, err = marshal.DecodeIdentity(raw)
 		})
+		// Str stays empty only when the first element really was an INTEGER:
+		// the legacy fold sets IsInt while leaving the decoded Str in place, so
+		// this is what separates the one-to-one variant from the many-to-one
+		// one without having to re-walk raw's tags.
+		if err != nil || !res.IsInt || res.Str != "" {
+			return
+		}
+		require.Equal(t, raw, marshal.EncodeIdentity(res.Int32, res.Data),
+			"accepted bytes must be the canonical encoding of the decoded identity")
 	})
 }

--- a/token/services/identity/marshal/marshal_test.go
+++ b/token/services/identity/marshal/marshal_test.go
@@ -435,7 +435,10 @@ func TestDecodeErrors(t *testing.T) {
 		},
 		{
 			"readLen truncated (n=2 but only 1 byte left)",
-			[]byte{seqByte, 0x02, byte(asn1.TagInteger), 0x82, 0x01},
+			// The outer SEQUENCE length must agree with the buffer (0x03,
+			// not 0x02) or the outer-length check fires first and this
+			// stops exercising the inner readLen failure it is named for.
+			[]byte{seqByte, 0x03, byte(asn1.TagInteger), 0x82, 0x01},
 			marshal.ErrInvalidLen,
 		},
 		{
@@ -455,7 +458,9 @@ func TestDecodeErrors(t *testing.T) {
 		},
 		{
 			"wrong tag for OCTET STRING",
-			[]byte{seqByte, 0x05, byte(asn1.TagInteger), 0x01, 0x00, byte(asn1.TagInteger), 0x01, 0x00},
+			// Outer SEQUENCE length corrected to 0x06 so it matches the six
+			// bytes that follow; see the note on the readLen case above.
+			[]byte{seqByte, 0x06, byte(asn1.TagInteger), 0x01, 0x00, byte(asn1.TagInteger), 0x01, 0x00},
 			marshal.ErrUnexpectedTag,
 		},
 		{

--- a/token/services/identity/marshal/minimal_length_test.go
+++ b/token/services/identity/marshal/minimal_length_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package marshal_test
+
+import (
+	"encoding/asn1"
+	"math"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/marshal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests below cover the second non-canonical vector in identity decoding:
+// non-minimal DER length encodings.
+//
+// readLen used to accept any long form of 1–4 length bytes, so the same length
+// could be written several ways — 0x06, 0x81 0x06, 0x82 0x00 0x06 — all decoding
+// to an identical identity. As with trailing bytes, that matters because
+// Identity.UniqueID() hashes the raw bytes rather than a canonicalised form of
+// the decoded value, so each spelling is a separate cache key across the
+// identity and wallet layers for one logical identity.
+//
+// This is safe to tighten because both producers of these bytes emit minimal
+// lengths: appendTLV in this package, and encoding/asn1.Marshal (legacy
+// TypedIdentity encodings). TestDecodeIdentity_AcceptsEveryLengthFormOurEncoderEmits
+// and TestDecodeIdentity_StdlibEncodingsRemainDecodable are the guards against
+// over-tightening.
+
+// TestDecodeIdentity_RejectsNonMinimalLengthEncoding walks the three places a
+// length appears in an identity encoding — the outer SEQUENCE, the type field,
+// and the OCTET STRING — and confirms each rejects a non-minimal spelling.
+func TestDecodeIdentity_RejectsNonMinimalLengthEncoding(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{
+			// Outer SEQUENCE length 6 written as 0x81 0x06 instead of 0x06.
+			"outer sequence length in long form",
+			[]byte{
+				seqByte, 0x81, 0x06,
+				byte(asn1.TagInteger), 0x01, 0x01,
+				byte(asn1.TagOctetString), 0x01, 0xAA,
+			},
+		},
+		{
+			// INTEGER length 1 written as 0x82 0x00 0x01.
+			"integer length with leading zero byte",
+			[]byte{
+				seqByte, 0x08,
+				byte(asn1.TagInteger), 0x82, 0x00, 0x01, 0x01,
+				byte(asn1.TagOctetString), 0x01, 0xAA,
+			},
+		},
+		{
+			// OCTET STRING length 1 written as 0x81 0x01.
+			"octet string length in long form",
+			[]byte{
+				seqByte, 0x07,
+				byte(asn1.TagInteger), 0x01, 0x01,
+				byte(asn1.TagOctetString), 0x81, 0x01, 0xAA,
+			},
+		},
+		{
+			// UTF8String length 5 written as 0x81 0x05.
+			"utf8 string length in long form",
+			[]byte{
+				seqByte, 0x0B,
+				byte(asn1.TagUTF8String), 0x81, 0x05, 'x', '5', '0', '9', '!',
+				byte(asn1.TagOctetString), 0x01, 0xAA,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := marshal.DecodeIdentity(tt.raw)
+			require.ErrorIs(t, err, marshal.ErrNonMinimalLen,
+				"a non-minimal DER length must be rejected: it is a second spelling of an identity we already accept in canonical form")
+		})
+	}
+}
+
+// TestDecodeIdentity_NonMinimalLengthWasADistinctCacheKey states the reason the
+// laxness mattered, rather than just that it existed: the non-minimal spelling
+// decoded to exactly the same identity yet hashed differently, so it occupied a
+// second slot in every UniqueID()-keyed cache.
+func TestDecodeIdentity_NonMinimalLengthWasADistinctCacheKey(t *testing.T) {
+	canonical := marshal.EncodeIdentity(1, []byte{0xAA})
+	require.Equal(t, byte(0x06), canonical[1], "fixture assumes a short-form outer length")
+
+	// Rewrite the outer length 0x06 as the long form 0x81 0x06. Nothing else
+	// about the value changes.
+	nonMinimal := append([]byte{canonical[0], 0x81}, canonical[1:]...)
+
+	res, err := marshal.DecodeIdentity(canonical)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), res.Int32)
+	assert.Equal(t, []byte{0xAA}, res.Data)
+
+	_, err = marshal.DecodeIdentity(nonMinimal)
+	require.ErrorIs(t, err, marshal.ErrNonMinimalLen,
+		"the long-form spelling of a short-form length must be rejected")
+
+	assert.NotEqual(t, token.Identity(canonical).UniqueID(), token.Identity(nonMinimal).UniqueID(),
+		"UniqueID() hashes the raw bytes, so the non-minimal spelling was a distinct cache key")
+}
+
+// TestDecodeIdentity_AcceptsEveryLengthFormOurEncoderEmits guards the
+// minimal-length check against over-tightening: appendTLV grows from the short
+// form to the 0x81/0x82/0x83 long forms as the payload grows, and every one of
+// those must keep decoding. A payload spanning each boundary is round-tripped.
+func TestDecodeIdentity_AcceptsEveryLengthFormOurEncoderEmits(t *testing.T) {
+	for _, size := range []int{0, 1, 0x7F, 0x80, 0xFF, 0x100, 0xFFFF, 0x10000} {
+		data := make([]byte, size)
+		for i := range data {
+			data[i] = byte(i)
+		}
+
+		res, err := marshal.DecodeIdentity(marshal.EncodeIdentity(3, data))
+		require.NoError(t, err, "our own encoder must always emit a decodable minimal length (payload %d bytes)", size)
+		require.Len(t, res.Data, size)
+		assert.Equal(t, int32(3), res.Int32)
+	}
+
+	// Same for the string variant, whose first field length also crosses the
+	// short/long-form boundary.
+	for _, size := range []int{0x7F, 0x80} {
+		res, err := marshal.DecodeIdentity(marshal.Encode(marshal.Result{
+			Str:  string(make([]byte, size)),
+			Data: []byte{0x01},
+		}))
+		require.NoError(t, err, "string field of %d bytes must decode", size)
+		assert.Len(t, res.Str, size)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Non-minimal INTEGER contents
+// ---------------------------------------------------------------------------
+
+// A minimal length is only half of a minimal INTEGER: the *contents* admit
+// redundant spellings too. 02 02 00 05 declares a perfectly minimal length of
+// two for a value that fits in one byte, so the length check above waves it
+// through, and parseInt32 then sign-extended and accumulated the redundant
+// leading byte away — yielding the same identity type under different raw
+// bytes, one field over from the check that was just tightened.
+
+// TestDecodeIdentity_RejectsNonMinimalIntegerEncoding covers each redundant
+// leading-byte shape DER forbids, in the identity type field.
+func TestDecodeIdentity_RejectsNonMinimalIntegerEncoding(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{
+			// A leading 0x00 is only permitted when it stops a positive value
+			// from being read as negative, which 0x05 does not need: the
+			// minimal spelling of 5 is 02 01 05.
+			"redundant leading zero",
+			[]byte{
+				seqByte, 0x07,
+				byte(asn1.TagInteger), 0x02, 0x00, 0x05,
+				byte(asn1.TagOctetString), 0x01, 0xAA,
+			},
+		},
+		{
+			"two redundant leading zeros",
+			[]byte{
+				seqByte, 0x08,
+				byte(asn1.TagInteger), 0x03, 0x00, 0x00, 0x05,
+				byte(asn1.TagOctetString), 0x01, 0xAA,
+			},
+		},
+		{
+			// A leading 0xFF is only permitted when it keeps a negative value
+			// negative, which 0x85 (already negative) does not need.
+			"redundant leading ff",
+			[]byte{
+				seqByte, 0x07,
+				byte(asn1.TagInteger), 0x02, 0xFF, 0x85,
+				byte(asn1.TagOctetString), 0x01, 0xAA,
+			},
+		},
+		{
+			// Padded all the way out to parseInt32's 5-byte allowance, which
+			// widened the set of spellings further.
+			"zero-padded to five bytes",
+			[]byte{
+				seqByte, 0x0A,
+				byte(asn1.TagInteger), 0x05, 0x00, 0x00, 0x00, 0x00, 0x05,
+				byte(asn1.TagOctetString), 0x01, 0xAA,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := marshal.DecodeIdentity(tt.raw)
+			require.ErrorIs(t, err, marshal.ErrNonMinimalInt,
+				"a non-minimal DER integer must be rejected: it is a second spelling of an identity we already accept in canonical form")
+		})
+	}
+}
+
+// TestDecodeIdentity_NonMinimalIntegerWasADistinctCacheKey states why the
+// laxness mattered, mirroring the length-encoding case above.
+func TestDecodeIdentity_NonMinimalIntegerWasADistinctCacheKey(t *testing.T) {
+	canonical := marshal.EncodeIdentity(5, []byte("payload"))
+
+	res, err := marshal.DecodeIdentity(canonical)
+	require.NoError(t, err)
+	require.Equal(t, int32(5), res.Int32)
+
+	// Same identity, type written as 02 02 00 05 instead of 02 01 05.
+	padded := []byte{seqByte, 0x0D, byte(asn1.TagInteger), 0x02, 0x00, 0x05, byte(asn1.TagOctetString), 0x07}
+	padded = append(padded, []byte("payload")...)
+
+	_, err = marshal.DecodeIdentity(padded)
+	require.ErrorIs(t, err, marshal.ErrNonMinimalInt,
+		"the zero-padded spelling of the type field must be rejected")
+
+	assert.NotEqual(t, token.Identity(canonical).UniqueID(), token.Identity(padded).UniqueID(),
+		"UniqueID() hashes the raw bytes, so the padded spelling was a distinct cache key")
+}
+
+// TestDecodeIdentity_AcceptsEveryIntegerOurEncoderEmits guards the integer
+// check against over-tightening. encodeInt32 strips redundant leading bytes
+// with exactly the rule parseInt32 now enforces, so the tree cannot reject its
+// own output — including the one case where a leading 0x00 is *required*
+// (a positive value whose top content byte has the high bit set) and the
+// negative values that legitimately begin 0xFF.
+func TestDecodeIdentity_AcceptsEveryIntegerOurEncoderEmits(t *testing.T) {
+	for _, v := range []int32{
+		0, 1, 5, 127,
+		128,   // 0x00 0x80 — the required leading zero
+		255,   // 0x00 0xFF
+		32767, // 0x7F 0xFF, no leading zero needed
+		32768, // 0x00 0x80 0x00
+		math.MaxInt32,
+		-1, // 0xFF
+		-128,
+		-129, // 0xFF 0x7F — leading 0xFF required
+		math.MinInt32,
+	} {
+		res, err := marshal.DecodeIdentity(marshal.EncodeIdentity(v, []byte{0xAA}))
+		require.NoError(t, err, "our own encoder must always emit a decodable minimal integer (value %d)", v)
+		assert.Equal(t, v, res.Int32)
+	}
+
+	// encoding/asn1.Marshal is the other producer of these bytes (legacy
+	// TypedIdentity encodings) and is likewise canonical.
+	for _, v := range []int32{0, 127, 128, 255, math.MaxInt32, -1, -129, math.MinInt32} {
+		res, err := marshal.DecodeIdentity(marshalInt(t, v, []byte{0xAA}))
+		require.NoError(t, err, "encoding/asn1's integer encoding must remain decodable (value %d)", v)
+		assert.Equal(t, v, res.Int32)
+	}
+}

--- a/token/services/identity/multisig/identity.go
+++ b/token/services/identity/multisig/identity.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/json"
 	tdriver "github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/marshal"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
@@ -32,10 +33,13 @@ func (m *MultiIdentity) Serialize() ([]byte, error) {
 	return asn1.Marshal(*m)
 }
 
+// Deserialize decodes raw DER bytes into the receiver. It rejects trailing
+// bytes after the encoded value: raw comes off the wire, and accepting a
+// non-canonical re-encoding of an identity would make two distinct byte
+// strings decode to the same MultiIdentity while hashing to different
+// Identity.UniqueID()s. See marshal.UnmarshalCanonicalDER.
 func (m *MultiIdentity) Deserialize(raw []byte) error {
-	_, err := asn1.Unmarshal(raw, m)
-
-	return err
+	return marshal.UnmarshalCanonicalDER(raw, m)
 }
 
 func (m *MultiIdentity) Bytes() ([]byte, error) {

--- a/token/services/identity/multisig/multisig_fuzz_test.go
+++ b/token/services/identity/multisig/multisig_fuzz_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package multisig
 
 import (
+	"encoding/asn1"
 	"testing"
 
 	"github.com/LFDT-Panurus/panurus/token"
@@ -19,12 +20,31 @@ const maxFuzzMultisigBytes = 64 << 10
 // MultiIdentity.Deserialize instead of returning an error. This is the
 // deserialization entry point for multisig identities across
 // DeserializeVerifier, GetAuditInfoMatcher, Recipients and Unwrap.
+// It also pins the canonicality contract at this call site: any input
+// Deserialize accepts must re-serialize to exactly those bytes, because
+// Identity.UniqueID() hashes the raw bytes and a second accepted spelling of one
+// identity is a second cache slot for it across the identity and wallet layers.
+//
+// Note what this does and does not buy. UnmarshalCanonicalDER currently enforces the
+// contract by re-marshalling and comparing, which is the same computation
+// Bytes() performs — so against today's implementation the assertion cannot
+// fail, and it is not what found the bug it was written for. Its value is as a
+// regression guard: it is stated in terms of the contract rather than the
+// implementation, so it fails if UnmarshalCanonicalDER is ever swapped for a cheaper
+// hand-rolled check that misses a case. Coverage of the actual vectors lives in
+// security_test.go, which asserts against fixed attacker-crafted bytes.
 func FuzzMultiIdentityDeserializeNoPanic(f *testing.F) {
-	valid, err := (&MultiIdentity{Identities: []token.Identity{
-		[]byte("alice"), []byte("bob"),
-	}}).Bytes()
+	ids := []token.Identity{[]byte("alice"), []byte("bob")}
+	valid, err := (&MultiIdentity{Identities: ids}).Bytes()
 	require.NoError(f, err)
 	f.Add(valid)
+	// Garbage appended after the top-level value...
+	f.Add(append(append([]byte{}, valid...), 0xDE, 0xAD))
+	// ...and the same garbage smuggled inside the SEQUENCE, which a check on
+	// asn1.Unmarshal's "rest" cannot see.
+	smuggled, err := asn1.Marshal(multiIdentityWithExtra{Identities: ids, Extra: 42})
+	require.NoError(f, err)
+	f.Add(smuggled)
 	f.Add([]byte{})
 	f.Add([]byte("not asn1"))
 
@@ -32,10 +52,18 @@ func FuzzMultiIdentityDeserializeNoPanic(f *testing.F) {
 		if len(raw) > maxFuzzMultisigBytes {
 			t.Skip()
 		}
+		mid := &MultiIdentity{}
+		var err error
 		require.NotPanics(t, func() {
-			mid := &MultiIdentity{}
-			_ = mid.Deserialize(raw)
+			err = mid.Deserialize(raw)
 		})
+		if err != nil {
+			return
+		}
+		reencoded, err := mid.Bytes()
+		require.NoError(t, err, "an accepted MultiIdentity must be re-serializable")
+		require.Equal(t, raw, reencoded,
+			"accepted bytes must be the canonical encoding of the decoded identity")
 	})
 }
 
@@ -44,9 +72,14 @@ func FuzzMultiIdentityDeserializeNoPanic(f *testing.F) {
 // deserialization entry point invoked directly on peer-supplied signature
 // bytes in Verifier.Verify.
 func FuzzMultiSignatureFromBytesNoPanic(f *testing.F) {
-	valid, err := (&MultiSignature{Signatures: [][]byte{[]byte("sig1"), []byte("sig2")}}).Bytes()
+	sigs := [][]byte{[]byte("sig1"), []byte("sig2")}
+	valid, err := (&MultiSignature{Signatures: sigs}).Bytes()
 	require.NoError(f, err)
 	f.Add(valid)
+	f.Add(append(append([]byte{}, valid...), 0x00))
+	smuggled, err := asn1.Marshal(multiSignatureWithExtra{Signatures: sigs, Extra: 7})
+	require.NoError(f, err)
+	f.Add(smuggled)
 	f.Add([]byte{})
 	f.Add([]byte("not asn1"))
 
@@ -54,9 +87,19 @@ func FuzzMultiSignatureFromBytesNoPanic(f *testing.F) {
 		if len(raw) > maxFuzzMultisigBytes {
 			t.Skip()
 		}
+		sig := &MultiSignature{}
+		var err error
 		require.NotPanics(t, func() {
-			sig := &MultiSignature{}
-			_ = sig.FromBytes(raw)
+			err = sig.FromBytes(raw)
 		})
+		if err != nil {
+			return
+		}
+		reencoded, err := sig.Bytes()
+		require.NoError(t, err, "an accepted MultiSignature must be re-serializable")
+		// Contract-level regression guard; see FuzzMultiIdentityDeserializeNoPanic
+		// for what this does and does not buy.
+		require.Equal(t, raw, reencoded,
+			"accepted bytes must be the canonical encoding of the decoded signature")
 	})
 }

--- a/token/services/identity/multisig/security_test.go
+++ b/token/services/identity/multisig/security_test.go
@@ -8,6 +8,7 @@ package multisig
 
 import (
 	"context"
+	"encoding/asn1"
 	"testing"
 
 	"github.com/LFDT-Panurus/panurus/token"
@@ -102,4 +103,123 @@ func TestDuplicateIdentityRejectedAtDeserializeTime(t *testing.T) {
 
 	_, err = d.DeserializeVerifier(ctx, Multisig, raw)
 	require.Error(t, err, "a multisig identity with a duplicated component identity must be rejected at deserialize time")
+}
+
+// TestTrailingBytesRejectedOnIdentityDeserialize is the reproduction from the
+// issue: MultiIdentity.Deserialize discarded encoding/asn1.Unmarshal's "rest"
+// return, so a canonical MultiIdentity with garbage appended still deserialized
+// successfully — while hashing to a *different* Identity.UniqueID(), because
+// UniqueID() hashes the raw bytes rather than a canonicalised form of the
+// decoded value. Since UniqueID() is the cache key throughout the
+// identity/wallet layers (role/registry.go's fast path, provider.go's signer
+// cache, …), one logical identity could occupy two cache slots.
+func TestTrailingBytesRejectedOnIdentityDeserialize(t *testing.T) {
+	canonical, err := (&MultiIdentity{Identities: []token.Identity{
+		token.Identity("alice"), token.Identity("bob"),
+	}}).Bytes()
+	require.NoError(t, err)
+
+	require.NoError(t, (&MultiIdentity{}).Deserialize(canonical),
+		"the canonical encoding must still deserialize")
+
+	padded := append(append([]byte{}, canonical...), 0xDE, 0xAD, 0xBE, 0xEF)
+
+	require.Error(t, (&MultiIdentity{}).Deserialize(padded),
+		"a MultiIdentity with trailing bytes appended must be rejected")
+
+	// This inequality is why the lenient parse mattered: the two byte strings
+	// decoded to the same logical identity but keyed the caches differently.
+	require.NotEqual(t, token.Identity(canonical).UniqueID(), token.Identity(padded).UniqueID(),
+		"UniqueID() hashes the raw bytes, so the padded form was a distinct cache key")
+}
+
+// TestTrailingBytesRejectedOnSignatureFromBytes covers the same laxness in
+// MultiSignature.FromBytes, which is invoked directly on peer-supplied bytes in
+// Verifier.Verify. Only the multisig *envelope* is tightened here; the
+// individual signatures it carries are still parsed by their own verifiers,
+// which must stay lenient for external signers and HSMs.
+func TestTrailingBytesRejectedOnSignatureFromBytes(t *testing.T) {
+	canonical, err := (&MultiSignature{Signatures: [][]byte{
+		[]byte("sig1"), []byte("sig2"),
+	}}).Bytes()
+	require.NoError(t, err)
+
+	require.NoError(t, (&MultiSignature{}).FromBytes(canonical),
+		"the canonical encoding must still deserialize")
+
+	padded := append(append([]byte{}, canonical...), 0x00)
+
+	require.Error(t, (&MultiSignature{}).FromBytes(padded),
+		"a MultiSignature with trailing bytes appended must be rejected")
+}
+
+// multiIdentityWithExtra is MultiIdentity plus one undeclared trailing element.
+// Marshalling it is how an attacker writes the smuggled form: encoding/asn1
+// consumes only as many SEQUENCE elements as the destination struct has fields
+// and silently drops the rest, so these bytes decode into a plain MultiIdentity
+// with nothing left over.
+type multiIdentityWithExtra struct {
+	Identities []token.Identity
+	Extra      int32
+}
+
+// TestExtraElementInsideSequenceRejectedOnIdentityDeserialize covers the vector
+// the trailing-byte check alone cannot see. Appending garbage *after* the
+// top-level TLV is caught by asn1.Unmarshal's "rest"; moving that same garbage
+// *inside* the SEQUENCE, with the outer length grown to cover it, leaves rest
+// empty — so the identity decodes to {alice, bob} under raw bytes that hash to
+// a different UniqueID(). Concretely: a token transferred to the smuggled form
+// verifies (the verifier works on the decoded identities) but never resolves to
+// alice's or bob's wallet (the lookup works on UniqueID()), leaving a valid
+// token neither owner can see.
+func TestExtraElementInsideSequenceRejectedOnIdentityDeserialize(t *testing.T) {
+	ids := []token.Identity{token.Identity("alice"), token.Identity("bob")}
+
+	canonical, err := (&MultiIdentity{Identities: ids}).Bytes()
+	require.NoError(t, err)
+	require.NoError(t, (&MultiIdentity{}).Deserialize(canonical),
+		"the canonical encoding must still deserialize")
+
+	smuggled, err := asn1.Marshal(multiIdentityWithExtra{Identities: ids, Extra: 42})
+	require.NoError(t, err)
+	require.NotEqual(t, canonical, smuggled, "the two encodings must really differ")
+
+	// Baseline: the lax decode accepts it, yields the same identities, and has
+	// nothing left over for a rest check to catch.
+	var lenient MultiIdentity
+	rest, err := asn1.Unmarshal(smuggled, &lenient)
+	require.NoError(t, err)
+	require.Empty(t, rest, "the extra element is inside the SEQUENCE, so there is no tail to reject")
+	require.Equal(t, ids, lenient.Identities, "same logical identity, different bytes")
+
+	require.NotEqual(t, token.Identity(canonical).UniqueID(), token.Identity(smuggled).UniqueID(),
+		"UniqueID() hashes the raw bytes, so the smuggled form is a distinct cache key")
+
+	require.Error(t, (&MultiIdentity{}).Deserialize(smuggled),
+		"a MultiIdentity with an element smuggled inside the SEQUENCE must be rejected")
+}
+
+// multiSignatureWithExtra is MultiSignature plus one undeclared element, the
+// signature-envelope analog of multiIdentityWithExtra.
+type multiSignatureWithExtra struct {
+	Signatures [][]byte
+	Extra      int32
+}
+
+// TestExtraElementInsideSequenceRejectedOnSignatureFromBytes covers the same
+// vector in MultiSignature.FromBytes, which Verifier.Verify calls directly on
+// peer-supplied bytes.
+func TestExtraElementInsideSequenceRejectedOnSignatureFromBytes(t *testing.T) {
+	sigs := [][]byte{[]byte("sig1"), []byte("sig2")}
+
+	canonical, err := (&MultiSignature{Signatures: sigs}).Bytes()
+	require.NoError(t, err)
+	require.NoError(t, (&MultiSignature{}).FromBytes(canonical),
+		"the canonical encoding must still deserialize")
+
+	smuggled, err := asn1.Marshal(multiSignatureWithExtra{Signatures: sigs, Extra: 7})
+	require.NoError(t, err)
+
+	require.Error(t, (&MultiSignature{}).FromBytes(smuggled),
+		"a MultiSignature with an element smuggled inside the SEQUENCE must be rejected")
 }

--- a/token/services/identity/multisig/sig.go
+++ b/token/services/identity/multisig/sig.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token"
 	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/marshal"
 	"github.com/LFDT-Panurus/panurus/token/services/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
@@ -26,10 +27,15 @@ func (m *MultiSignature) Bytes() ([]byte, error) {
 	return asn1.Marshal(*m)
 }
 
+// FromBytes deserialises raw ASN.1 DER into the receiver. It rejects trailing
+// bytes after the encoded value: raw is peer-supplied, and the envelope itself
+// is always produced by our own canonical asn1.Marshal, so leftover bytes only
+// ever mean a mangled or deliberately padded signature. (This tightens the
+// MultiSignature *envelope* only — the individual signatures it carries are
+// parsed by their own verifiers, which must stay lenient for external
+// signers/HSMs.)
 func (m *MultiSignature) FromBytes(raw []byte) error {
-	_, err := asn1.Unmarshal(raw, m)
-
-	return err
+	return marshal.UnmarshalCanonicalDER(raw, m)
 }
 
 // JoinSignatures joins the signatures of the given identities into a single signature


### PR DESCRIPTION
`Identity.UniqueID()` hashes the **raw** identity bytes, not the decoded value, and it is the cache key across the identity and wallet layers. So two byte strings that decode to the same identity but differ as bytes give that one identity two cache slots. Every identity decode path allowed exactly that.

## The problem

Alice and Bob's 2-of-2 multisig identity:

```
canonical : 300e 300c 0405 616c696365 0403 626f62
variant   : 3011 300c 0405 616c696365 0403 626f62 02012a
                 ^^ 14 -> 17                      ^^^^^^ undeclared junk
```

Both decode to `MultiIdentity{alice, bob}`; both were accepted; their `UniqueID()`s differ.

Transfer a token to `variant` and it **verifies** — verification works on the decoded identities — but never resolves to Alice's or Bob's wallet, because the lookup works on `UniqueID()`. A valid, signed, spendable token neither owner can see.

Four spellings of one identity did this:

| spelling | caught by |
|---|---|
| garbage appended **after** the value | `rest != 0` |
| garbage smuggled **inside** the SEQUENCE, outer length grown to cover it | re-encode + compare |
| `T61String`/`IA5String`/`GeneralString` where `UTF8String` was declared | re-encode + compare |
| non-minimal lengths (`0x81 0x06`) and integers (`02 02 00 05`) | `readLen` / `parseInt32` |

The second is the subtle one: `rest` only reports bytes *after* the top-level TLV, and `encoding/asn1` silently discards SEQUENCE elements the destination struct has no field for. The outer TLV consumed the whole input, so `rest` is empty and a check on `rest` alone sees a clean parse.

## The fix

* **`marshal.UnmarshalCanonicalDER`** (`MultiIdentity`, `PolicyIdentity`, `MultiSignature`, `PolicySignature`) checks `rest`, then re-encodes the decoded value and requires it to reproduce the input byte-for-byte (`ErrNonCanonical`). One check for the first three rows, and for any further `encoding/asn1` leniency. Cost: one extra marshal of a small struct per decode.
* **`marshal.DecodeIdentity`** (the `TypedIdentity` envelope, and the hot path — hand-walks TLVs, no re-marshal) pins the outer SEQUENCE length to `len(b)`, requires the OCTET STRING to end exactly at `len(b)`, and rejects non-minimal lengths (`ErrNonMinimalLen`) and non-minimal INTEGER contents (`ErrNonMinimalInt`).

## No existing identity can be rejected

The envelope is single-sourced: all seven construction sites funnel through `TypedIdentity.Bytes()` → `marshal.EncodeIdentity`, and the four inner envelopes only through their own `asn1.Marshal`. Every one of those encoders is canonical — `appendTLV` emits minimal lengths, `encodeInt32` strips exactly the bytes `parseInt32` now rejects, and `asn1.Marshal` is canonical by construction, including the legacy string-typed spellings written by older versions of this SDK. There is no non-Go producer of these bytes.

So nothing previously written — on a ledger or in storage — becomes undecodable, and old and new nodes cannot disagree during a rolling upgrade. Pinned by `TestUnmarshalCanonicalDER_AcceptsWhatStdlibMarshalEmits`, `TestDecodeIdentity_AcceptsEveryLengthFormOurEncoderEmits`, `TestDecodeIdentity_AcceptsEveryIntegerOurEncoderEmits` and `TestDecodeIdentity_StdlibEncodingsRemainDecodable`. **If you know of a producer outside this repo, say so** — the two non-minimal checks are the only ones that could reject a legitimately-encoded foreign identity, and can be dropped or gated separately.

Key material is unaffected: x509 certs and idemix credentials live inside the `OCTET STRING` and never reach these decoders.

## Scope

Identity **envelopes** only, per the issue. Deliberately not covered, and now stated in `docs/services/identity.md`:

* Signature parsing (`x509/crypto/ecdsa.go`, `idemixnym/nym/signer.go`) stays lenient — those bytes come from external signers and HSMs. The `MultiSignature`/`PolicySignature` *envelopes* are strict since we always produce them; the signatures they carry are not.
* **The legacy type fold is still a `UniqueID()` split, and it is the same class of problem.** `INTEGER 2`, `UTF8String "x509"` and `PrintableString "x509"` all decode to one x509 identity under three different `UniqueID()`s, so a token paid to the second or third spelling of a victim's identity verifies but does not reach their wallet. This PR narrows that set from unbounded to exactly three; closing it to one cannot be done in the decoder, because older versions of this SDK wrote those spellings and they may exist in persisted data. It needs a rule at the validator boundary — require the `INTEGER` spelling for new transactions, keep decoding the others for reads — tracked separately.
* The payload inside the `OCTET STRING` is **protobuf** for x509/idemix identities, not DER, and remains malleable.

`UnmarshalCanonicalDER`'s round-trip means "`b` is what `asn1.Marshal` would emit", which is narrower than "valid DER": a field tagged `optional`/`omitempty`, or a `time.Time`, would false-reject legal encodings. None of the four types has one, and `TestUnmarshalCanonicalDER_FourCallSitesHaveNoOptionalFields` reflects over them so a future field trips there rather than in production.

## Tests

Every vector is tested at each affected site, asserting the bypass really did decode to the same value with an empty `rest` and a different `UniqueID()` — not just that it now errors. The five fuzz targets also assert canonicality; note this is a contract-level regression guard at the four `asn1` sites (`UnmarshalCanonicalDER` enforces it the same way `Bytes()` computes it), and a genuinely independent check only in `FuzzDecodeIdentityNoPanic`, where `DecodeIdentity` and `EncodeIdentity` are separate implementations. boolpolicy's two targets are new and wired into the nightly-fuzz matrix.

Two `TestDecodeErrors` fixtures had an outer length disagreeing with their own buffer, so the new check fired before the inner failure they were named for; their lengths are corrected rather than their expectations.

Squashed to a single commit, rebased onto current `main`.

Fixes #2071


