### PR TITLE
2032_guard_fabtoken_htlc_validate_missing_signatures

### DIFF
--- a/docs/drivers/extending_validator.md
+++ b/docs/drivers/extending_validator.md
@@ -69,6 +69,11 @@ func MyCustomTransferValidation(ctx validator.Context, tr *transfer.Action) erro
 }
 ```
 
+A validation function must not assume that any other step of the pipeline has already run:
+fields that earlier steps populate (`validator.Context.InputTokens`, `Context.Signatures`, ...)
+may be empty or shorter than expected, so bound-check them and return an error instead of
+indexing blindly.
+
 ### 2. Create a custom Validator Driver
 
 Implement the `driver.ValidatorDriver` interface by wrapping the standard one.

--- a/token/core/fabtoken/v1/validator/validator_test.go
+++ b/token/core/fabtoken/v1/validator/validator_test.go
@@ -997,6 +997,93 @@ func TestTransferHTLCValidate(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expiration date has already passed")
 	})
+
+	t.Run("MissingSignature_NoPanic", func(t *testing.T) {
+		sender, _ := identity.WrapWithType(x509.IdentityType, []byte("sender"))
+		htlcOwner := newExpiredHTLCOwner(t, sender)
+
+		ta := &actions.TransferAction{
+			Outputs: []*actions.Output{
+				{Owner: sender, Type: "ABC", Quantity: "100"},
+			},
+		}
+		c := &validator.Context{
+			TransferAction:  ta,
+			InputTokens:     []*actions.Output{{Owner: htlcOwner, Type: "ABC", Quantity: "100"}},
+			Signatures:      nil,
+			MetadataCounter: make(map[string]int),
+		}
+		err := validator.TransferHTLCValidate(ctx, c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing signature for input at index [0]")
+	})
+
+	t.Run("ShortSignatures_NoPanic", func(t *testing.T) {
+		sender, _ := identity.WrapWithType(x509.IdentityType, []byte("sender"))
+		htlcOwner := newExpiredHTLCOwner(t, sender)
+
+		ta := &actions.TransferAction{
+			Outputs: []*actions.Output{
+				{Owner: sender, Type: "ABC", Quantity: "100"},
+			},
+		}
+		// two htlc-owned inputs but only one signature: the second input must
+		// return an error instead of indexing past the end of ctx.Signatures
+		c := &validator.Context{
+			TransferAction: ta,
+			InputTokens: []*actions.Output{
+				{Owner: htlcOwner, Type: "ABC", Quantity: "100"},
+				{Owner: htlcOwner, Type: "ABC", Quantity: "100"},
+			},
+			Signatures:      [][]byte{[]byte("sig")},
+			MetadataCounter: make(map[string]int),
+		}
+		err := validator.TransferHTLCValidate(ctx, c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing signature for input at index [1]")
+	})
+
+	t.Run("NilInputToken_NoPanic", func(t *testing.T) {
+		owner1, _ := identity.WrapWithType(x509.IdentityType, []byte("owner1"))
+		ta := &actions.TransferAction{
+			Outputs: []*actions.Output{{Owner: owner1, Type: "ABC", Quantity: "100"}},
+		}
+		c := &validator.Context{
+			TransferAction:  ta,
+			InputTokens:     []*actions.Output{nil},
+			MetadataCounter: make(map[string]int),
+		}
+		err := validator.TransferHTLCValidate(ctx, c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil input token at index [0]")
+	})
+}
+
+// newExpiredHTLCOwner returns an htlc-script identity whose deadline has already
+// passed, so that a transfer back to the sender is validated as a reclaim.
+func newExpiredHTLCOwner(t *testing.T, sender driver.Identity) driver.Identity {
+	t.Helper()
+
+	recipient, err := identity.WrapWithType(x509.IdentityType, []byte("recipient"))
+	require.NoError(t, err)
+	hash := crypto.SHA256.New()
+	hash.Write([]byte("preimage"))
+	script := &htlc.Script{
+		Sender:    sender,
+		Recipient: recipient,
+		Deadline:  time.Now().Add(-1 * time.Hour), // expired
+		HashInfo: htlc.HashInfo{
+			Hash:         hash.Sum(nil),
+			HashFunc:     crypto.SHA256,
+			HashEncoding: encoding.Base64,
+		},
+	}
+	scriptBytes, err := json.Marshal(script)
+	require.NoError(t, err)
+	htlcOwner, err := identity.WrapWithType(htlc.ScriptType, scriptBytes)
+	require.NoError(t, err)
+
+	return htlcOwner
 }
 
 // BenchmarkValidatorTransfer benchmarks the verification of a transfer token request.

--- a/token/core/fabtoken/v1/validator/validator_transfer.go
+++ b/token/core/fabtoken/v1/validator/validator_transfer.go
@@ -150,11 +150,18 @@ func TransferBalanceValidate(c context.Context, ctx *Context) error {
 	return nil
 }
 
-// TransferHTLCValidate checks the validity of the HTLC scripts, if any
+// TransferHTLCValidate checks the validity of the HTLC scripts, if any.
+// A nil input token or a signature missing at the index of an HTLC-owned input
+// yields a validation error rather than a panic, regardless of the order in which
+// the validation steps of the pipeline are executed.
 func TransferHTLCValidate(c context.Context, ctx *Context) error {
 	now := time.Now()
 
 	for i, in := range ctx.InputTokens {
+		// guard: a nil token in the input slice must return an error, not panic
+		if in == nil {
+			return errors.Errorf("nil input token at index [%d]", i)
+		}
 		owner, err := identity.UnmarshalTypedIdentity(in.GetOwner())
 		if err != nil {
 			return errors.Wrap(err, "failed to unmarshal owner of input token")
@@ -186,6 +193,11 @@ func TransferHTLCValidate(c context.Context, ctx *Context) error {
 			}
 
 			// check metadata
+			// guard against a missing signature at index i (e.g., when this validator
+			// runs without TransferSignatureValidate having populated ctx.Signatures)
+			if i >= len(ctx.Signatures) {
+				return errors.Errorf("missing signature for input at index [%d]", i)
+			}
 			sigma := ctx.Signatures[i]
 			metadataKey, err := htlc2.MetadataClaimKeyCheck(ctx.TransferAction, script, op, sigma)
 			if err != nil {


### PR DESCRIPTION
`TransferHTLCValidate` in the fabtoken transfer validator indexed `ctx.Signatures` with the
`ctx.InputTokens` loop index without a bounds check, so a nil or short `ctx.Signatures` made an
HTLC-owned input panic with index-out-of-range instead of returning a validation error. The
equivalent zkatdlog validator already guards this case.

This PR adds the same bounds check, plus a nil guard for entries of `ctx.InputTokens` whose owner
was dereferenced unconditionally in the same loop, and regression tests for both. Neither state is
reachable through the default pipeline — `TransferSignatureValidate` populates one signature per
input before this step runs — so this is a defense-in-depth fix for reordered or custom validation
pipelines. The validator extension guide now notes that a validation function must not assume other
pipeline steps have already run.

Fixes #2032