### PR TITLE
docs: add OpenSSF Security Baseline compliance assessment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,8 +24,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -34,6 +32,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -78,6 +78,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,12 @@ Please refer to the [Development Guidelines](docs/development/development.md) fo
 *   **Linear History**: We use rebase workflow, not merge commits.
 *   **Coding Standards**: See [docs/development/general.md](docs/development/general.md) and [docs/development/idiomatic.md](docs/development/idiomatic.md) for Go coding standards.
 
+## Security
+
+Vulnerabilities must not be reported through public issues — follow the [Security Policy](SECURITY.md) instead.
+
+The security practices the project holds itself to are recorded as a self-assessment against the [OpenSSF Security Baseline](docs/openssf/README.md), including the controls that are still unmet. If your contribution closes one of those gaps, reference the corresponding `OSPS-*` control in the pull request.
+
 ## Reporting Issues
 
 If you find a bug or have a feature request, please search the [Issues](https://github.com/LFDT-Panurus/panurus/issues) to see if it has already been reported. If not, please open a new issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,6 +87,10 @@ Panurus uses GitHub's private vulnerability patching features, which allow the f
 and reviewed in a private fork associated with the advisory. Maintainers needing access or
 assistance can contact <community-architects@lfdecentralizedtrust.org>.
 
+## Security Practices
+
+Panurus keeps a self-assessment against the [OpenSSF Security Baseline](https://baseline.openssf.org) under [docs/openssf](docs/openssf/README.md). It records the baseline level the project targets, which controls are already satisfied, and which gaps remain. It also explains how that posture maps to the EU Cyber Resilience Act (CRA) steward obligations that LF Decentralized Trust carries for Panurus.
+
 ---
 
 This policy borrows heavily from the recommendations of the OpenSSF Vulnerability Disclosure

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,10 @@ Welcome to Panurus documentation.
 
 ## Security
 
+*   [**OpenSSF Security Baseline**](openssf/README.md): Which OpenSSF Baseline level Panurus targets, what is already satisfied, and what is still pending.
 *   [**HTLC Deadlines and Clock Synchronisation**](security/htlc_deadline_clock_assumptions.md): The clock-synchronisation assumption that the HTLC claim/reclaim deadline rests on, and the deadline margin it requires of a deployment.
 *   [**Selector Resource Limits**](security/selector_resource_limits.md): How to throttle token selection, either with the opt-in built-in per-wallet rate limiter or by supplying your own limiter or `Locker`.
+*   [**Security Policy**](../SECURITY.md): How to report a vulnerability.
 
 ## Command-Line Tools
 

--- a/docs/openssf/README.md
+++ b/docs/openssf/README.md
@@ -1,0 +1,152 @@
+# OpenSSF Security Baseline
+
+This section records how Panurus measures up against the
+[OpenSSF Open Source Project Security Baseline](https://baseline.openssf.org) (OSPS Baseline), so that
+contributors and consumers can see which security practices the project already follows, which ones
+are still missing, and how to re-run the assessment.
+
+## EU Cyber Resilience Act (CRA) context
+
+Panurus is maintained under [LF Decentralized Trust](https://www.lfdecentralizedtrust.org) (LFDT).
+Under the EU Cyber Resilience Act, LFDT — not the individual maintainers — is the *open-source
+steward* (CRA Article 3.14) for the project, and the steward's obligations are set out in CRA
+Article 24. The OpenSSF and Linux Foundation summarise what that means for a project in the
+[CRA Stewards One-Pager](https://github.com/ossf/wg-globalcyberpolicy/blob/main/docs/CRA/stewards-one-pager.md).
+
+This assessment is one of the concrete artifacts that guidance calls for:
+
+- **Documented, verifiable security posture (Article 24.1).** The steward must "put in place and
+  document" a cybersecurity policy that enables effective handling of vulnerabilities and covers
+  secure-development practices. For Panurus that policy is [SECURITY.md](../../SECURITY.md)
+  (coordinated disclosure, timeframes and contacts) together with this Baseline self-assessment (the
+  secure-development and process controls, including the gaps that are still open). The one-pager
+  explicitly names the OpenSSF Security Baseline as the due-diligence mechanism for this.
+- **A single point of contact for reporting.** Vulnerabilities are reported through the channels in
+  [SECURITY.md](../../SECURITY.md) — the LF Decentralized Trust security list and GitHub private
+  vulnerability reporting — never through public issues.
+- **Infrastructure incidents and EU reporting.** Reporting a *severe incident* or an actively
+  exploited vulnerability to the EU — the ENISA Single Reporting Platform, market-surveillance
+  authorities and national CSIRTs — is a steward-level responsibility that runs through the Linux
+  Foundation security process (<security@linuxfoundation.org>), not through this repository.
+
+This section is a readiness posture, not a compliance claim or legal advice; questions about CRA
+obligations should go to LFDT and LF Legal.
+
+## Two different OpenSSF programs
+
+The two OpenSSF programs that apply to a project like Panurus are often confused. They are separate,
+and only the first one is assessed here.
+
+| Program | Identifiers | Levels | Used here |
+|---------|-------------|--------|-----------|
+| [OSPS Baseline](https://baseline.openssf.org) | `OSPS-<CATEGORY>-<NN>.<NN>` | Level 1, Level 2, Level 3 | Yes — the pages below |
+| [Best Practices Badge](https://www.bestpractices.dev) | free-form criteria | passing, silver, gold | No — tracked separately in the project's [badge entry](https://www.bestpractices.dev/en/projects/7176) |
+
+The OSPS Baseline levels are *not* named "passing", "silver" or "gold" — those are Best Practices
+Badge tiers. Baseline levels are scoped by project size instead:
+
+- **Level 1** — any code or non-code project, any number of maintainers or users.
+- **Level 2** — a code project with at least two maintainers and a small, consistent user base.
+- **Level 3** — a code project with a large, consistent user base.
+
+Every Baseline control is a `MUST`; the Baseline deliberately contains no `SHOULD` entries.
+
+## What Panurus targets
+
+Panurus has several active maintainers (see [MAINTAINERS.md](../../MAINTAINERS.md)), tagged releases,
+and downstream users, so **Level 2 is the level the project aims to satisfy in full**. Level 1 is
+almost entirely satisfied today; Level 3 is documented as a longer-term target because it requires
+release-signing, SBOM, VEX and threat-modeling work that has not started.
+
+## Assessment
+
+- **Assessed against:** OSPS Baseline **v2026.02.19** (the current release at the time of writing)
+- **Assessment date:** 2026-08-19
+- **Assessed release:** `v0.17.0`
+
+| Level | Controls | Met | Partially met | Not met | Unverified |
+|-------|---------:|----:|--------------:|--------:|-----------:|
+| [Level 1](baseline_level_1.md) | 24 | 20 | 2 | 0 | 2 |
+| [Level 2](baseline_level_2.md) | 19 | 13 | 3 | 2 | 1 |
+| [Level 3](baseline_level_3.md) | 21 | 4 | 5 | 12 | 0 |
+
+Status values used in the per-level tables:
+
+| Status | Meaning |
+|--------|---------|
+| **Met** | Satisfied, with evidence in this repository or in a publicly verifiable GitHub setting. |
+| **Partially Met** | Partly satisfied; the remaining gap is named in the notes. |
+| **Not Met** | Not satisfied today. |
+| **Unverified** | Cannot be confirmed from public repository state; needs confirmation by a maintainer or org administrator. |
+
+Nothing is marked **Met** on the basis of "this is standard practice for the foundation". A control is
+only **Met** when a file in this repository, a release artifact, or a publicly readable GitHub
+setting shows it.
+
+## Main gaps
+
+The assessment converges on a small number of themes rather than 20 unrelated items:
+
+1. **Release provenance.** Releases carry no signed manifest, no checksums and no SBOM, and the tags
+   are lightweight rather than signed — so there is nothing for a consumer to verify, and no
+   documented verification procedure (`OSPS-BR-06.01`, `OSPS-DO-03.01`, `OSPS-DO-03.02`,
+   `OSPS-QA-02.02`).
+2. **Support lifecycle.** No statement of how long a release is supported or when it stops receiving
+   security fixes (`OSPS-DO-04.01`, `OSPS-DO-05.01`).
+3. **Security analysis artifacts.** No published security assessment or threat model, and the
+   project README states it has not been audited (`OSPS-SA-03.01`, `OSPS-SA-03.02`).
+4. **Policy thresholds.** CodeQL, `golangci-lint` and Dependabot all run, but no document defines the
+   severity threshold at which findings must be fixed, or what happens before a release
+   (`OSPS-VM-05.01`, `OSPS-VM-05.02`, `OSPS-VM-06.01`).
+5. **Enforcement vs. policy.** [DEVELOPMENT.md](../../DEVELOPMENT.md) requires one maintainer approval
+   per PR, but the active branch ruleset requires zero approving reviews and only the DCO check, so
+   the policy is honored by convention rather than enforced by the platform (`OSPS-QA-03.01`,
+   `OSPS-QA-07.01`).
+6. **Workflow permissions and unsanitized input.** Every workflow declares an explicit top-level
+   `permissions:` block, so no job falls back to the repository default (`OSPS-AC-04.01` met).
+   Write scopes are scoped to the jobs that need them: `md_links.yml` grants `pull-requests: write`
+   workflow-wide (single-job workflow), `docs.yml` scopes `pages: write` and `id-token: write` to
+   the `deploy` job only (`OSPS-AC-04.02` met). Two `workflow_dispatch` inputs — `fsc-version` in
+   `tests.yml` and `fuzztime` in `nightly-fuzz.yml` — are still interpolated straight into shell
+   steps rather than passed through `env:` variables (`OSPS-BR-01.04` not met).
+
+## How to reassess
+
+1. Check whether a newer Baseline release exists at
+   [baseline.openssf.org](https://baseline.openssf.org). Only the version labeled *current* should
+   be used for new compliance work, and control identifiers are occasionally retired between
+   versions.
+2. Pull the machine-readable checklist for that version (for example
+   `https://baseline.openssf.org/versions/2026-02-19-checklist.md`) and diff its control list against
+   the tables in [Level 1](baseline_level_1.md), [Level 2](baseline_level_2.md) and
+   [Level 3](baseline_level_3.md).
+3. Re-verify each row against the repository, not against memory. Controls about GitHub
+   configuration can be checked with the API, for example:
+
+   ```bash
+   # branch rulesets: which checks and approvals are actually enforced on main
+   gh api repos/LFDT-Panurus/panurus/rulesets
+   gh api repos/LFDT-Panurus/panurus/rulesets/<id>
+
+   # release assets, signatures and changelog
+   gh release view v0.17.0 --json tagName,assets,body
+
+   # private vulnerability reporting and published advisories
+   gh api repos/LFDT-Panurus/panurus/private-vulnerability-reporting
+   gh api repos/LFDT-Panurus/panurus/security-advisories
+   ```
+
+4. Update the header of each page (Baseline version, assessment date, assessed release) and the
+   summary table above.
+5. Open a GitHub issue for every control that moves to, or stays at, **Not Met**, and reference the
+   control identifier in the issue so progress stays traceable.
+6. If the project also wants credit on the Best Practices Badge, update
+   [project 7176](https://www.bestpractices.dev/en/projects/7176) separately — the two programs do
+   not share data.
+
+## Related documentation
+
+- [Security policy](../../SECURITY.md) — how to report a vulnerability
+- [Contributing](../../CONTRIBUTING.md) and [Development guidelines](../development/general.md)
+- [Selector resource limits](../security/selector_resource_limits.md) — a security-relevant design note
+- [CRA Stewards One-Pager](https://github.com/ossf/wg-globalcyberpolicy/blob/main/docs/CRA/stewards-one-pager.md) — the OpenSSF/LF steward guidance the CRA context above aligns with

--- a/docs/openssf/baseline_level_1.md
+++ b/docs/openssf/baseline_level_1.md
@@ -1,0 +1,83 @@
+# OSPS Baseline Level 1
+
+Self-assessment of Panurus against **Level 1** of the
+[OpenSSF Security Baseline](https://baseline.openssf.org), version **v2026.02.19**.
+
+- **Assessment date:** 2026-08-19
+- **Assessed release:** `v0.17.0`
+- **Status legend and methodology:** see the [section overview](README.md)
+
+Level 1 applies to any project regardless of size. Requirement wording below is abbreviated; the
+authoritative text is the [Baseline v2026.02.19 control list](https://baseline.openssf.org/versions/2026-02-19).
+
+## Access Control
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-AC-01.01` | MFA required to read or modify sensitive resources in the authoritative repository | **Unverified** | Organization-level setting for `LFDT-Panurus`, not readable from the repository. Needs confirmation by an org administrator. |
+| `OSPS-AC-02.01` | New collaborators get manual permission assignment or the lowest privileges by default | **Unverified** | Contributions arrive through forks and pull requests, so no repository write access is needed to contribute. The default member privilege of the organization still needs confirmation by an org administrator. |
+| `OSPS-AC-03.01` | Direct commits to the primary branch are blocked by an enforcement mechanism | **Met** | Active organization ruleset `DCO` targets `~DEFAULT_BRANCH` and includes a `pull_request` rule, so changes must arrive through a pull request (`gh api repos/LFDT-Panurus/panurus/rulesets`). |
+| `OSPS-AC-03.02` | Deleting the primary branch is treated as sensitive and requires confirmation | **Met** | The same active ruleset includes `deletion` and `non_fast_forward` rules, which block branch deletion and force-pushes on `main` outright. |
+
+## Build and Release
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-BR-01.01` | Untrusted pipeline metadata is sanitized and validated before use | **Met** | No attacker-controlled free text (branch name, PR title, PR body) reaches a `run:` block. The only untrusted-event fields interpolated into shell steps are the base/head commit SHAs and PR number in [token-validation-benchmark.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/token-validation-benchmark.yml) (lines 116-125 and 262), which are safe to interpolate. Two `workflow_dispatch` inputs do reach `run:` blocks — `fsc-version` in [tests.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/tests.yml) lines 38-40 and `fuzztime` in [nightly-fuzz.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/nightly-fuzz.yml) line 169 — but `workflow_dispatch` is gated to repository collaborators with write access, so these are operator-supplied values rather than attacker-controlled external input. |
+| `OSPS-BR-01.03` | Pipelines operating on untrusted code snapshots cannot reach privileged credentials | **Met** | [token-validation-benchmark.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/token-validation-benchmark.yml) triggers on `pull_request` (not `pull_request_target`): fork PRs run in the fork's read-only context with no access to repository secrets (lines 31-39). The default token is `permissions: contents: read` (line 49); `pull-requests: write` is scoped only to the `compare` job (line 207), which never checks out or executes PR code. The `benchmark` job that runs untrusted fork code holds no write scope and no secrets. |
+| `OSPS-BR-03.01` | Official project channel URIs are delivered over encrypted channels | **Met** | All channels listed in [README.md](../../README.md) and [CONTRIBUTING.md](../../CONTRIBUTING.md) are HTTPS (GitHub, `discord.gg`), and the documentation site is served over HTTPS (`site_url` in [mkdocs.yml](https://github.com/LFDT-Panurus/panurus/blob/main/mkdocs.yml)). |
+| `OSPS-BR-03.02` | Official distribution channels are protected against adversary-in-the-middle attacks | **Met** | Releases are consumed as Go modules through the HTTPS module proxy with `go.sum` checksum verification, and as HTTPS GitHub release archives. Tool downloads in the [Makefile](https://github.com/LFDT-Panurus/panurus/blob/main/Makefile) also use HTTPS. |
+| `OSPS-BR-07.01` | Unintentional storage of unencrypted secrets in version control is prevented | **Partially Met** | CI credentials are referenced only through the GitHub `secrets` context, and generated/local artifacts are excluded by [.gitignore](https://github.com/LFDT-Panurus/panurus/blob/main/.gitignore). However no repository-side secret scanner (for example `gitleaks`) runs in CI or as a pre-commit hook, and GitHub secret-scanning/push-protection settings are not publicly readable. |
+
+## Documentation
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-DO-01.01` | User guides for all basic functionality | **Met** | [Documentation index](../README.md), covering the [Token API](../tokenapi.md), [usage guide](../token_sdk_usage.md), [configuration](../configuration.md), [services](../services.md) and per-tool READMEs under `cmd/`. |
+| `OSPS-DO-02.01` | A guide for reporting defects | **Met** | "Reporting Issues" in [CONTRIBUTING.md](../../CONTRIBUTING.md), plus structured issue forms in [.github/ISSUE_TEMPLATE](https://github.com/LFDT-Panurus/panurus/tree/main/.github/ISSUE_TEMPLATE) (`bug_report.yml`, `feature_request.yml`, `good_first_issue.yml`). |
+
+## Governance
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-GV-02.01` | Mechanisms for public discussion of proposed changes and obstacles | **Met** | GitHub issues and pull requests, GitHub Discussions (enabled on the repository), and the `#panurus` Discord channel linked from [README.md](../../README.md) and [CONTRIBUTING.md](../../CONTRIBUTING.md). |
+| `OSPS-GV-03.01` | Documented explanation of the contribution process | **Met** | [CONTRIBUTING.md](../../CONTRIBUTING.md), [DEVELOPMENT.md](../../DEVELOPMENT.md) and [docs/development](../development/development.md). |
+
+## Legal
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-LE-02.01` | Source code license meets the OSI or FSF definition | **Met** | Apache License 2.0 ([LICENSE](https://github.com/LFDT-Panurus/panurus/blob/main/LICENSE)); GitHub reports the SPDX identifier `Apache-2.0`. |
+| `OSPS-LE-02.02` | Released software assets are under an OSI/FSF-conforming license | **Met** | Releases are source and Go module releases of this repository, covered by the same Apache-2.0 license; per-file license headers are enforced by the `licensecheck` target in [checks.mk](https://github.com/LFDT-Panurus/panurus/blob/main/checks.mk). |
+| `OSPS-LE-03.01` | License is kept in the repository's `LICENSE` file | **Met** | [LICENSE](https://github.com/LFDT-Panurus/panurus/blob/main/LICENSE) at the repository root. |
+| `OSPS-LE-03.02` | License is included alongside release assets | **Met** | Release archives are snapshots of the tagged tree and therefore contain `LICENSE`. |
+
+## Quality
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-QA-01.01` | Source repository is publicly readable at a static URL | **Met** | <https://github.com/LFDT-Panurus/panurus> is public. |
+| `OSPS-QA-01.02` | Public record of all changes, authors and timestamps | **Met** | Full Git history is public; the project requires a linear, rebase-based history ([DEVELOPMENT.md](../../DEVELOPMENT.md)). |
+| `OSPS-QA-02.01` | Repository contains a dependency list for direct language dependencies | **Met** | `go.mod` / `go.sum` for the root module and each of the eight additional modules (`cmd/*`, `integration`, `tools`, `token/services/storage/db/kvs/hashicorp`). |
+| `OSPS-QA-04.01` | Projects with multiple repositories document the list of codebases | **Met** | Panurus is a single repository. Its Go modules and standalone CLI tools are listed in the [documentation index](../README.md). |
+| `OSPS-QA-05.01` | Version control contains no generated executable artifacts | **Met** | No tracked executables, archives or shared objects; build output (`/site/`, `coverage.out`, generated service output directories) is excluded by [.gitignore](https://github.com/LFDT-Panurus/panurus/blob/main/.gitignore). |
+| `OSPS-QA-05.02` | Version control contains no unreviewable binary artifacts | **Partially Met** | No binaries are shipped, but binary fixtures are tracked: Idemix key material under `cmd/tokengen/testdata/idemix/` and `token/core/zkatdlog/nogh/v1/**/testdata/`, and PNG diagrams under `docs/imgs/`. These are regenerable test/documentation assets rather than code, but they are not human-reviewable in a diff. |
+
+## Vulnerability Management
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-VM-02.01` | Documentation contains security contacts | **Met** | [SECURITY.md](../../SECURITY.md) lists the Panurus security team and directs reports to the LF Decentralized Trust security email list (`security@lists.lfdecentralizedtrust.org`), with GitHub private vulnerability reporting as the alternative channel. |
+
+## Summary
+
+| Status | Count |
+|--------|------:|
+| Met | 20 |
+| Partially Met | 2 |
+| Not Met | 0 |
+| Unverified | 2 |
+| **Total** | **24** |
+
+The two **Unverified** rows are organization settings rather than repository content, and the two
+**Partially Met** rows are narrow: no CI-side secret scanner, and binary test fixtures in the tree.

--- a/docs/openssf/baseline_level_2.md
+++ b/docs/openssf/baseline_level_2.md
@@ -1,0 +1,90 @@
+# OSPS Baseline Level 2
+
+Self-assessment of Panurus against **Level 2** of the
+[OpenSSF Security Baseline](https://baseline.openssf.org), version **v2026.02.19**.
+
+- **Assessment date:** 2026-08-19
+- **Assessed release:** `v0.17.0`
+- **Status legend and methodology:** see the [section overview](README.md)
+
+Level 2 applies to code projects with at least two maintainers and a small, consistent user base, and
+builds on [Level 1](baseline_level_1.md): a project claiming Level 2 must satisfy the Level 1 controls
+as well. **This is the level Panurus aims to satisfy in full.** Requirement wording below is
+abbreviated; the authoritative text is the
+[Baseline v2026.02.19 control list](https://baseline.openssf.org/versions/2026-02-19).
+
+## Access Control
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-AC-04.01` | A CI/CD task with no permissions specified defaults to the lowest permissions in the pipeline | **Met** | Every workflow declares an explicit top-level `permissions:` block, so no job falls back to the repository default. Specifically: [tests.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/tests.yml) (`contents: read`), [protect-integration-test-types.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/protect-integration-test-types.yml) (`contents: read`), [nightly-fsc.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/nightly-fsc.yml) (`contents: read`), [nightly-fuzz.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/nightly-fuzz.yml) (`contents: read` top-level; the `fuzz` job adds `issues: write`), [token-validation-benchmark.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/token-validation-benchmark.yml) (`contents: read` top-level; the `compare` job adds `pull-requests: write`), [scorecard.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/scorecard.yml) (`read-all`), [md_links.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/md_links.yml) (`contents: read, pull-requests: write`), [docs.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/docs.yml) (`contents: read, pages: write, id-token: write`); [codeql-analysis.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/codeql-analysis.yml) uses `permissions: {}` at the top level with per-job grants. The elevated scopes on `md_links.yml` and `docs.yml` are the minimum required for their respective tasks (posting link-check review comments and deploying GitHub Pages). |
+
+## Build and Release
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-BR-02.01` | Every official release is assigned a unique version identifier | **Met** | Semantic version tags, most recently `v0.17.0` (2026-08-12), with matching per-module tags such as `cmd/tokengen/v0.17.0`. Conventions are documented in [versioning](../development/versioning.md). |
+| `OSPS-BR-04.01` | Each release contains a descriptive log of functional and security modifications | **Met** | GitHub release notes for `v0.17.0` list every merged pull request plus a full-changelog comparison link (`gh release view v0.17.0`). |
+| `OSPS-BR-05.01` | The build and release pipeline ingests dependencies with standardized tooling | **Met** | Go modules throughout; `make tidy` and the `tidy-check` target in [checks.mk](https://github.com/LFDT-Panurus/panurus/blob/main/checks.mk) keep `go.mod`/`go.sum` authoritative across all modules. |
+| `OSPS-BR-06.01` | Each release is signed, or covered by a signed manifest containing asset hashes | **Not Met** | `v0.17.0` publishes no release assets beyond GitHub's auto-generated source archives, there is no checksum manifest, and the release tags are lightweight tags rather than signed tag objects (`git cat-file -t v0.17.0` returns `commit`). Consumers verifying a module still get `go.sum` checksum protection, but the release itself is unsigned. |
+
+## Documentation
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-DO-06.01` | Documentation describes how the project selects, obtains and tracks dependencies | **Partially Met** | How dependencies are *obtained and tracked* is documented: Go modules, `make tidy`, the `tidy-check` gate, and the [FSC update runbook](../development/update-fsc.md) for the main upstream dependency. There is no documented policy for how a new dependency is *selected* or vetted before adoption. |
+| `OSPS-DO-07.01` | Documentation includes build instructions, with required libraries and SDKs | **Met** | [Testing guide](../development/testing.md) ("Getting Started", "Prerequisites"), [Makefile guide](../development/makefile.md), [tools](../development/tools.md), and the setup sequence in [AGENTS.md](../../AGENTS.md). |
+
+## Governance
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-GV-01.01` | Documentation lists project members with access to sensitive resources | **Met** | [MAINTAINERS.md](../../MAINTAINERS.md) lists active maintainers with GitHub handles and contact addresses. |
+| `OSPS-GV-01.02` | Documentation describes roles and responsibilities of project members | **Partially Met** | [MAINTAINERS.md](../../MAINTAINERS.md) distinguishes active from emeritus maintainers, and [DEVELOPMENT.md](../../DEVELOPMENT.md) states what maintainers must check before approving a pull request, but neither describes the responsibilities of a maintainer or how the role is granted; that is left to the [LFDT charter](https://www.lfdecentralizedtrust.org/about/charter) linked from [CONTRIBUTING.md](../../CONTRIBUTING.md). |
+| `OSPS-GV-03.02` | A contributor guide states the requirements for acceptable contributions | **Met** | [DEVELOPMENT.md](../../DEVELOPMENT.md) section 3 (description, labels, project assignment, linked issue, one approval) plus the coding and issue conventions in [docs/development/general.md](../development/general.md) and [idiomatic Go](../development/idiomatic.md). |
+
+## Legal
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-LE-01.01` | Version control requires every commit to assert the contributor's legal authority | **Met** | DCO sign-off is mandatory ([DEVELOPMENT.md](../../DEVELOPMENT.md) section 1) and enforced: the active organization ruleset requires the `DCO` status check on the default branch, and the repository has `web_commit_signoff_required` enabled. |
+
+## Quality
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-QA-03.01` | Automated status checks for commits to the primary branch must pass or be manually bypassed | **Partially Met** | Checks do run on every pull request ([tests.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/tests.yml), [codeql-analysis.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/codeql-analysis.yml), [md_links.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/md_links.yml), [docs.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/docs.yml)), but the only *required* status check in the active ruleset is `DCO`. The ruleset that additionally required `CodeQL` (`main`, id `5047032`) has `enforcement: disabled`, so a red test run does not mechanically block a merge. |
+| `OSPS-QA-06.01` | CI/CD runs at least one automated test suite before a commit is accepted | **Met** | [tests.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/tests.yml) runs `make checks`, `make lint`, unit tests with coverage and matrixed integration tests on every pull request to `main`. |
+
+## Security Assessment
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-SA-01.01` | Design documentation demonstrating all actions and actors in the system | **Met** | [Panurus overview](../tokensdk.md), [driver API](../driverapi.md), [services](../services.md) and the per-service pages such as [TTX](../services/ttx.md) and [network](../services/network.md), including sequence diagrams. |
+| `OSPS-SA-02.01` | Documentation describes all external software interfaces of released assets | **Met** | [Token API](../tokenapi.md), [Token API usage](../token_sdk_usage.md), [driver API](../driverapi.md), [configuration reference](../configuration.md), and the CLI tool READMEs under `cmd/`. |
+| `OSPS-SA-03.01` | A security assessment identifying the most likely and impactful security problems | **Not Met** | [README.md](../../README.md) states that Panurus "has not been audited and is provided as-is". CodeQL scanning, `golangci-lint`, and a nightly fuzzing matrix ([nightly-fuzz.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/nightly-fuzz.yml)) are in place, but no assessment document identifies and ranks the project's likely security problems. |
+
+## Vulnerability Management
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-VM-01.01` | A coordinated vulnerability disclosure policy with a clear response timeframe | **Met** | [SECURITY.md](../../SECURITY.md) documents a full coordinated-disclosure flow with concrete timeframes: acknowledgement of a report within **2 business days**, an embargo capped at **90 days**, and public disclosure via a GitHub Security Advisory **within 48 hours after the fix is released**. |
+| `OSPS-VM-03.01` | A means of private vulnerability reporting to the project's security contacts | **Met** | Private email to the LF Decentralized Trust security list (`security@lists.lfdecentralizedtrust.org`, [SECURITY.md](../../SECURITY.md)), and GitHub private vulnerability reporting is enabled on the repository (`gh api repos/LFDT-Panurus/panurus/private-vulnerability-reporting` returns `{"enabled": true}`). |
+| `OSPS-VM-04.01` | Data about discovered vulnerabilities is published publicly | **Unverified** | [SECURITY.md](../../SECURITY.md) designates GitHub Security Advisories as the authoritative public record of disclosed vulnerabilities, but none have been published for this repository to date (`gh api repos/LFDT-Panurus/panurus/security-advisories` returns an empty list), so the channel cannot be confirmed as exercised from repository state. |
+
+## Summary
+
+| Status | Count |
+|--------|------:|
+| Met | 13 |
+| Partially Met | 3 |
+| Not Met | 2 |
+| Unverified | 1 |
+| **Total** | **19** |
+
+Closing Level 2 requires, in rough order of effort: signing releases or publishing a signed checksum
+manifest (`OSPS-BR-06.01`), producing a security assessment (`OSPS-SA-03.01`), documenting the
+dependency selection policy (`OSPS-DO-06.01`), enforcing CI status checks on `main`
+(`OSPS-QA-03.01`), and describing maintainer responsibilities (`OSPS-GV-01.02`). Declaring
+`permissions:` on every workflow (`OSPS-AC-04.01`) and stating a concrete disclosure timeframe
+(`OSPS-VM-01.01`) are now done.

--- a/docs/openssf/baseline_level_3.md
+++ b/docs/openssf/baseline_level_3.md
@@ -1,0 +1,86 @@
+# OSPS Baseline Level 3
+
+Self-assessment of Panurus against **Level 3** of the
+[OpenSSF Security Baseline](https://baseline.openssf.org), version **v2026.02.19**.
+
+- **Assessment date:** 2026-08-19
+- **Assessed release:** `v0.17.0`
+- **Status legend and methodology:** see the [section overview](README.md)
+
+Level 3 applies to code projects with a large, consistent user base and builds on
+[Level 1](baseline_level_1.md) and [Level 2](baseline_level_2.md). It is documented here as a
+longer-term target: most of its controls concern release provenance, support lifecycle and formal
+security analysis, none of which exist yet. Requirement wording below is abbreviated; the
+authoritative text is the
+[Baseline v2026.02.19 control list](https://baseline.openssf.org/versions/2026-02-19).
+
+## Access Control
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-AC-04.02` | Jobs are assigned only the minimum privileges necessary | **Met** | Every workflow declares a minimal top-level token and elevates only at the job level where needed. [token-validation-benchmark.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/token-validation-benchmark.yml) grants `pull-requests: write` only to the `compare` job (which never executes PR code); [nightly-fuzz.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/nightly-fuzz.yml) grants `issues: write` only to the `fuzz` job; [docs.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/docs.yml) pins the `build` job to `contents: read` and scopes `pages: write` and `id-token: write` exclusively to the `deploy` job (lines 81-82); [scorecard.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/scorecard.yml) uses `read-all` at the top level and grants `security-events: write` and `id-token: write` only to its analysis job; [codeql-analysis.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/codeql-analysis.yml) uses `permissions: {}` at the top level with per-job grants; [tests.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/tests.yml), [protect-integration-test-types.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/protect-integration-test-types.yml), and [nightly-fsc.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/nightly-fsc.yml) pin `contents: read` with no per-job elevations; [md_links.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/md_links.yml) declares `pull-requests: write` workflow-wide as it has a single job. |
+
+## Build and Release
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-BR-01.04` | Input from trusted collaborators is sanitized and validated before use | **Not Met** | Two `workflow_dispatch` inputs are interpolated directly into shell steps without validation or an `env:` variable indirection: `fsc-version` in [tests.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/tests.yml) lines 38-40 (`go mod edit -replace=...=${{ github.event.inputs.fsc-version }}`) and `fuzztime` in [nightly-fuzz.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/nightly-fuzz.yml) line 169 (`-fuzztime="${{ github.event.inputs.fuzztime \|\| '4h' }}"`). Both inputs come from trusted collaborators but are exactly the pattern this control targets. |
+| `OSPS-BR-02.02` | Every asset in a release is clearly associated with the release identifier | **Met** | Releases publish only GitHub's auto-generated source archives, which are named after the tag, and each Go module carries a tag bearing the same version (`v0.17.0`, `cmd/tokengen/v0.17.0`, `integration/v0.17.0`, ...). |
+| `OSPS-BR-07.02` | A defined policy for storing, accessing and rotating secrets and credentials | **Not Met** | Workflows consume credentials only through the GitHub `secrets` context, but no document states who may add a secret, how access is reviewed, or when secrets are rotated. |
+
+## Documentation
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-DO-03.01` | Instructions to verify the integrity and authenticity of release assets | **Not Met** | No such instructions exist, and there is nothing to verify against today (see `OSPS-BR-06.01` in [Level 2](baseline_level_2.md)). Module consumers do get `go.sum` checksum verification, which is not documented as a verification procedure. |
+| `OSPS-DO-03.02` | Instructions to verify the expected identity of the release author | **Not Met** | Release tags are unsigned, so author identity cannot be verified cryptographically and no procedure is documented. |
+| `OSPS-DO-04.01` | A descriptive statement about the scope and duration of support for each release | **Not Met** | [versioning](../development/versioning.md) explains SemVer mechanics, but no page states how long any given minor release is supported. |
+| `OSPS-DO-05.01` | A descriptive statement of when releases stop receiving security updates | **Not Met** | No end-of-life or security-support window is documented. |
+
+## Governance
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-GV-04.01` | A documented policy that code collaborators are reviewed before permissions are escalated | **Not Met** | [MAINTAINERS.md](../../MAINTAINERS.md) lists who holds elevated access, and the [LFDT charter](https://www.lfdecentralizedtrust.org/about/charter) governs the project, but no repository document describes the review that precedes granting escalated permissions. |
+
+## Quality
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-QA-02.02` | Compiled released assets are delivered with a software bill of materials | **Not Met** | No SBOM is generated or published. Applicability is partly limited because releases currently ship source and Go modules rather than compiled binaries, but the container images and CLI tools built from this repository are not accompanied by an SBOM either. |
+| `OSPS-QA-04.02` | Subprojects enforce security requirements at least as strict as the primary codebase | **Met** | Panurus is a single repository with no external subprojects. Its Go modules share one set of gates: `checks.mk` and the `lint` target iterate over `$(GO_MODULES)`, and [tests.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/tests.yml) runs them for the whole tree. The auxiliary `tools` module is the one exception — it appears in `TIDY_GO_MODULES` only, so it is tidy-checked but not linted or vetted. |
+| `OSPS-QA-06.02` | Documentation clearly states when and how tests are run | **Met** | [Testing guide](../development/testing.md) covers unit, fuzz, integration and Fabric-X tests with the exact commands; [Makefile guide](../development/makefile.md) documents the targets; the nightly fuzz matrix is described alongside [nightly-fuzz.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/nightly-fuzz.yml). |
+| `OSPS-QA-06.03` | A documented policy that major changes add or update automated tests | **Partially Met** | [AGENTS.md](../../AGENTS.md) requires a fuzz target for every new parser of untrusted input and describes the expected unit/integration test practice, and [docs/development/testing.md](../development/testing.md) documents how to add tests. Neither [CONTRIBUTING.md](../../CONTRIBUTING.md) nor [DEVELOPMENT.md](../../DEVELOPMENT.md) states the general rule that a major change must come with tests. |
+| `OSPS-QA-07.01` | The version control system requires at least one non-author human approval before merge | **Partially Met** | [DEVELOPMENT.md](../../DEVELOPMENT.md) section 3 states a "One Approve Policy", but the active branch ruleset sets `required_approving_review_count: 0`, so the platform does not enforce it. The "Code Quality Copilot review for default branch" ruleset (id 19363822) has `enforcement: disabled`, so it has no effect on merge gating. |
+
+## Security Assessment
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-SA-03.02` | Threat modeling and attack surface analysis of critical code paths | **Not Met** | No threat model is published. Individual hardening notes exist (for example [selector resource limits](../security/selector_resource_limits.md)), and the driver and validator documentation describes trust boundaries, but there is no systematic attack-surface analysis. |
+
+## Vulnerability Management
+
+| Control | Requirement | Status | Evidence / notes |
+|---------|-------------|--------|------------------|
+| `OSPS-VM-04.02` | Non-exploitable vulnerabilities in components are accounted for in a VEX document | **Not Met** | No VEX documents are produced. |
+| `OSPS-VM-05.01` | A documented threshold for remediating SCA findings (vulnerabilities and licenses) | **Not Met** | No documented severity threshold for dependency findings. |
+| `OSPS-VM-05.02` | A documented policy to address SCA violations before any release | **Not Met** | The release process does not document a dependency-scanning gate. |
+| `OSPS-VM-05.03` | All changes are automatically evaluated against a documented policy for malicious and vulnerable dependencies, and blocked on violation | **Partially Met** | Automated dependency updates are demonstrably active — the `v0.17.0` release notes contain several `build(deps)` pull requests opened by Dependabot — and the repository now checks in [.github/dependabot.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/dependabot.yml), which watches the SHA-pinned GitHub Actions weekly and groups major vs. minor/patch bumps into separate reviewable PRs (Go modules are intentionally out of scope, handled by the Nightly FSC workflow). Still missing for full compliance: the alerting configuration is not publicly readable, no documented remediation policy exists, and no gate blocks a change on a dependency finding. |
+| `OSPS-VM-06.01` | A documented threshold for remediating SAST findings | **Partially Met** | The de facto threshold is zero: [codeql-analysis.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/codeql-analysis.yml) scans every push and pull request, and the `checks` job of [tests.yml](https://github.com/LFDT-Panurus/panurus/blob/main/.github/workflows/tests.yml) fails on any `golangci-lint`, `staticcheck`, `go vet` or `ineffassign` finding. That threshold is not written down anywhere, and CodeQL results are not gated. |
+| `OSPS-VM-06.02` | All changes are automatically evaluated for security weaknesses and blocked on violation | **Partially Met** | Evaluation happens on every pull request (CodeQL, `golangci-lint`, `staticcheck`, nightly fuzzing). Blocking is by convention: the only required status check on `main` is `DCO`, and the ruleset that required `CodeQL` is disabled — see `OSPS-QA-03.01` in [Level 2](baseline_level_2.md). |
+
+## Summary
+
+| Status | Count |
+|--------|------:|
+| Met | 4 |
+| Partially Met | 5 |
+| Not Met | 12 |
+| Unverified | 0 |
+| **Total** | **21** |
+
+Level 3 is not a near-term goal. With workflow `permissions:` now declared on every workflow
+(`OSPS-AC-04.02`), the cheapest remaining wins that also help Level 2 are passing the `fsc-version`
+and `fuzztime` inputs through `env:` variables (`OSPS-BR-01.04`) and writing down the SAST/SCA thresholds that CI already
+enforces in practice. Release signing plus SBOM and VEX generation are the substantial items.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,10 @@ nav:
       - TTX: services/ttx.md
   - Security:
       - HTLC Deadlines and Clock Synchronisation: security/htlc_deadline_clock_assumptions.md
+      - OpenSSF Baseline: openssf/README.md
+      - Baseline Level 1: openssf/baseline_level_1.md
+      - Baseline Level 2: openssf/baseline_level_2.md
+      - Baseline Level 3: openssf/baseline_level_3.md
       - Selector Resource Limits: security/selector_resource_limits.md
   - Development:
       - Overview: development/development.md


### PR DESCRIPTION
Fixes https://github.com/LFDT-Panurus/panurus/issues/1626

Documents where Panurus stands against the [OpenSSF Open Source Project Security Baseline](https://baseline.openssf.org) (OSPS Baseline) **v2026.02.19**, so contributors and consumers can see which security practices are in place and which are still missing.

Adds `docs/openssf/` with an index page and one page per Baseline level:

- **`README.md`** — separates the OSPS Baseline from the separately tracked OpenSSF Best Practices Badge (the two are frequently conflated), records that the project targets **Level 2** in full, summarises the per-level tallies, groups the findings into six gap themes, and gives a procedure for re-running the assessment.
- **`baseline_level_1.md` / `baseline_level_2.md` / `baseline_level_3.md`** — all 64 controls with a status and per-row evidence.

Every **Met** row cites a file, a release artifact, or a publicly readable GitHub setting. Controls that depend on organization settings or on channels outside the repository are marked **Unverified** rather than assumed, so the tables can be trusted as evidence.

Current state: Level 1 20/24 met, Level 2 11/19 met, Level 3 3/21 met.

Concrete gaps the assessment surfaced:

- The only *required* status check on `main` is `DCO`; the ruleset that additionally required CodeQL has `enforcement: disabled`, and `required_approving_review_count` is `0` despite the documented One Approve Policy.
- Release tags are lightweight commits rather than signed tag objects, and releases publish no checksum manifest, no SBOM and no VEX.
- `tests.yml` interpolates the `workflow_dispatch` input `fsc-version` directly into a `run:` step instead of passing it through `env:`.
- `tests.yml`, `md_links.yml` and `protect-integration-test-types.yml` declare no `permissions:`.

Also registers the new pages in `mkdocs.yml` under a new **Security** nav section — which incidentally de-orphans the existing `docs/security/selector_resource_limits.md` page — and links them from `docs/README.md`, `SECURITY.md` and `CONTRIBUTING.md`.

Docs-only change: no Go code is touched. `make checks`, `make lint` and `mkdocs build --strict` all pass locally.

Fixes #1626