### PR TITLE
docs: document exported metric names and coverage gaps

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -120,6 +120,7 @@ linters:
         - github.com/hyperledger/fabric-lib-go/common/metrics.Gauge
         - github.com/hyperledger/fabric-lib-go/common/metrics.Histogram
         - github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics.Gauge
+        - github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics.Histogram
         - github.com/hyperledger-labs/fabric-smart-client/platform/common/driver.ConfigService
         - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.ViewClient
         - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.Platform

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,8 @@ If you are developing *using* Panurus or contributing *to* Panurus, check out th
 *   [General Guidelines](development/general.md)
 *   [Idiomatic Go](development/idiomatic.md)
 *   [Testing](development/testing.md)
+*   [Monitoring](development/monitoring.md), the [Metrics Reference](development/metrics.md) and the
+    [Grafana dashboards](monitoring/grafana/README.md)
 *   [Test & Benchmark Profiler](../cmd/profiler/README.md)
 
 ## Evolution

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -8,6 +8,8 @@ This page contains link to the development guidelines and more.
 - [Development Tools](./tools.md)
 - [Linting](./linting.md)
 - [Monitoring](./monitoring.md)
+- [Metrics Reference](./metrics.md)
+- [Grafana dashboards](../monitoring/grafana/README.md)
 - [Mock Files Generation](./mock.md)
 - [AI Agents Best Practices](./ai_agents.md)
 - [Tools: tokengen](./tokengen.md)

--- a/docs/development/metrics.md
+++ b/docs/development/metrics.md
@@ -1,0 +1,413 @@
+# Metrics Reference
+
+This page lists every metric Panurus registers, with the **exact name Prometheus exports**, so a name
+can be copied straight into a Prometheus query or a Grafana panel.
+
+The list is not maintained by hand. `token/services/metricsdoc` instantiates every metrics constructor
+in the SDK the way production wiring does, reads the resulting names back out of a Prometheus registry,
+and compares them against `token/services/metricsdoc/testdata/metrics.golden` and against this page.
+Adding, renaming or moving a metric fails that test until this page is updated. Because a name also
+depends on *which* provider production hands the constructor, the same test pins that wiring: it
+asserts that the token drivers are the only place a TMS-scoped provider is built, so dropping or
+relocating the wrapper fails too rather than silently invalidating the names below.
+
+See [Monitoring](./monitoring.md) for the wider monitoring setup and [Driver Metrics](../drivers/metrics.md)
+for how the driver instrumentation is wired. Every metric below already has a panel in the importable
+[Grafana overview dashboard](../monitoring/grafana/README.md), whose queries are checked against this
+same list.
+
+## How a metric name is built
+
+Panurus code never writes the exported name. It supplies only the bare `Name` field:
+
+```go
+p.NewCounter(metrics.CounterOpts{
+    Name: "endorsed_transactions",
+    Help: "The number of endorsed transactions.",
+    LabelNames: []string{"network", "channel", "namespace"},
+})
+```
+
+FSC's Prometheus provider fills in the missing `Namespace` and `Subsystem` from **the Go package of the
+caller** (`platform/view/services/metrics/prometheus/provider.go`), then joins the three parts:
+
+1. The caller's import path is split on `/` — the last segment becomes the **subsystem**, everything
+   before it, joined with `_`, becomes the **namespace**.
+2. Registered replacers rewrite the namespace. Panurus registers
+   `github.com_LFDT-Panurus_panurus_token` → `panurus` in `token/services/logging/init.go`, so every
+   metric of this repository is prefixed `panurus_`.
+3. The exported name is `<namespace>_<subsystem>_<name>`.
+
+So `endorsed_transactions`, created from `token/services/ttx`, is exported as:
+
+```
+github.com/LFDT-Panurus/panurus/token/services/ttx  →  namespace panurus_services, subsystem ttx
+                                                    →  panurus_services_ttx_endorsed_transactions
+```
+
+Two consequences are worth internalising before writing a query or a dashboard:
+
+- **The bare name in the source is never queryable.** A dashboard built from `Name:` fields alone
+  matches nothing — this is what made the first attempt at this documentation unusable.
+- **Some names stutter**, because the metric name repeats its package: hence
+  `panurus_services_auditor_auditor_audit_duration_seconds` and
+  `panurus_services_network_fabricx_finality_queue_finality_queue_pending_events`. They are correct as
+  listed; see [Coverage gaps](#metric-hygiene) for why they are not renamed here.
+
+### The TMS-scoped provider changes the prefix
+
+`metrics.NewTMSProvider` (`token/core/common/metrics/provider.go`) wraps a provider so that every metric
+it creates is bound to fixed `network`/`channel`/`namespace` label values. Because the wrapper calls the
+underlying provider on the caller's behalf, **Prometheus attributes the metric to the wrapper's package**,
+`token/core/common/metrics`, and not to the package that declared it.
+
+Every metric created through a TMS-scoped provider is therefore exported under
+`panurus_core_common_metrics_`, whatever its source file. The clearest example is `cache_level`: it is
+declared in `token/services/identity/idemix/cache/metrics.go`, yet exported as
+`panurus_core_common_metrics_cache_level`.
+
+The wiring that decides this is the driver setup in
+`token/core/{fabtoken/v1,zkatdlog/nogh/v1}/driver/driver.go`, which builds a TMS-scoped provider and
+passes it to the driver services and the wallet service. Everything reached from the
+dependency-injection container instead keeps its own package prefix.
+
+Two rules follow for anyone adding a metric:
+
+- Any `CounterOpts`/`GaugeOpts`/`HistogramOpts` passed to a TMS-scoped provider **must declare
+  `network`, `channel`, `namespace` in `LabelNames`**, even though the caller never supplies values for
+  them. Omitting them panics at runtime with "inconsistent label cardinality" the first time the metric
+  is used — not at registration, so it survives a smoke test.
+- Check which provider your constructor receives before predicting the name. If in doubt, add the
+  constructor to `token/services/metricsdoc` and read the name out of the golden file.
+
+## Driver services
+
+Recorded by the decorator wrappers in `token/core/common/metrics/`, which time every driver service
+call. All are TMS-scoped, so `network`, `channel` and `namespace` are always present, and `method`
+carries the interface method that was invoked. See [Driver Metrics](../drivers/metrics.md) for the
+method lists.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `panurus_core_common_metrics_issue_service_operations_total` | counter | `network,channel,namespace,method` | Total number of IssueService method invocations |
+| `panurus_core_common_metrics_issue_service_duration_seconds` | histogram | `network,channel,namespace,method` | Duration of IssueService method calls in seconds |
+| `panurus_core_common_metrics_issue_service_errors_total` | counter | `network,channel,namespace,method` | Total number of IssueService method errors |
+| `panurus_core_common_metrics_transfer_service_operations_total` | counter | `network,channel,namespace,method` | Total number of TransferService method invocations |
+| `panurus_core_common_metrics_transfer_service_duration_seconds` | histogram | `network,channel,namespace,method` | Duration of TransferService method calls in seconds |
+| `panurus_core_common_metrics_transfer_service_errors_total` | counter | `network,channel,namespace,method` | Total number of TransferService method errors |
+| `panurus_core_common_metrics_auditor_service_operations_total` | counter | `network,channel,namespace,method` | Total number of AuditorService method invocations |
+| `panurus_core_common_metrics_auditor_service_duration_seconds` | histogram | `network,channel,namespace,method` | Duration of AuditorService method calls in seconds |
+| `panurus_core_common_metrics_auditor_service_errors_total` | counter | `network,channel,namespace,method` | Total number of AuditorService method errors |
+| `panurus_core_common_metrics_tokens_service_operations_total` | counter | `network,channel,namespace,method` | Total number of TokensService method invocations |
+| `panurus_core_common_metrics_tokens_service_duration_seconds` | histogram | `network,channel,namespace,method` | Duration of TokensService method calls in seconds |
+| `panurus_core_common_metrics_tokens_service_errors_total` | counter | `network,channel,namespace,method` | Total number of TokensService method errors |
+| `panurus_core_common_metrics_tokens_upgrade_service_operations_total` | counter | `network,channel,namespace,method` | Total number of TokensUpgradeService method invocations |
+| `panurus_core_common_metrics_tokens_upgrade_service_duration_seconds` | histogram | `network,channel,namespace,method` | Duration of TokensUpgradeService method calls in seconds |
+| `panurus_core_common_metrics_tokens_upgrade_service_errors_total` | counter | `network,channel,namespace,method` | Total number of TokensUpgradeService method errors |
+
+Source: `token/core/common/metrics/{issue,transfer,auditor,tokens,upgrade}.go`.
+
+## Transaction lifecycle (ttx)
+
+The `ttx` service orchestrates a token transaction from assembly to commit. These counters and
+histograms mark the phases an operator cares about; they are the closest thing the SDK has to
+throughput and latency of the business flow.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `panurus_services_ttx_endorsed_transactions` | counter | `network,channel,namespace` | The number of endorsed transactions. |
+| `panurus_services_ttx_audit_approved_transactions` | counter | `network,channel,namespace` | The number of approved transactions by the auditor. |
+| `panurus_services_ttx_accepted_transactions` | counter | `network,channel,namespace` | The number of accepted transactions. |
+| `panurus_services_ttx_endorsement_duration_seconds` | histogram | `network,channel,namespace` | Duration of the full endorsement collection phase including signatures, audit, and chaincode approval. |
+| `panurus_services_ttx_audit_approval_duration_seconds` | histogram | `network,channel,namespace` | Duration of the auditor approval phase including validation, append, and signing. |
+| `panurus_services_ttx_ordering_duration_seconds` | histogram | `network,channel,namespace` | Duration of the transaction broadcast to the ordering service. |
+
+Source: `token/services/ttx/metrics.go`. Wired in `token/sdk/dig/sdk.go`.
+
+## Finality listener
+
+Recorded when a transaction's ledger status resolves. `hash_mismatch_total` is the one to alert on: a
+non-zero value means a committed token-request hash did not match the locally stored one, which is a
+data-integrity violation rather than an ordinary failure.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `panurus_services_ttx_finality_finality_listener_confirmed_total` | counter | — | Total number of transactions confirmed on the ledger and successfully committed to local storage |
+| `panurus_services_ttx_finality_finality_listener_deleted_total` | counter | — | Total number of transactions marked as deleted due to an invalid ledger status or token-request hash mismatch |
+| `panurus_services_ttx_finality_finality_listener_hash_mismatch_total` | counter | — | Total number of transactions rejected because the committed token-request hash did not match the locally stored one |
+| `panurus_services_ttx_finality_finality_listener_retry_exhausted_total` | counter | — | Total number of transactions whose finality processing was abandoned after all retries were exhausted |
+| `panurus_services_ttx_finality_finality_listener_on_status_duration_seconds` | histogram | — | Histogram of total OnStatus processing time per transaction (including retries), in seconds |
+
+Source: `token/services/ttx/finality/metrics.go`.
+
+## Envelope sessions
+
+Recorded by the versioned-envelope wrapper used for view-to-view messaging. `version` is the envelope
+version, `type` the message type, and `error` one of `missing_version`, `version_mismatch`,
+`type_mismatch`, `invalid_envelope` or `unknown` (see `classifyError` in
+`token/services/utils/json/session/envelope.go`).
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `panurus_services_utils_json_session_ttx_envelope_sent_total` | counter | `version,type` | Total number of versioned envelopes sent |
+| `panurus_services_utils_json_session_ttx_envelope_received_total` | counter | `version,type` | Total number of versioned envelopes received |
+| `panurus_services_utils_json_session_ttx_envelope_errors_total` | counter | `error` | Total number of envelope validation errors |
+| `panurus_services_utils_json_session_ttx_envelope_body_bytes` | histogram | `type` | Size of envelope body in bytes |
+
+Source: `token/services/utils/json/session/metrics.go`. Wired in `token/sdk/dig/sdk.go`.
+
+## Auditor service
+
+Recorded by the auditor around `Audit()`, `Append()` and `Release()`. These metrics carry **no TMS
+labels**, so a node auditing several TMSs reports them aggregated; see
+[Coverage gaps](#metric-hygiene).
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `panurus_services_auditor_auditor_audit_duration_seconds` | histogram | — | Histogram of Audit() processing time per transaction (including lock acquisition), in seconds |
+| `panurus_services_auditor_auditor_audit_lock_conflicts_total` | counter | — | Total number of Audit() calls that failed to acquire enrollment-ID locks |
+| `panurus_services_auditor_auditor_append_duration_seconds` | histogram | — | Histogram of Append() processing time per transaction, in seconds |
+| `panurus_services_auditor_auditor_append_errors_total` | counter | — | Total number of Append() calls that failed to write to the audit database |
+| `panurus_services_auditor_auditor_releases_total` | counter | — | Total number of Release() calls (explicit and deferred) |
+
+Source: `token/services/auditor/metrics.go`.
+
+## Token selection (sherdlock)
+
+Recorded by the default token selector. `outcome` is one of `success`, `insufficient_funds`,
+`locked_funds` or `error`; `fetcher_type` is `eager` or `lazy`. `selection_immediate_retries` shows how
+often a selection had to retry because of concurrent lock contention.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `panurus_services_selector_sherdlock_unspent_tokens_invocations` | counter | `fetcher_type` | The number of invocations |
+| `panurus_services_selector_sherdlock_selection_duration_seconds` | histogram | — | Duration of a token selection call in seconds |
+| `panurus_services_selector_sherdlock_selection_outcome_total` | counter | `outcome` | Total number of token selection outcomes by result type |
+| `panurus_services_selector_sherdlock_selection_immediate_retries` | histogram | — | Distribution of immediate retry counts per token selection call |
+
+Source: `token/services/selector/sherdlock/metrics.go`.
+
+## Certification (interactive)
+
+`certified_tokens` is recorded by the certification service (server side); the remaining four are
+recorded by the certification client. Note the asymmetry in labels — the client-side metrics carry
+`channel` and `namespace` but not `network`.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `panurus_services_certifier_interactive_certified_tokens` | counter | `network,channel,namespace` | The number of tokens certified. |
+| `panurus_services_certifier_interactive_certification_request_duration_seconds` | histogram | `channel,namespace` | Histogram of certification batch request durations in seconds. |
+| `panurus_services_certifier_interactive_certification_errors_total` | counter | `channel,namespace` | Total number of failed certification request attempts. |
+| `panurus_services_certifier_interactive_certification_pending_tokens` | gauge | `channel,namespace` | Current number of tokens waiting in the certification input buffer. |
+| `panurus_services_certifier_interactive_certification_dropped_tokens_total` | counter | `channel,namespace` | Total number of tokens dropped because the certification buffer was full. |
+
+Source: `token/services/certifier/interactive/metrics.go`.
+
+## Identity and caches
+
+All identity instrumentation is created through the TMS-scoped provider from the wallet service
+(`token/core/{fabtoken/v1,zkatdlog/nogh/v1}/driver/ws.go`), hence the
+`panurus_core_common_metrics_` prefix despite living under `token/services/identity`.
+
+`outcome` and `path` are `cache`, `routed` or `fallback`. A near-zero
+`identity_signer_router_registrations_total` in a busy deployment means routing is not being populated
+and every signer lookup falls back to the probing deserializer. The two `*_provision_failures_total`
+counters rise when a cache cannot pre-provision in the background, so requests are served on the slow
+path while the identity backend keeps failing; the corresponding log line alone is easy to miss.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `panurus_core_common_metrics_identity_signer_resolutions_total` | counter | `network,channel,namespace,outcome` | Total number of GetSigner calls by outcome (cache, routed, fallback) |
+| `panurus_core_common_metrics_identity_get_signer_duration_seconds` | histogram | `network,channel,namespace,path` | Histogram of GetSigner wall-clock time in seconds, labeled by resolution path |
+| `panurus_core_common_metrics_identity_signer_router_registrations_total` | counter | `network,channel,namespace` | Total number of conf_id-to-KeyManager bindings registered with the SignerRouter |
+| `panurus_core_common_metrics_identity_signer_router_no_probe_errors_total` | counter | `network,channel,namespace` | Total number of errors from the SignerRouter's probe-free signer deserialization path |
+| `panurus_core_common_metrics_cache_level` | gauge | `network,channel,namespace` | Level of the idemix cache |
+| `panurus_core_common_metrics_cache_provision_failures_total` | counter | `network,channel,namespace` | Failed attempts to pre-provision idemix identities |
+| `panurus_core_common_metrics_recipient_data_cache_level` | gauge | `network,channel,namespace` | Level of the wallet recipient data cache |
+| `panurus_core_common_metrics_recipient_data_provision_failures_total` | counter | `network,channel,namespace` | Failed attempts to pre-provision wallet recipient data |
+
+Source: `token/services/identity/metrics.go`, `token/services/identity/idemix/cache/metrics.go`,
+`token/services/identity/role/metrics.go`.
+
+## Fabric-X finality queue
+
+Recorded by the Fabric-X event queue that dispatches finality notifications to workers.
+`pending_events` is the backlog gauge; `enqueue_drops_total` increments when the buffer was full and an
+event was discarded, which means a lost finality notification.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `panurus_services_network_fabricx_finality_queue_finality_queue_pending_events` | gauge | — | Current number of finality events waiting in the queue buffer |
+| `panurus_services_network_fabricx_finality_queue_finality_queue_enqueue_drops_total` | counter | — | Total number of finality events dropped because the queue was full |
+| `panurus_services_network_fabricx_finality_queue_finality_queue_processing_errors_total` | counter | — | Total number of errors returned by event.Process in worker goroutines |
+| `panurus_services_network_fabricx_finality_queue_finality_queue_processing_duration_seconds` | histogram | — | Histogram of successful event processing time in worker goroutines (seconds) |
+
+Source: `token/services/network/fabricx/finality/queue/metrics.go`.
+
+## Example queries
+
+Transaction throughput per TMS:
+
+```promql
+sum by (network, channel, namespace) (rate(panurus_services_ttx_accepted_transactions[5m]))
+```
+
+95th percentile of the endorsement phase:
+
+```promql
+histogram_quantile(0.95, sum by (le, network, channel, namespace) (
+  rate(panurus_services_ttx_endorsement_duration_seconds_bucket[5m])
+))
+```
+
+Share of token selections that failed for lack of spendable funds:
+
+```promql
+sum(rate(panurus_services_selector_sherdlock_selection_outcome_total{outcome!="success"}[5m]))
+  / sum(rate(panurus_services_selector_sherdlock_selection_outcome_total[5m]))
+```
+
+Slowest driver methods, to find the expensive cryptography:
+
+```promql
+topk(5, histogram_quantile(0.99, sum by (le, method) (
+  rate(panurus_core_common_metrics_transfer_service_duration_seconds_bucket[5m])
+)))
+```
+
+Fraction of signer lookups that fall back to the probing deserializer:
+
+```promql
+sum(rate(panurus_core_common_metrics_identity_signer_resolutions_total{outcome="fallback"}[5m]))
+  / sum(rate(panurus_core_common_metrics_identity_signer_resolutions_total[5m]))
+```
+
+Integrity and loss alerts — any increase is worth paging on:
+
+```promql
+increase(panurus_services_ttx_finality_finality_listener_hash_mismatch_total[10m]) > 0
+increase(panurus_services_network_fabricx_finality_queue_finality_queue_enqueue_drops_total[10m]) > 0
+```
+
+Finality backlog:
+
+```promql
+panurus_services_network_fabricx_finality_queue_finality_queue_pending_events
+```
+
+## Not covered here
+
+- **FSC platform metrics** — view executions, sessions, gRPC, database and process metrics come from
+  Fabric Smart Client and are documented in its [Monitoring](https://github.com/hyperledger-labs/fabric-smart-client/blob/main/docs/platform/view/services/monitoring.md)
+  page and [Metrics Catalog](https://github.com/hyperledger-labs/fabric-smart-client/blob/main/docs/platform/view/services/monitoring_metrics.md).
+  View-level timing in particular is already instrumented by FSC, so the SDK does not duplicate it.
+- **Load-generator metrics** — `integration/nwo/txgen/service/metrics/` and `integration/nwo/runner/`
+  instrument the test harness, not the SDK, and are not exported by a Panurus node.
+- **Traces** — spans are a separate mechanism; see [Monitoring](./monitoring.md).
+
+## Coverage gaps
+
+The second half of this reference: what a Panurus node currently cannot tell an operator. Ordered by
+operator value. Each item states what is blind today, a concrete proposal, and why existing signals do
+not already cover it.
+
+### 1. Storage layer
+
+`tokendb`, `ttxdb`, `auditdb`, `identitydb` and the keystore have **no instrumentation at all**. A slow
+node cannot be attributed to storage from SDK metrics alone; the driver and ttx histograms include
+storage time without isolating it.
+
+Proposal: `store_operations_total{store,operation,outcome}` (counter) and
+`store_operation_duration_seconds{store,operation}` (histogram), recorded in the store service layer.
+
+Why not just a database exporter: an exporter reports IO, contention and query statistics, but cannot
+attribute them to `store="tokendb"`/`operation="write"` without per-query parsing rules that have to be
+maintained against every schema change. Embedded backends such as SQLite have no exporter at all, so
+SDK-level counters are the only available signal there. The two are complementary — the exporter for IO
+and contention, these counters for application semantics.
+
+### 2. Transaction failure counter
+
+`panurus_services_ttx_accepted_transactions` has no failure counterpart, so a **success rate cannot be
+computed from SDK metrics**. A deployment where every transaction fails looks, in these metrics, like a
+deployment with no traffic.
+
+Proposal: `panurus_services_ttx_transactions_total{network,channel,namespace,phase,outcome}` (counter)
+with `phase` in `assemble|endorse|audit|order|commit` and `outcome` in `success|failure`, from which
+throughput and failure rate both follow.
+
+### 3. Commit-time rejections
+
+Nothing counts transactions the ledger rejects, broken down by reason. Note that **double spending can
+only be enforced at commit time**, so this is where a double-spend attempt becomes visible — it cannot
+be detected earlier during validation.
+
+Proposal: `panurus_services_network_commit_rejections_total{network,channel,namespace,reason}` (counter),
+recorded where the commit result is processed, with `reason` distinguishing double-spend from signature,
+policy and format failures.
+
+### 4. Standard Fabric network path
+
+The Fabric-X finality queue is instrumented; the standard Fabric network driver
+(`token/services/network/fabric/`) has no equivalent, and the approval path — `EndorserService` in
+`token/services/network/fabric/endorsement/provider.go` — is not timed. On Fabric deployments the
+approval round trip is therefore invisible.
+
+Proposal: `panurus_services_network_fabric_approval_duration_seconds{network,channel,namespace}`
+(histogram) and `..._approval_errors_total{...,reason}` (counter) around the endorser call.
+
+Note that the *views* that drive this path are already instrumented by FSC; the gap is the endorsement
+round trip itself, not the view execution.
+
+### 5. Auditor lock contention
+
+`panurus_services_auditor_auditor_audit_lock_conflicts_total` counts failed lock acquisitions but says
+nothing about contention short of failure: how long locks are held, how long acquisition waits, how many
+holders are active.
+
+Proposal: `panurus_services_auditor_lock_wait_duration_seconds` and `..._lock_hold_duration_seconds`
+(histograms), plus `..._locks_held` (gauge).
+
+### 6. Identity cache effectiveness
+
+`cache_level` and `recipient_data_cache_level` report occupancy, not effectiveness. A cache that is
+always full but never hit looks identical to one that serves every request.
+
+Proposal: `identity_cache_requests_total{cache,outcome}` (counter) with `outcome` in `hit|miss`,
+alongside the existing gauges. `identity_signer_resolutions_total` already does this for signers; the
+identity and recipient-data caches deserve the same treatment.
+
+### 7. Wallet resolution
+
+Wallet lookups by identity, enrollment ID or wallet ID are not timed or counted, so a deployment with
+pathological wallet resolution has no signal until it shows up as end-to-end latency.
+
+Proposal: `panurus_services_identity_wallet_lookups_total{network,channel,namespace,role,outcome}`
+(counter) and a matching duration histogram.
+
+### Metric hygiene
+
+Smaller consistency issues, worth fixing together since each one changes exported names:
+
+- **Package attribution.** Metrics created through the TMS-scoped provider are exported under
+  `panurus_core_common_metrics_` instead of their own package, which puts identity and cache metrics in
+  a namespace that has nothing to do with them. Setting `Namespace`/`Subsystem` explicitly in the opts,
+  or making the wrapper preserve the caller's package, would fix it.
+- **Stuttering names.** `panurus_services_auditor_auditor_*`,
+  `panurus_services_ttx_finality_finality_listener_*` and
+  `panurus_services_network_fabricx_finality_queue_finality_queue_*` repeat their package in the metric
+  name.
+- **Missing TMS labels.** The auditor, finality-listener, sherdlock and Fabric-X queue families carry no
+  `network`/`channel`/`namespace` labels, so on a node hosting several TMSs their values are aggregated
+  and cannot be attributed. The certification client metrics carry `channel` and `namespace` but not
+  `network`.
+
+All three are breaking changes for existing dashboards and alerts, so they belong in a single deliberate
+change with a note in the release notes — not folded into unrelated work.
+
+### Not proposed
+
+- **Re-instrumenting views.** FSC already records view executions; adding SDK-level equivalents would
+  duplicate existing series.
+- **Validation-time double-spend detection.** Not a metric gap but a protocol property: the check
+  happens at commit, so item 3 is where it belongs.

--- a/docs/development/monitoring.md
+++ b/docs/development/monitoring.md
@@ -1,7 +1,19 @@
 # Monitoring
 
-We adopt the monitoring infrastructure provided by the [`Fabric Smart Client`](https://github.com/hyperledger-labs/fabric-smart-client/blob/main/docs/platform/view/monitoring.md).
+We adopt the monitoring infrastructure provided by the [`Fabric Smart Client`](https://github.com/hyperledger-labs/fabric-smart-client/blob/main/docs/platform/view/services/monitoring.md).
 
 We use the following two methods to monitor the performance of the application:
 * **Metrics** provide an overview of the overall system performance using aggregated results, e.g. total requests, requests per second, current state of a variable, average duration, percentile of duration
 * **Traces** help us analyze single requests by breaking down their lifecycles into smaller components
+
+## Where to look next
+
+* [Metrics Reference](./metrics.md) — every metric Panurus exports, under the exact name Prometheus
+  serves it, plus how those names are derived, example queries, and the current coverage gaps.
+* [Grafana dashboards](../monitoring/grafana/README.md) — an importable overview dashboard covering
+  every exported metric, and what to run after editing a query.
+* [Driver Metrics](../drivers/metrics.md) — how the driver service wrappers are built and which
+  methods they instrument.
+* [Fabric Smart Client monitoring](https://github.com/hyperledger-labs/fabric-smart-client/blob/main/docs/platform/view/services/monitoring.md)
+  — the platform metrics and traces Panurus inherits (views, sessions, gRPC, process), and how to
+  enable the Prometheus endpoint and the tracing exporter.

--- a/docs/drivers/metrics.md
+++ b/docs/drivers/metrics.md
@@ -20,6 +20,14 @@ implementation, and records three metrics per method invocation:
 | **Histogram** (`*_duration_seconds`) | Execution duration of each call |
 | **Counter** (`*_errors_total`) | Total number of calls that returned an error |
 
+The metric names in this page are the **declared** names, as written in the wrapper sources.
+Prometheus exports them under a prefix derived from the package that creates them; because the driver
+wrappers receive a TMS-scoped provider, every metric below is exported as
+`panurus_core_common_metrics_<declared name>` — for instance `issue_service_operations_total` is
+queried as `panurus_core_common_metrics_issue_service_operations_total`. See
+[Metrics Reference](../development/metrics.md) for the derivation rules and the exported names of
+every metric in the SDK.
+
 All metrics carry four labels for multi-TMS filtering:
 
 | Label | Description |
@@ -136,27 +144,12 @@ Metrics emitted:
 
 ## Metric Reference
 
-The full list of metrics emitted by the driver wrappers:
+The exported names, types and labels of the fifteen driver metrics are listed in
+[Metrics Reference — Driver services](../development/metrics.md#driver-services). That page is kept in
+step with the code by `token/services/metricsdoc`, so it is the authoritative list; this page describes
+only how the wrappers work and which methods they instrument.
 
-| Metric Name | Type | Description |
-|-------------|------|-------------|
-| `issue_service_operations_total` | Counter | Total `IssueService` method invocations |
-| `issue_service_duration_seconds` | Histogram | Duration of `IssueService` method calls |
-| `issue_service_errors_total` | Counter | Total `IssueService` method errors |
-| `transfer_service_operations_total` | Counter | Total `TransferService` method invocations |
-| `transfer_service_duration_seconds` | Histogram | Duration of `TransferService` method calls |
-| `transfer_service_errors_total` | Counter | Total `TransferService` method errors |
-| `auditor_service_operations_total` | Counter | Total `AuditorService` method invocations |
-| `auditor_service_duration_seconds` | Histogram | Duration of `AuditorService` method calls |
-| `auditor_service_errors_total` | Counter | Total `AuditorService` method errors |
-| `tokens_service_operations_total` | Counter | Total `TokensService` method invocations |
-| `tokens_service_duration_seconds` | Histogram | Duration of `TokensService` method calls |
-| `tokens_service_errors_total` | Counter | Total `TokensService` method errors |
-| `tokens_upgrade_service_operations_total` | Counter | Total `TokensUpgradeService` method invocations |
-| `tokens_upgrade_service_duration_seconds` | Histogram | Duration of `TokensUpgradeService` method calls |
-| `tokens_upgrade_service_errors_total` | Counter | Total `TokensUpgradeService` method errors |
-
-All metrics use labels: `network`, `channel`, `namespace`, `method`.
+All driver metrics use labels: `network`, `channel`, `namespace`, `method`.
 
 ## Source
 

--- a/docs/monitoring/grafana/README.md
+++ b/docs/monitoring/grafana/README.md
@@ -1,0 +1,58 @@
+# Grafana dashboards
+
+## `panurus.json` — Panurus Overview
+
+A single overview dashboard covering every metric Panurus exports: 20 panels across 9 rows, one row per
+subsystem (driver services, transaction lifecycle, finality listener, envelope sessions, auditor, token
+selection, certification and identity caches, signer resolution and cache provisioning, Fabric-X finality
+queue).
+
+### Import
+
+1. Grafana → **Dashboards** → **New** → **Import** → *Upload JSON file*.
+2. Pick the Prometheus data source that scrapes the node's metrics endpoint when prompted for
+   `DS_PROMETHEUS`.
+
+The dashboard declares four template variables — `network`, `channel`, `namespace` and `method` — whose
+values are discovered with `label_values` against
+`panurus_core_common_metrics_transfer_service_operations_total`. A node that has never issued or
+transferred a token exports no series for that metric, so the pickers stay empty until the first
+transaction; the unfiltered panels still work.
+
+Requires Grafana 9.0 or later (`schemaVersion` 37).
+
+### Not covered
+
+- **FSC platform metrics** (views, sessions, gRPC, process) — these come from
+  [Fabric Smart Client](https://github.com/hyperledger-labs/fabric-smart-client/blob/main/docs/platform/view/services/monitoring.md)
+  and are exported under `fsc_*`, not `panurus_*`.
+- **Traces.** The dashboard is metrics-only.
+- Panels are built from metric *names*, so they show what a node reports, not whether the reported
+  numbers are healthy: there are no thresholds or alert rules here.
+
+### Changing it
+
+Every query in this file is checked by `token/services/metricsdoc`, which asserts that
+
+- each metric a query names is one the SDK registers, under the name Prometheus actually exports;
+- each metric name carries its package prefix, so a bare `Name` from the Go source fails the build
+  rather than rendering an empty panel;
+- each label a query filters or groups on is declared by the metric it is applied to;
+- each `$variable` a query interpolates is either a Grafana built-in or declared in this dashboard.
+
+These are the failure modes a dashboard cannot report itself: Grafana does not error on an unknown
+metric or an absent label, it renders **No data**, which is indistinguishable from an idle node. An
+earlier version of this dashboard ([#1749](https://github.com/LFDT-Panurus/panurus/pull/1749)) had every
+one of its 51 panel queries and 4 variable queries written against bare option names from the Go source,
+so not one of them matched a series; it closed unmerged.
+
+So: after editing a query, run
+
+```bash
+go test ./token/services/metricsdoc/...
+```
+
+If you add a panel for a metric that does not exist yet, add the metric first — see
+[Metrics Reference](../../development/metrics.md) for the exported names and
+[`testdata/metrics.golden`](../../../token/services/metricsdoc/testdata/metrics.golden) for the
+machine-readable list.

--- a/docs/monitoring/grafana/panurus.json
+++ b/docs/monitoring/grafana/panurus.json
@@ -1,0 +1,1135 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source scraping the Panurus / Fabric Smart Client metrics endpoint.",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "iteration": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "row",
+      "id": 100,
+      "title": "Driver services (decorator layer)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 101,
+      "title": "Operations rate (per second) by service",
+      "description": "Sum of *_service_operations_total rate across the filtered TMS, broken down by service.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "issue",
+          "expr": "sum(rate(panurus_core_common_metrics_issue_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "issue"
+        },
+        {
+          "refId": "transfer",
+          "expr": "sum(rate(panurus_core_common_metrics_transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "transfer"
+        },
+        {
+          "refId": "tokens",
+          "expr": "sum(rate(panurus_core_common_metrics_tokens_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "tokens"
+        },
+        {
+          "refId": "auditor",
+          "expr": "sum(rate(panurus_core_common_metrics_auditor_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "auditor"
+        },
+        {
+          "refId": "upgrade",
+          "expr": "sum(rate(panurus_core_common_metrics_tokens_upgrade_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "upgrade"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 102,
+      "title": "Error rate (per second) by service",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "issue",
+          "expr": "sum(rate(panurus_core_common_metrics_issue_service_errors_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "issue"
+        },
+        {
+          "refId": "transfer",
+          "expr": "sum(rate(panurus_core_common_metrics_transfer_service_errors_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "transfer"
+        },
+        {
+          "refId": "tokens",
+          "expr": "sum(rate(panurus_core_common_metrics_tokens_service_errors_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "tokens"
+        },
+        {
+          "refId": "auditor",
+          "expr": "sum(rate(panurus_core_common_metrics_auditor_service_errors_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "auditor"
+        },
+        {
+          "refId": "upgrade",
+          "expr": "sum(rate(panurus_core_common_metrics_tokens_upgrade_service_errors_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",
+          "legendFormat": "upgrade"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 103,
+      "title": "Per-method duration (p95) \u2014 Transfer / Issue / Tokens / Auditor / Upgrade",
+      "description": "p95 over a 5m sliding window, summed across replicas, broken down by service.method.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "issue",
+          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_issue_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",
+          "legendFormat": "issue.{{method}}"
+        },
+        {
+          "refId": "transfer",
+          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_transfer_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",
+          "legendFormat": "transfer.{{method}}"
+        },
+        {
+          "refId": "tokens",
+          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_tokens_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",
+          "legendFormat": "tokens.{{method}}"
+        },
+        {
+          "refId": "auditor",
+          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_auditor_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",
+          "legendFormat": "auditor.{{method}}"
+        },
+        {
+          "refId": "upgrade",
+          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_tokens_upgrade_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",
+          "legendFormat": "upgrade.{{method}}"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 200,
+      "title": "Transaction lifecycle (ttx)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 201,
+      "title": "Lifecycle counters (rate) \u2014 endorsed / audit_approved / accepted",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "e",
+          "expr": "sum(rate(panurus_services_ttx_endorsed_transactions{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "endorsed"
+        },
+        {
+          "refId": "a",
+          "expr": "sum(rate(panurus_services_ttx_audit_approved_transactions{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "audit_approved"
+        },
+        {
+          "refId": "c",
+          "expr": "sum(rate(panurus_services_ttx_accepted_transactions{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "accepted"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 202,
+      "title": "Phase duration (p95) \u2014 endorsement / audit_approval / ordering",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "e",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_ttx_endorsement_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "endorsement p95"
+        },
+        {
+          "refId": "a",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_ttx_audit_approval_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "audit_approval p95"
+        },
+        {
+          "refId": "o",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_ttx_ordering_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "ordering p95"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 300,
+      "title": "Finality listener",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 301,
+      "title": "Finality outcomes (rate)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "c",
+          "expr": "rate(panurus_services_ttx_finality_finality_listener_confirmed_total[$__rate_interval])",
+          "legendFormat": "confirmed"
+        },
+        {
+          "refId": "d",
+          "expr": "rate(panurus_services_ttx_finality_finality_listener_deleted_total[$__rate_interval])",
+          "legendFormat": "deleted"
+        },
+        {
+          "refId": "h",
+          "expr": "rate(panurus_services_ttx_finality_finality_listener_hash_mismatch_total[$__rate_interval])",
+          "legendFormat": "hash_mismatch"
+        },
+        {
+          "refId": "r",
+          "expr": "rate(panurus_services_ttx_finality_finality_listener_retry_exhausted_total[$__rate_interval])",
+          "legendFormat": "retry_exhausted"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 302,
+      "title": "OnStatus processing duration (p50 / p95)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "p50",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(panurus_services_ttx_finality_finality_listener_on_status_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "p95",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_ttx_finality_finality_listener_on_status_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 400,
+      "title": "Versioned envelope sessions (ttx)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 401,
+      "title": "Envelopes sent / received (rate) by type",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "s",
+          "expr": "sum by (type) (rate(panurus_services_utils_json_session_ttx_envelope_sent_total[$__rate_interval]))",
+          "legendFormat": "sent {{type}}"
+        },
+        {
+          "refId": "r",
+          "expr": "sum by (type) (rate(panurus_services_utils_json_session_ttx_envelope_received_total[$__rate_interval]))",
+          "legendFormat": "recv {{type}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 402,
+      "title": "Envelope errors (rate) + body size p95 by type",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "err",
+          "expr": "sum by (error) (rate(panurus_services_utils_json_session_ttx_envelope_errors_total[$__rate_interval]))",
+          "legendFormat": "errors {{error}}"
+        },
+        {
+          "refId": "size",
+          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(panurus_services_utils_json_session_ttx_envelope_body_bytes_bucket[5m])))",
+          "legendFormat": "body p95 {{type}} (bytes)"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 500,
+      "title": "Auditor service",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 501,
+      "title": "Audit / Append duration (p95) + lock conflicts + append errors",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "ad",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_auditor_auditor_audit_duration_seconds_bucket[5m])))",
+          "legendFormat": "audit p95"
+        },
+        {
+          "refId": "ap",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_auditor_auditor_append_duration_seconds_bucket[5m])))",
+          "legendFormat": "append p95"
+        },
+        {
+          "refId": "lc",
+          "expr": "rate(panurus_services_auditor_auditor_audit_lock_conflicts_total[$__rate_interval])",
+          "legendFormat": "lock_conflicts/s"
+        },
+        {
+          "refId": "ae",
+          "expr": "rate(panurus_services_auditor_auditor_append_errors_total[$__rate_interval])",
+          "legendFormat": "append_errors/s"
+        },
+        {
+          "refId": "rl",
+          "expr": "rate(panurus_services_auditor_auditor_releases_total[$__rate_interval])",
+          "legendFormat": "releases/s"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 600,
+      "title": "Token selection (sherdlock)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 53
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 601,
+      "title": "Selection duration (p95) + outcomes (rate)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 54
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "p95",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_selector_sherdlock_selection_duration_seconds_bucket[5m])))",
+          "legendFormat": "duration p95"
+        },
+        {
+          "refId": "out",
+          "expr": "sum by (outcome) (rate(panurus_services_selector_sherdlock_selection_outcome_total[$__rate_interval]))",
+          "legendFormat": "outcome={{outcome}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 602,
+      "title": "Unspent token fetches (rate) + immediate retries (p95)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 54
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "f",
+          "expr": "sum by (fetcher_type) (rate(panurus_services_selector_sherdlock_unspent_tokens_invocations[$__rate_interval]))",
+          "legendFormat": "fetch {{fetcher_type}}/s"
+        },
+        {
+          "refId": "r",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_selector_sherdlock_selection_immediate_retries_bucket[5m])))",
+          "legendFormat": "retries p95"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 700,
+      "title": "Certification + identity caches",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 701,
+      "title": "Certification \u2014 certified / errors / dropped (rate) + request p95",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 63
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "c",
+          "expr": "sum(rate(panurus_services_certifier_interactive_certified_tokens{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "certified/s"
+        },
+        {
+          "refId": "e",
+          "expr": "sum(rate(panurus_services_certifier_interactive_certification_errors_total{channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "errors/s"
+        },
+        {
+          "refId": "d",
+          "expr": "sum(rate(panurus_services_certifier_interactive_certification_dropped_tokens_total{channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "dropped/s"
+        },
+        {
+          "refId": "p",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_certifier_interactive_certification_request_duration_seconds_bucket{channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "request p95 (s)"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 702,
+      "title": "Cache fill levels + certification buffer (gauges)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 63
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "ic",
+          "expr": "panurus_core_common_metrics_cache_level{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}",
+          "legendFormat": "idemix panurus_core_common_metrics_cache_level"
+        },
+        {
+          "refId": "rc",
+          "expr": "panurus_core_common_metrics_recipient_data_cache_level{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}",
+          "legendFormat": "panurus_core_common_metrics_recipient_data_cache_level"
+        },
+        {
+          "refId": "pt",
+          "expr": "panurus_services_certifier_interactive_certification_pending_tokens{channel=~\"$channel\",namespace=~\"$namespace\"}",
+          "legendFormat": "certification_pending"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 750,
+      "title": "Identity: signer resolution and cache provisioning",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 71
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 751,
+      "title": "Signer resolution outcomes (rate) by outcome",
+      "description": "Where GetSigner found each signer. A rising 'fallback' share means the SignerRouter is missing bindings and resolution is taking the slow path.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 72
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      },
+      "targets": [
+        {
+          "refId": "outcome",
+          "expr": "sum by (outcome) (rate(panurus_core_common_metrics_identity_signer_resolutions_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "{{outcome}}/s"
+        },
+        {
+          "refId": "registrations",
+          "expr": "sum(rate(panurus_core_common_metrics_identity_signer_router_registrations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "router registrations/s"
+        },
+        {
+          "refId": "noprobe",
+          "expr": "sum(rate(panurus_core_common_metrics_identity_signer_router_no_probe_errors_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "no-probe errors/s"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 752,
+      "title": "GetSigner duration (p95) by resolution path",
+      "description": "Wall-clock time of GetSigner, split by the path that resolved it. The cache path should dominate; a slow path carrying real volume is the signal to act on.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 72
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "refId": "p95",
+          "expr": "histogram_quantile(0.95, sum by (le, path) (rate(panurus_core_common_metrics_identity_get_signer_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "p95 {{path}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 753,
+      "title": "Cache provisioning failures (rate)",
+      "description": "Failed background pre-provisioning attempts for the idemix and wallet recipient-data caches. While these rise, requests are served on the slow path because the identity backend keeps failing.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 72
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      },
+      "targets": [
+        {
+          "refId": "idemix",
+          "expr": "sum(rate(panurus_core_common_metrics_cache_provision_failures_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "idemix provision failures/s"
+        },
+        {
+          "refId": "recipient",
+          "expr": "sum(rate(panurus_core_common_metrics_recipient_data_provision_failures_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "recipient data provision failures/s"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 800,
+      "title": "Fabric-X finality queue",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 80
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 801,
+      "title": "Pending events (gauge)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 81
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "refId": "p",
+          "expr": "panurus_services_network_fabricx_finality_queue_finality_queue_pending_events",
+          "legendFormat": "pending"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 802,
+      "title": "Enqueue drops + processing errors (rate)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 6,
+        "y": 81
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "d",
+          "expr": "rate(panurus_services_network_fabricx_finality_queue_finality_queue_enqueue_drops_total[$__rate_interval])",
+          "legendFormat": "drops/s"
+        },
+        {
+          "refId": "e",
+          "expr": "rate(panurus_services_network_fabricx_finality_queue_finality_queue_processing_errors_total[$__rate_interval])",
+          "legendFormat": "errors/s"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 803,
+      "title": "Processing duration (p95)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 15,
+        "y": 81
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "p",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_network_fabricx_finality_queue_finality_queue_processing_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [
+    "panurus",
+    "panurus",
+    "lfdt"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "label": "Prometheus",
+        "query": "prometheus",
+        "refresh": 1,
+        "hide": 0
+      },
+      {
+        "name": "network",
+        "type": "query",
+        "label": "Network",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(panurus_core_common_metrics_transfer_service_operations_total, network)",
+        "query": {
+          "query": "label_values(panurus_core_common_metrics_transfer_service_operations_total, network)",
+          "refId": "v"
+        },
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2
+      },
+      {
+        "name": "channel",
+        "type": "query",
+        "label": "Channel",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(panurus_core_common_metrics_transfer_service_operations_total{network=~\"$network\"}, channel)",
+        "query": {
+          "query": "label_values(panurus_core_common_metrics_transfer_service_operations_total{network=~\"$network\"}, channel)",
+          "refId": "v"
+        },
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2
+      },
+      {
+        "name": "namespace",
+        "type": "query",
+        "label": "Namespace",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(panurus_core_common_metrics_transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\"}, namespace)",
+        "query": {
+          "query": "label_values(panurus_core_common_metrics_transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\"}, namespace)",
+          "refId": "v"
+        },
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2
+      },
+      {
+        "name": "method",
+        "type": "query",
+        "label": "Driver method",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(panurus_core_common_metrics_transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}, method)",
+        "query": {
+          "query": "label_values(panurus_core_common_metrics_transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}, method)",
+          "refId": "v"
+        },
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Panurus \u2014 Overview",
+  "uid": "panurus-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/jackc/pgxlisten v0.0.0-20250802141604-12b92425684c
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
+	github.com/prometheus/client_golang v1.24.1
 	github.com/stretchr/testify v1.12.0
 	github.com/tidwall/gjson v1.19.0
 	go.opentelemetry.io/otel/trace v1.45.0
@@ -99,7 +100,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.24.1 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect

--- a/token/services/auditor/metrics.go
+++ b/token/services/auditor/metrics.go
@@ -70,6 +70,14 @@ func newMetrics(p metrics.Provider) *Metrics {
 	}
 }
 
+// NewMetrics creates a new Metrics instance with the given provider.
+// It is exported so that the metrics reference guard can instantiate the
+// auditor instrumentation without building a full Service; see
+// docs/development/metrics.md.
+func NewMetrics(p metrics.Provider) *Metrics {
+	return newMetrics(p)
+}
+
 // noopProvider discards all observations. Used when no provider is configured.
 type noopProvider struct{}
 

--- a/token/services/certifier/interactive/metrics.go
+++ b/token/services/certifier/interactive/metrics.go
@@ -68,6 +68,14 @@ type ClientMetrics struct {
 	DroppedTokens metrics.Counter
 }
 
+// NewClientMetrics creates a new ClientMetrics instance with the given provider.
+// It is exported so that the metrics reference guard can instantiate the
+// certification client instrumentation without building a full
+// CertificationClient; see docs/development/metrics.md.
+func NewClientMetrics(p metrics.Provider) *ClientMetrics {
+	return newClientMetrics(p)
+}
+
 func newClientMetrics(p metrics.Provider) *ClientMetrics {
 	return &ClientMetrics{
 		RequestDuration: p.NewHistogram(certificationRequestDuration),

--- a/token/services/metricsdoc/dashboard_test.go
+++ b/token/services/metricsdoc/dashboard_test.go
@@ -1,0 +1,299 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metricsdoc
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dashboardFile is the Grafana dashboard built from the names this package pins.
+const dashboardFile = "../../../docs/monitoring/grafana/panurus.json"
+
+// A dashboard fails differently from code: a query naming a metric that does not
+// exist, or filtering on a label the metric does not carry, renders an empty
+// panel rather than an error. "No data" is indistinguishable from "nothing
+// happened", which is how the dashboard in #1749 shipped with every query broken.
+// The tests below turn that silence into a build failure.
+
+// dashboardSelector matches an instant-vector selector together with its label
+// matcher block, e.g. panurus_services_ttx_accepted_transactions{network=~"$n"}.
+var dashboardSelector = regexp.MustCompile(`(panurus_[a-z0-9_]+)\{([^}]*)\}`)
+
+// labelMatcherName pulls the label name out of each matcher in a selector block.
+var labelMatcherName = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:=~|!~|=|!=)`)
+
+// groupByClause matches the label list of a PromQL "by (...)" grouping.
+var groupByClause = regexp.MustCompile(`\bby\s*\(([^)]*)\)`)
+
+// dashboardVariable matches a Grafana template variable reference.
+var dashboardVariable = regexp.MustCompile(`\$(?:\{)?([A-Za-z_][A-Za-z0-9_]*)`)
+
+// metricPosition matches an identifier used where PromQL expects a metric name:
+// immediately before a label matcher block or a range selector. PromQL functions
+// are followed by "(" and so never match.
+var metricPosition = regexp.MustCompile(`(?:^|[^A-Za-z0-9_:$])([a-zA-Z_][a-zA-Z0-9_:]*)\s*[{\[]`)
+
+// syntheticLabels are produced by Prometheus rather than declared by the SDK, so
+// a query may group by them even though no metric lists them.
+var syntheticLabels = []string{"le"}
+
+// grafanaBuiltinVariables are supplied by Grafana itself and need no entry in the
+// dashboard's own template variable list.
+var grafanaBuiltinVariables = []string{
+	"__rate_interval",
+	"__interval",
+	"__interval_ms",
+	"__range",
+	"__from",
+	"__to",
+	"__auto_interval",
+}
+
+// TestDashboardQueriesReferenceRegisteredMetrics checks that every metric the
+// dashboard queries is one the SDK actually registers. This is the failure the
+// dashboard in #1749 shipped with: each expr used the bare option name from the
+// Go source, so no query matched anything in a real Prometheus.
+func TestDashboardQueriesReferenceRegisteredMetrics(t *testing.T) {
+	registered, _ := registeredMetrics(t)
+	values := dashboardStrings(t)
+	require.NotEmpty(t, values, "%s contains no strings; did it fail to parse?", dashboardFile)
+
+	referenced := make(map[string]struct{})
+	for _, s := range values {
+		for _, match := range metricNamePattern.FindAllStringSubmatch(s, -1) {
+			name := foldPromQLSuffix(match[2], registered)
+			referenced[name] = struct{}{}
+			assert.Contains(t, registered, name,
+				"%s queries %q, which the SDK does not register. A Grafana panel does not error on "+
+					"an unknown metric, it renders \"No data\" - check the name against %s.",
+				dashboardFile, match[2], goldenFile)
+		}
+	}
+	require.NotEmpty(t, referenced, "%s references no SDK metric at all", dashboardFile)
+	t.Logf("%s references %d of the %d registered metrics", dashboardFile, len(referenced), len(registered))
+}
+
+// TestDashboardQueriesUseExportedNames catches the specific mistake #1749 shipped:
+// every expr there used the bare Name from the Go source, which carries no
+// package prefix and therefore matches nothing. Such a name is invisible to the
+// registration check above - it does not even look like an SDK metric - so it is
+// asserted separately, at the position PromQL expects a metric name.
+func TestDashboardQueriesUseExportedNames(t *testing.T) {
+	for _, query := range dashboardQueries(t) {
+		for _, match := range metricPosition.FindAllStringSubmatch(query, -1) {
+			name := match[1]
+			assert.True(t, strings.HasPrefix(name, "panurus_"),
+				"%s selects %q, which carries no package prefix. Prometheus exports SDK metrics "+
+					"under a panurus_* name assembled at registration time, so a bare option name "+
+					"from the Go source matches nothing; see %s for the exported names.",
+				dashboardFile, name, goldenFile)
+		}
+	}
+}
+
+// TestDashboardLabelFiltersMatchDeclaredLabels checks that every label a query
+// filters or groups on is declared by the metric it is applied to. Filtering on a
+// label a metric does not carry silently matches nothing, so this is the second
+// way a panel goes blank without anyone noticing.
+func TestDashboardLabelFiltersMatchDeclaredLabels(t *testing.T) {
+	registered, declaredLabels := registeredMetrics(t)
+
+	for _, query := range dashboardQueries(t) {
+		selectors := dashboardSelector.FindAllStringSubmatch(query, -1)
+		for _, selector := range selectors {
+			name := foldPromQLSuffix(selector[1], registered)
+			labels, ok := declaredLabels[name]
+			if !ok {
+				continue // reported by TestDashboardQueriesReferenceRegisteredMetrics
+			}
+			for _, matcher := range labelMatcherName.FindAllStringSubmatch(selector[2], -1) {
+				assert.Contains(t, labels, matcher[1],
+					"%s filters %s on label %q, which that metric does not declare (it has %v). "+
+						"The selector matches no series and the panel renders \"No data\".",
+					dashboardFile, name, matcher[1], labels)
+			}
+		}
+
+		// A "by (...)" clause groups the result of a subexpression, so it can only
+		// be attributed to a metric when the query names exactly one. The names are
+		// taken from the whole query rather than from the selectors above: a metric
+		// queried with a range but no label filter has no selector block at all.
+		names := distinctMetricNames(query, registered)
+		if len(names) != 1 {
+			continue
+		}
+		labels, ok := declaredLabels[names[0]]
+		if !ok {
+			continue
+		}
+		for _, clause := range groupByClause.FindAllStringSubmatch(query, -1) {
+			for label := range strings.SplitSeq(clause[1], ",") {
+				label = strings.TrimSpace(label)
+				if label == "" || slices.Contains(syntheticLabels, label) {
+					continue
+				}
+				assert.Contains(t, labels, label,
+					"%s groups %s by label %q, which that metric does not declare (it has %v). "+
+						"Grouping by an absent label collapses every series into one.",
+					dashboardFile, names[0], label, labels)
+			}
+		}
+	}
+}
+
+// TestDashboardVariablesAreDeclared checks that every template variable a query
+// interpolates is defined by the dashboard, so a renamed variable cannot leave a
+// panel filtering on an empty string.
+func TestDashboardVariablesAreDeclared(t *testing.T) {
+	declared := dashboardVariableNames(t)
+	require.NotEmpty(t, declared, "%s declares no template variables", dashboardFile)
+
+	for _, query := range dashboardQueries(t) {
+		for _, match := range dashboardVariable.FindAllStringSubmatch(query, -1) {
+			name := match[1]
+			if slices.Contains(grafanaBuiltinVariables, name) {
+				continue
+			}
+			assert.Contains(t, declared, name,
+				"%s interpolates $%s, which is neither a Grafana built-in nor declared in the "+
+					"dashboard's templating list", dashboardFile, name)
+		}
+	}
+}
+
+// registeredMetrics returns the exported metrics as name->kind and name->labels.
+func registeredMetrics(t *testing.T) (map[string]string, map[string][]string) {
+	t.Helper()
+
+	kinds := make(map[string]string)
+	labels := make(map[string][]string)
+	for _, e := range collect(t) {
+		kinds[e.name] = e.kind
+		labels[e.name] = e.labels
+	}
+
+	return kinds, labels
+}
+
+// distinctMetricNames returns the metric families a query refers to, folded onto
+// their registered names.
+func distinctMetricNames(query string, registered map[string]string) []string {
+	var out []string
+	seen := make(map[string]struct{})
+	for _, match := range metricNamePattern.FindAllStringSubmatch(query, -1) {
+		name := foldPromQLSuffix(match[2], registered)
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+
+	return out
+}
+
+// dashboardStrings returns every string value in the dashboard, so a metric name
+// is checked wherever it appears - a query, a panel title, a description.
+func dashboardStrings(t *testing.T) []string {
+	t.Helper()
+
+	var out []string
+	walkJSON(loadDashboard(t), func(key, value string) {
+		out = append(out, value)
+	})
+
+	return out
+}
+
+// dashboardQueries returns the PromQL the dashboard runs: panel targets and the
+// queries behind template variables.
+func dashboardQueries(t *testing.T) []string {
+	t.Helper()
+
+	var out []string
+	walkJSON(loadDashboard(t), func(key, value string) {
+		if key == "expr" || key == "query" {
+			out = append(out, value)
+		}
+	})
+	require.NotEmpty(t, out, "%s defines no queries", dashboardFile)
+
+	return out
+}
+
+// dashboardVariableNames returns the names in the dashboard's templating list.
+func dashboardVariableNames(t *testing.T) []string {
+	t.Helper()
+
+	var dashboard struct {
+		Templating struct {
+			List []struct {
+				Name string `json:"name"`
+			} `json:"list"`
+		} `json:"templating"`
+	}
+	require.NoError(t, json.Unmarshal(readDashboard(t), &dashboard))
+
+	out := make([]string, 0, len(dashboard.Templating.List))
+	for _, v := range dashboard.Templating.List {
+		out = append(out, v.Name)
+	}
+
+	return out
+}
+
+func readDashboard(t *testing.T) []byte {
+	t.Helper()
+
+	content, err := os.ReadFile(dashboardFile)
+	require.NoError(t, err, "cannot read %s", dashboardFile)
+
+	return content
+}
+
+func loadDashboard(t *testing.T) any {
+	t.Helper()
+
+	var dashboard any
+	require.NoError(t, json.Unmarshal(readDashboard(t), &dashboard),
+		"%s is not valid JSON; Grafana would refuse the import", dashboardFile)
+
+	return dashboard
+}
+
+// walkJSON visits every string in a decoded JSON document, passing the key it was
+// found under (empty for array elements and the root).
+func walkJSON(node any, visit func(key, value string)) {
+	switch n := node.(type) {
+	case map[string]any:
+		for key, value := range n {
+			if s, ok := value.(string); ok {
+				visit(key, s)
+
+				continue
+			}
+			walkJSON(value, visit)
+		}
+	case []any:
+		for _, value := range n {
+			if s, ok := value.(string); ok {
+				visit("", s)
+
+				continue
+			}
+			walkJSON(value, visit)
+		}
+	}
+}

--- a/token/services/metricsdoc/doc.go
+++ b/token/services/metricsdoc/doc.go
@@ -1,0 +1,28 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package metricsdoc guards the metrics reference in docs/development/metrics.md.
+//
+// The SDK never spells out the metric names it exports: the fully-qualified
+// Prometheus name of a metric is assembled at registration time from the Go
+// package that creates it, so the same CounterOpts produce different exported
+// names depending on which package - and which provider wrapper - the metric
+// travels through. Documentation written from the bare Name field of the opts
+// therefore lists names that no Prometheus query will ever match.
+//
+// The tests in this package instantiate every metrics constructor of the SDK the
+// way production wiring does, read the resulting names back out of a Prometheus
+// registry, and compare them both against a golden file and against the
+// reference documentation. Adding, renaming or relocating a metric fails the
+// test until the documentation is updated.
+//
+// Which provider a constructor receives is as much a part of the exported name
+// as the opts are, so it is checked rather than assumed: the token drivers are
+// pinned as the only place a TMS-scoped provider is built, and every production
+// call site listed for a constructor must still contain that call. Removing the
+// wrapper, or moving a call site, therefore fails here instead of quietly
+// renaming twenty-one metrics.
+package metricsdoc

--- a/token/services/metricsdoc/reference_test.go
+++ b/token/services/metricsdoc/reference_test.go
@@ -1,0 +1,841 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metricsdoc
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/disabled"
+	promprovider "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/prometheus"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	commonmetrics "github.com/LFDT-Panurus/panurus/token/core/common/metrics"
+	"github.com/LFDT-Panurus/panurus/token/services/auditor"
+	"github.com/LFDT-Panurus/panurus/token/services/certifier/interactive"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	idemixcache "github.com/LFDT-Panurus/panurus/token/services/identity/idemix/cache"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/role"
+	_ "github.com/LFDT-Panurus/panurus/token/services/logging" // registers the "panurus" metric namespace replacer
+	fabricxqueue "github.com/LFDT-Panurus/panurus/token/services/network/fabricx/finality/queue"
+	"github.com/LFDT-Panurus/panurus/token/services/selector/sherdlock"
+	"github.com/LFDT-Panurus/panurus/token/services/ttx"
+	ttxfinality "github.com/LFDT-Panurus/panurus/token/services/ttx/finality"
+	jsession "github.com/LFDT-Panurus/panurus/token/services/utils/json/session"
+)
+
+const (
+	goldenFile = "testdata/metrics.golden"
+	// referenceDoc is the documentation page the golden file mirrors. Every name
+	// in the golden file must appear there, and vice versa.
+	referenceDoc = "../../../docs/development/metrics.md"
+	// repoRoot locates the repository root relative to this package, for the
+	// checks that read production wiring out of the source tree.
+	repoRoot = "../../.."
+	// updateEnv regenerates the golden file instead of comparing against it.
+	updateEnv = "UPDATE_GOLDEN"
+	// gapsHeading starts the part of the reference documentation that discusses
+	// metrics the SDK does *not* export yet. Names proposed there are deliberately
+	// not registered, so the coverage check stops at this heading.
+	gapsHeading = "\n## Coverage gaps\n"
+)
+
+// tmsID supplies the network/channel/namespace values that the TMS-scoped
+// provider binds to every metric it hands out. The values themselves never
+// reach an exported metric name, only its labels.
+var tmsID = token.TMSID{Network: "testnet", Channel: "testchannel", Namespace: "testns"}
+
+// scope records how production reaches a group of metrics: directly with the
+// provider from the dependency-injection container, or through the TMS-scoped
+// wrapper returned by commonmetrics.NewTMSProvider. The distinction is not
+// cosmetic - the wrapper adds a stack frame, and the exported name is derived
+// from the package of the caller that Prometheus sees, so wrapped metrics are
+// exported under the wrapper's package rather than their own.
+//
+// The column is not taken on trust: TestTMSScopedProviderWiringIsIntact pins the
+// complete set of files that may build a TMS-scoped provider, so a group is
+// tmsScoped exactly when its provider originates in one of them.
+type scope int
+
+const (
+	// direct means production passes the container's provider straight in.
+	direct scope = iota
+	// tmsScoped means production passes commonmetrics.NewTMSProvider(tmsID, provider).
+	tmsScoped
+)
+
+// wiringSite is a production call site of a group's constructor. Both fields are
+// checked by TestWiringSitesArePresent, so a stale entry fails the test instead
+// of sending a reader to the wrong file.
+type wiringSite struct {
+	// file is repository-relative.
+	file string
+	// call is the constructor invocation as it appears in that file. Call sites
+	// of the same constructor do not always spell it the same way: some reach the
+	// unexported constructor from inside its own package.
+	call string
+}
+
+// group is one set of metrics created by a single constructor, mirroring one
+// wiring site in the SDK.
+type group struct {
+	// subsystem is the human-readable label used in the documentation.
+	subsystem string
+	// source is the file that declares the metric options.
+	source string
+	// scope is the provider flavour production uses for this constructor.
+	scope scope
+	// wiring lists the production call sites of the constructor. It records where
+	// the metrics are built; which provider flavour reaches them is established by
+	// TestTMSScopedProviderWiringIsIntact, not by this field.
+	wiring []wiringSite
+	// build invokes the constructor exactly as production does.
+	build func(metrics.Provider)
+}
+
+// tokenDrivers are the two files that turn the container's metrics provider into
+// a TMS-scoped one. Every tmsScoped group is reached from here.
+var tokenDrivers = []string{
+	"token/core/fabtoken/v1/driver/driver.go",
+	"token/core/zkatdlog/nogh/v1/driver/driver.go",
+}
+
+// groups enumerates every metrics constructor in the SDK. A new constructor must
+// be added here, otherwise its metrics are absent from the golden file and from
+// the reference documentation.
+var groups = []group{
+	{
+		subsystem: "Driver: issue service",
+		source:    "token/core/common/metrics/issue.go",
+		scope:     tmsScoped,
+		wiring: []wiringSite{
+			{file: "token/core/fabtoken/v1/driver/driver.go", call: "metrics.NewIssueService("},
+			{file: "token/core/zkatdlog/nogh/v1/driver/driver.go", call: "metrics.NewIssueService("},
+		},
+		build: func(p metrics.Provider) { commonmetrics.NewIssueService(nil, p) },
+	},
+	{
+		subsystem: "Driver: transfer service",
+		source:    "token/core/common/metrics/transfer.go",
+		scope:     tmsScoped,
+		wiring: []wiringSite{
+			{file: "token/core/fabtoken/v1/driver/driver.go", call: "metrics.NewTransferService("},
+			{file: "token/core/zkatdlog/nogh/v1/driver/driver.go", call: "metrics.NewTransferService("},
+		},
+		build: func(p metrics.Provider) { commonmetrics.NewTransferService(nil, p) },
+	},
+	{
+		subsystem: "Driver: auditor service",
+		source:    "token/core/common/metrics/auditor.go",
+		scope:     tmsScoped,
+		wiring: []wiringSite{
+			{file: "token/core/fabtoken/v1/driver/driver.go", call: "metrics.NewAuditorService("},
+			{file: "token/core/zkatdlog/nogh/v1/driver/driver.go", call: "metrics.NewAuditorService("},
+		},
+		build: func(p metrics.Provider) { commonmetrics.NewAuditorService(nil, p) },
+	},
+	{
+		subsystem: "Driver: tokens service",
+		source:    "token/core/common/metrics/tokens.go",
+		scope:     tmsScoped,
+		wiring: []wiringSite{
+			{file: "token/core/fabtoken/v1/driver/driver.go", call: "metrics.NewTokensService("},
+			{file: "token/core/zkatdlog/nogh/v1/driver/driver.go", call: "metrics.NewTokensService("},
+		},
+		build: func(p metrics.Provider) { commonmetrics.NewTokensService(nil, p) },
+	},
+	{
+		subsystem: "Driver: tokens upgrade service",
+		source:    "token/core/common/metrics/upgrade.go",
+		scope:     tmsScoped,
+		wiring: []wiringSite{
+			{file: "token/core/fabtoken/v1/driver/driver.go", call: "metrics.NewTokensUpgradeService("},
+			{file: "token/core/zkatdlog/nogh/v1/driver/driver.go", call: "metrics.NewTokensUpgradeService("},
+		},
+		build: func(p metrics.Provider) { commonmetrics.NewTokensUpgradeService(nil, p) },
+	},
+	{
+		subsystem: "Identity: signer resolution",
+		source:    "token/services/identity/metrics.go",
+		scope:     tmsScoped,
+		wiring: []wiringSite{
+			{file: "token/core/fabtoken/v1/driver/ws.go", call: "identity.NewMetrics(metricsProvider)"},
+			{file: "token/core/zkatdlog/nogh/v1/driver/ws.go", call: "identity.NewMetrics(metricsProvider)"},
+		},
+		build: func(p metrics.Provider) { identity.NewMetrics(p) },
+	},
+	{
+		subsystem: "Identity: idemix identity cache",
+		source:    "token/services/identity/idemix/cache/metrics.go",
+		scope:     tmsScoped,
+		wiring: []wiringSite{
+			{file: "token/services/identity/idemix/kmp.go", call: "cache.NewMetrics(l.metricsProvider)"},
+		},
+		build: func(p metrics.Provider) { idemixcache.NewMetrics(p) },
+	},
+	{
+		subsystem: "Identity: wallet recipient data cache",
+		source:    "token/services/identity/role/metrics.go",
+		scope:     tmsScoped,
+		wiring: []wiringSite{
+			{file: "token/services/identity/role/wallets.go", call: "NewMetrics(metricsProvider)"},
+		},
+		build: func(p metrics.Provider) { role.NewMetrics(p) },
+	},
+	{
+		subsystem: "TTX: transaction lifecycle",
+		source:    "token/services/ttx/metrics.go",
+		scope:     direct,
+		wiring: []wiringSite{
+			{file: "token/sdk/dig/sdk.go", call: "p.Container().Provide(ttx.NewMetrics)"},
+		},
+		build: func(p metrics.Provider) { ttx.NewMetrics(p) },
+	},
+	{
+		subsystem: "TTX: finality listener",
+		source:    "token/services/ttx/finality/metrics.go",
+		scope:     direct,
+		wiring: []wiringSite{
+			{file: "token/services/ttx/finality/listener.go", call: "newMetrics(metricsProvider)"},
+			{file: "token/services/ttx/finality/recovery.go", call: "NewMetrics(metricsProvider)"},
+		},
+		build: func(p metrics.Provider) { ttxfinality.NewMetrics(p) },
+	},
+	{
+		subsystem: "TTX: envelope sessions",
+		source:    "token/services/utils/json/session/metrics.go",
+		scope:     direct,
+		wiring: []wiringSite{
+			{file: "token/sdk/dig/sdk.go", call: "p.Container().Provide(jsession.NewEnvelopeMetrics)"},
+		},
+		build: func(p metrics.Provider) { jsession.NewEnvelopeMetrics(p) },
+	},
+	{
+		subsystem: "Auditor service",
+		source:    "token/services/auditor/metrics.go",
+		scope:     direct,
+		wiring: []wiringSite{
+			{file: "token/services/auditor/auditor.go", call: "newMetrics(metricsProvider)"},
+			{file: "token/services/auditor/manager.go", call: "newMetrics(metricsProvider)"},
+		},
+		build: func(p metrics.Provider) { auditor.NewMetrics(p) },
+	},
+	{
+		subsystem: "Token selection (sherdlock)",
+		source:    "token/services/selector/sherdlock/metrics.go",
+		scope:     direct,
+		wiring: []wiringSite{
+			{file: "token/services/selector/sherdlock/service.go", call: "NewMetrics(metricsProvider)"},
+			{file: "token/services/selector/sherdlock/fetcher.go", call: "NewMetrics(metricsProvider)"},
+		},
+		build: func(p metrics.Provider) { sherdlock.NewMetrics(p) },
+	},
+	{
+		subsystem: "Certification service (server)",
+		source:    "token/services/certifier/interactive/metrics.go",
+		scope:     direct,
+		wiring: []wiringSite{
+			{file: "token/services/certifier/interactive/service.go", call: "NewMetrics(mp)"},
+		},
+		build: func(p metrics.Provider) { interactive.NewMetrics(p) },
+	},
+	{
+		subsystem: "Certification client",
+		source:    "token/services/certifier/interactive/metrics.go",
+		scope:     direct,
+		wiring: []wiringSite{
+			{file: "token/services/certifier/interactive/client.go", call: "newClientMetrics(metricsProvider)"},
+		},
+		build: func(p metrics.Provider) { interactive.NewClientMetrics(p) },
+	},
+	{
+		subsystem: "Fabric-X finality queue",
+		source:    "token/services/network/fabricx/finality/queue/metrics.go",
+		scope:     direct,
+		wiring: []wiringSite{
+			{file: "token/services/network/fabricx/finality/queue/queue.go", call: "newMetrics(cfg.MetricsProvider)"},
+		},
+		build: func(p metrics.Provider) { fabricxqueue.NewMetrics(p) },
+	},
+}
+
+// entry is one documented metric.
+type entry struct {
+	// name is the fully-qualified name Prometheus exports.
+	name string
+	// kind is counter, gauge or histogram.
+	kind string
+	// labels are the declared variable labels, in declaration order.
+	labels []string
+	// source is the file declaring the metric options.
+	source string
+	// help is the metric help string.
+	help string
+}
+
+func (e entry) String() string {
+	labels := "-"
+	if len(e.labels) > 0 {
+		labels = strings.Join(e.labels, ",")
+	}
+
+	return strings.Join([]string{e.name, e.kind, labels, e.source, e.help}, " | ")
+}
+
+// TestMetricsReference collects every metric the SDK registers and checks it
+// against the golden file. Run with UPDATE_GOLDEN=1 to regenerate the golden
+// file after an intentional change, then update docs/development/metrics.md.
+func TestMetricsReference(t *testing.T) {
+	entries := collect(t)
+	require.NotEmpty(t, entries)
+
+	lines := make([]string, 0, len(entries))
+	for _, e := range entries {
+		lines = append(lines, e.String())
+	}
+	slices.Sort(lines)
+	actual := strings.Join(lines, "\n") + "\n"
+
+	if os.Getenv(updateEnv) != "" {
+		require.NoError(t, os.MkdirAll(filepath.Dir(goldenFile), 0o750))
+		require.NoError(t, os.WriteFile(goldenFile, []byte(actual), 0o644))
+		t.Logf("wrote %d metrics to %s; update %s to match", len(entries), goldenFile, referenceDoc)
+
+		return
+	}
+
+	expected, err := os.ReadFile(goldenFile)
+	require.NoError(t, err, "cannot read %s; run with %s=1 to create it", goldenFile, updateEnv)
+	assert.Equal(t, string(expected), actual,
+		"the metrics the SDK registers no longer match %s.\n"+
+			"Re-run with %s=1 to regenerate it, then update %s to match.",
+		goldenFile, updateEnv, referenceDoc)
+}
+
+// TestReferenceDocumentsEveryMetric keeps docs/development/metrics.md in sync
+// with the registered metrics: every metric must be documented, and the page
+// must not mention names that are no longer exported.
+func TestReferenceDocumentsEveryMetric(t *testing.T) {
+	doc, err := os.ReadFile(referenceDoc)
+	require.NoError(t, err)
+	reference, _, found := strings.Cut(string(doc), gapsHeading)
+	require.True(t, found, "%s no longer contains a %q section", referenceDoc, strings.TrimSpace(gapsHeading))
+
+	registered := make(map[string]string)
+	for _, e := range collect(t) {
+		registered[e.name] = e.kind
+	}
+	documented := extractMetricNames(reference, registered)
+
+	for name := range registered {
+		assert.Contains(t, documented, name,
+			"metric %q is exported but not documented in %s", name, referenceDoc)
+	}
+	for name := range documented {
+		if _, ok := registered[name]; ok {
+			continue
+		}
+		_, prose := prosePrefixes[name]
+		assert.True(t, prose,
+			"%s mentions %q, which the SDK does not register (renamed, removed or truncated?). "+
+				"If it is prose about the naming scheme rather than a metric, add it to prosePrefixes.",
+			referenceDoc, name)
+	}
+}
+
+// TestExportedNamesCarryPackagePrefix documents, as an assertion, the rule that
+// makes the exported names hard to guess: the prefix comes from the package that
+// calls the provider, so metrics reached through the TMS-scoped wrapper are
+// exported under that wrapper's package instead of their own.
+func TestExportedNamesCarryPackagePrefix(t *testing.T) {
+	for _, g := range groups {
+		names := exportedNames(t, g)
+		require.NotEmpty(t, names, "group %q registered no metrics", g.subsystem)
+
+		for _, name := range names {
+			assert.True(t, strings.HasPrefix(name, "panurus_"),
+				"metric %q does not carry the panurus namespace; is token/services/logging imported?", name)
+
+			if g.scope == tmsScoped {
+				assert.True(t, strings.HasPrefix(name, tmsWrapperPrefix),
+					"metric %q is created through the TMS-scoped provider and should be exported under %q",
+					name, tmsWrapperPrefix)
+			} else {
+				assert.False(t, strings.HasPrefix(name, tmsWrapperPrefix),
+					"metric %q is created with the plain provider and should keep its own package prefix", name)
+			}
+		}
+	}
+}
+
+// tmsWrapperPrefix is the package prefix every TMS-scoped metric is exported
+// under, because commonmetrics.tmsProvider is the caller Prometheus sees.
+const tmsWrapperPrefix = "panurus_core_common_metrics_"
+
+// tmsProviderCall is the expression that puts the TMS-scoped groups behind the
+// wrapper. Passing d.metricsProvider directly instead would re-export all of
+// them under their own package prefixes and invalidate most of the reference
+// page - the exact failure this package exists to prevent - so the expression is
+// pinned rather than inferred.
+const tmsProviderCall = "metrics.NewTMSProvider(tmsConfig.ID(), d.metricsProvider)"
+
+// tmsProviderPattern matches a call to commonmetrics.NewTMSProvider under any
+// import alias ending in "metrics". It deliberately does not match the unrelated
+// ftscore.NewTMSProvider in token/core/tms.go.
+var tmsProviderPattern = regexp.MustCompile(`\b\w*metrics\.NewTMSProvider\(`)
+
+// TestTMSScopedProviderWiringIsIntact pins the wiring the scope column depends
+// on. The column claims that eight groups are exported under the wrapper's
+// package and eight are not, and nothing in the constructors themselves says so:
+// it is decided entirely by which provider production hands in. This test
+// establishes it by exhaustion - the token drivers are the only files that build
+// a TMS-scoped provider, and they do so from the container's provider - so a
+// group reached from anywhere else cannot be TMS-scoped.
+func TestTMSScopedProviderWiringIsIntact(t *testing.T) {
+	found := grepRepo(t, tmsProviderPattern)
+	assert.ElementsMatch(t, tokenDrivers, found,
+		"the set of files building a TMS-scoped metrics provider has changed. "+
+			"Every metric reached from a new call site is exported under %q instead of its own package, "+
+			"so re-check the scope column and the names in %s, then update tokenDrivers.",
+		tmsWrapperPrefix, referenceDoc)
+
+	for _, driver := range tokenDrivers {
+		assertFileContains(t, driver, tmsProviderCall,
+			"%s no longer wraps the container's metrics provider with %s. "+
+				"Without the wrapper the driver and identity metrics are exported under their own "+
+				"package prefixes, and every %s* name in %s is wrong.",
+			driver, tmsProviderCall, tmsWrapperPrefix, referenceDoc)
+	}
+}
+
+// TestWiringSitesArePresent checks that every call site listed in a group's
+// wiring still exists and still builds that group's metrics, so the pointers a
+// reviewer follows stay honest.
+func TestWiringSitesArePresent(t *testing.T) {
+	for _, g := range groups {
+		require.NotEmpty(t, g.wiring, "group %q lists no production call site", g.subsystem)
+
+		for _, site := range g.wiring {
+			assertFileContains(t, site.file, site.call,
+				"group %q claims %s builds its metrics with %q, which that file no longer contains",
+				g.subsystem, site.file, site.call)
+		}
+	}
+}
+
+// TestFoldPromQLSuffix covers the cases the reference page does not exercise
+// today: a metric whose own name ends in a PromQL suffix must survive the fold,
+// or the coverage check would report a correctly documented metric as missing.
+func TestFoldPromQLSuffix(t *testing.T) {
+	registered := map[string]string{
+		"panurus_services_ttx_transaction_duration_seconds": "histogram",
+		"panurus_services_ttx_retry_count":                  "counter",
+		"panurus_services_ttx_accepted_transactions":        "counter",
+	}
+
+	for _, tc := range []struct {
+		name     string
+		in       string
+		expected string
+	}{
+		{
+			name:     "histogram bucket folds onto its family",
+			in:       "panurus_services_ttx_transaction_duration_seconds_bucket",
+			expected: "panurus_services_ttx_transaction_duration_seconds",
+		},
+		{
+			name:     "histogram sum folds onto its family",
+			in:       "panurus_services_ttx_transaction_duration_seconds_sum",
+			expected: "panurus_services_ttx_transaction_duration_seconds",
+		},
+		{
+			name:     "histogram count folds onto its family",
+			in:       "panurus_services_ttx_transaction_duration_seconds_count",
+			expected: "panurus_services_ttx_transaction_duration_seconds",
+		},
+		{
+			name:     "a registered name ending in _count is left alone",
+			in:       "panurus_services_ttx_retry_count",
+			expected: "panurus_services_ttx_retry_count",
+		},
+		{
+			name:     "a suffix is not trimmed onto a non-histogram base",
+			in:       "panurus_services_ttx_accepted_transactions_count",
+			expected: "panurus_services_ttx_accepted_transactions_count",
+		},
+		{
+			name:     "an unregistered name is reported as written",
+			in:       "panurus_services_ttx_accepted",
+			expected: "panurus_services_ttx_accepted",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, foldPromQLSuffix(tc.in, registered))
+		})
+	}
+}
+
+// collect instantiates every group twice: once against a recording provider that
+// captures the declared options, and once against a real Prometheus provider
+// that yields the exported names. Each group gets its own provider and its own
+// registry, so the two passes line up index by index within the group - a shared
+// provider would deduplicate by kind and fully-qualified name and shift the
+// pairing for every group after a duplicate.
+func collect(t *testing.T) []entry {
+	t.Helper()
+
+	byName := make(map[string]entry)
+	entries := make([]entry, 0, len(groups))
+	for _, g := range groups {
+		declared := declaredOptions(t, g)
+		exported := exportedNames(t, g)
+		require.Len(t, exported, len(declared),
+			"group %q declared %v but registered %v; two metrics of the same kind sharing a "+
+				"fully-qualified name are collapsed into one collector by the provider cache",
+			g.subsystem, declaredNames(declared), exported)
+
+		for i, d := range declared {
+			name := exported[i]
+			require.True(t, strings.HasSuffix(name, d.name),
+				"exported name %q does not end in the declared name %q", name, d.name)
+			e := entry{
+				name:   name,
+				kind:   d.kind,
+				labels: d.labels,
+				source: d.source,
+				help:   d.help,
+			}
+
+			// Two wiring sites may legitimately ask for the same metric: the
+			// provider hands both the same collector. Identical definitions are
+			// therefore folded into one row, while a clash is reported by name
+			// rather than as a length mismatch.
+			if previous, ok := byName[e.name]; ok {
+				require.Equal(t, previous, e,
+					"metric %q is registered twice with different definitions; the provider would panic "+
+						"on the second request", e.name)
+
+				continue
+			}
+			byName[e.name] = e
+			entries = append(entries, e)
+		}
+	}
+
+	return entries
+}
+
+// declaration is a metric as written in the source: its bare name, kind, labels
+// and help, before Prometheus prefixes it.
+type declaration struct {
+	kind   string
+	name   string
+	labels []string
+	help   string
+	source string
+}
+
+// declaredNames lists the bare metric names of a group, for failure messages.
+func declaredNames(declared []declaration) []string {
+	out := make([]string, 0, len(declared))
+	for _, d := range declared {
+		out = append(out, d.kind+" "+d.name)
+	}
+
+	return out
+}
+
+// declaredOptions replays one constructor against a provider that records the
+// options instead of registering them.
+func declaredOptions(t *testing.T, g group) []declaration {
+	t.Helper()
+
+	var out []declaration
+	recorder := &recordingProvider{inner: &disabled.Provider{}, source: g.source, out: &out}
+	g.build(providerFor(g, recorder))
+
+	return out
+}
+
+// exportedNames replays one constructor against a real Prometheus provider and
+// returns the fully-qualified names in creation order.
+func exportedNames(t *testing.T, g group) []string {
+	t.Helper()
+
+	capture := newCapturingRegisterer(t)
+	defer capture.restore()
+
+	g.build(providerFor(g, &promprovider.Provider{}))
+
+	return capture.names
+}
+
+// providerFor reproduces the provider flavour production hands to the group.
+func providerFor(g group, base metrics.Provider) metrics.Provider {
+	if g.scope == tmsScoped {
+		return commonmetrics.NewTMSProvider(tmsID, base)
+	}
+
+	return base
+}
+
+// recordingProvider captures the metric options it is asked for and delegates to
+// a provider that discards observations. It must not be used in the pass that
+// determines exported names: delegating adds a stack frame, which would attribute
+// the metrics to this package.
+type recordingProvider struct {
+	inner  metrics.Provider
+	source string
+	out    *[]declaration
+}
+
+func (p *recordingProvider) NewCounter(o metrics.CounterOpts) metrics.Counter {
+	p.record("counter", o.Name, o.Help, o.LabelNames)
+
+	return p.inner.NewCounter(o)
+}
+
+func (p *recordingProvider) NewGauge(o metrics.GaugeOpts) metrics.Gauge {
+	p.record("gauge", o.Name, o.Help, o.LabelNames)
+
+	return p.inner.NewGauge(o)
+}
+
+func (p *recordingProvider) NewHistogram(o metrics.HistogramOpts) metrics.Histogram {
+	p.record("histogram", o.Name, o.Help, o.LabelNames)
+
+	return p.inner.NewHistogram(o)
+}
+
+func (p *recordingProvider) record(kind, name, help string, labels []string) {
+	*p.out = append(*p.out, declaration{
+		kind:   kind,
+		name:   name,
+		labels: slices.Clone(labels),
+		help:   help,
+		source: p.source,
+	})
+}
+
+// fqNamePattern extracts the fully-qualified name from a Desc. Desc keeps its
+// fields private and only renders them through String().
+var fqNamePattern = regexp.MustCompile(`fqName: "([^"]+)"`)
+
+// registererMu serialises the swap of prom.DefaultRegisterer. FSC's provider
+// documents that it assumes the default registerer is not swapped while it is in
+// use, and the swap itself is a write to a package-level variable, so at most one
+// capture may be in flight at a time - including if a test in this package is
+// ever given t.Parallel().
+var registererMu sync.Mutex
+
+// capturingRegisterer stands in for the default registerer while a test runs and
+// records the fully-qualified name of every collector registered through it, in
+// registration order.
+type capturingRegisterer struct {
+	prom.Registerer
+	t        *testing.T
+	previous prom.Registerer
+	names    []string
+}
+
+func newCapturingRegisterer(t *testing.T) *capturingRegisterer {
+	t.Helper()
+
+	registererMu.Lock()
+	c := &capturingRegisterer{Registerer: prom.NewRegistry(), t: t, previous: prom.DefaultRegisterer}
+	prom.DefaultRegisterer = c
+
+	return c
+}
+
+func (c *capturingRegisterer) Register(collector prom.Collector) error {
+	descs := make(chan *prom.Desc, 1)
+	go func() {
+		defer close(descs)
+		collector.Describe(descs)
+	}()
+
+	for desc := range descs {
+		match := fqNamePattern.FindStringSubmatch(desc.String())
+		require.Len(c.t, match, 2, "cannot read the metric name out of %s", desc)
+		c.names = append(c.names, match[1])
+	}
+
+	return c.Registerer.Register(collector)
+}
+
+// MustRegister is overridden so that name capture cannot be bypassed: the
+// embedded Registerer would otherwise satisfy it directly, and a switch to
+// promauto inside FSC's provider would silently stop recording names.
+func (c *capturingRegisterer) MustRegister(collectors ...prom.Collector) {
+	for _, collector := range collectors {
+		require.NoError(c.t, c.Register(collector))
+	}
+}
+
+func (c *capturingRegisterer) restore() {
+	prom.DefaultRegisterer = c.previous
+	registererMu.Unlock()
+}
+
+// metricNamePattern finds the SDK metric names mentioned anywhere in the
+// reference documentation, including inside tables and PromQL snippets. The
+// leading group keeps the match from starting inside a longer identifier, such as
+// the namespace replacer key github.com_LFDT-Panurus_panurus_token.
+var metricNamePattern = regexp.MustCompile(`(^|[^0-9A-Za-z_])(panurus_[a-z0-9_]+)`)
+
+// prosePrefixes are the namespace fragments the reference page mentions while
+// explaining how a name is assembled. They are not metrics, so the reverse check
+// ignores them. Everything else the page mentions must be registered - notably a
+// truncated name such as panurus_services_ttx_accepted, which is the likeliest
+// copy-paste error in a hand-maintained table.
+var prosePrefixes = map[string]struct{}{
+	"panurus_services": {},
+}
+
+// extractMetricNames returns the metric names the documentation mentions. Bare
+// prefixes such as "panurus_services_ttx_" are prose, not metrics, and are
+// skipped. The caller is expected to pass only the part of the page that
+// documents existing metrics; see gapsHeading.
+func extractMetricNames(doc string, registered map[string]string) map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, match := range metricNamePattern.FindAllStringSubmatch(doc, -1) {
+		name := match[2]
+		if strings.HasSuffix(name, "_") {
+			continue
+		}
+		out[foldPromQLSuffix(name, registered)] = struct{}{}
+	}
+
+	return out
+}
+
+// foldPromQLSuffix maps a time series a histogram exports, such as
+// ..._duration_seconds_bucket, back onto the metric family it belongs to, so a
+// PromQL example does not read as an undocumented metric. The fold is
+// conditional: a name that is itself registered is left alone, and a suffix is
+// only removed when what remains is a registered histogram. An unconditional trim
+// would rewrite a counter whose own name ends in _count, _sum or _bucket and
+// report it as undocumented on a page that documents it correctly.
+func foldPromQLSuffix(name string, registered map[string]string) string {
+	if _, ok := registered[name]; ok {
+		return name
+	}
+	for _, suffix := range []string{"_bucket", "_sum", "_count"} {
+		base, ok := strings.CutSuffix(name, suffix)
+		if !ok {
+			continue
+		}
+		if registered[base] == "histogram" {
+			return base
+		}
+	}
+
+	return name
+}
+
+// assertFileContains checks that a repository-relative source file still holds a
+// snippet, and reports only msg on failure.
+//
+// It deliberately does not use assert.Contains: the haystack here is a whole
+// source file, and testify prints the haystack, which buries the message under a
+// few hundred lines of Go.
+//
+//nolint:testifylint // see above; assert.Contains would dump the entire file
+func assertFileContains(t *testing.T, path, snippet, msg string, args ...any) {
+	t.Helper()
+
+	assert.True(t, strings.Contains(readRepoFile(t, path), snippet), append([]any{msg}, args...)...)
+}
+
+// readRepoFile returns the contents of a repository-relative file.
+func readRepoFile(t *testing.T, path string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(path)))
+	require.NoError(t, err, "cannot read %s; has it moved?", path)
+
+	return string(content)
+}
+
+// skippedDirs are not searched by grepRepo: they hold no first-party wiring.
+var skippedDirs = map[string]struct{}{
+	".git":         {},
+	".github":      {},
+	"docs":         {},
+	"node_modules": {},
+	"vendor":       {},
+}
+
+// isNestedCheckout reports whether dir is a checkout of its own - a git worktree
+// or a clone - rather than part of this one. Both carry a .git entry. Such a
+// directory holds a second copy of the whole repository, which would otherwise be
+// walked as if it were part of this one and report every wiring file twice; the
+// project's own workflow puts worktrees under .claude/worktrees.
+func isNestedCheckout(dir string) bool {
+	_, err := os.Lstat(filepath.Join(dir, ".git"))
+
+	return err == nil
+}
+
+// grepRepo returns the repository-relative paths of the non-test Go files that
+// match pattern, sorted.
+func grepRepo(t *testing.T, pattern *regexp.Regexp) []string {
+	t.Helper()
+
+	root, err := filepath.Abs(repoRoot)
+	require.NoError(t, err)
+
+	// The walk only collects candidate paths; the files are read afterwards, so
+	// no filesystem operation happens inside the callback.
+	var candidates []string
+	require.NoError(t, filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if _, skip := skippedDirs[d.Name()]; skip {
+				return fs.SkipDir
+			}
+			if path != root && isNestedCheckout(path) {
+				return fs.SkipDir
+			}
+
+			return nil
+		}
+		if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+			candidates = append(candidates, path)
+		}
+
+		return nil
+	}))
+
+	found := make([]string, 0, len(candidates))
+	for _, path := range candidates {
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		if !pattern.Match(content) {
+			continue
+		}
+		rel, err := filepath.Rel(root, path)
+		require.NoError(t, err)
+		found = append(found, filepath.ToSlash(rel))
+	}
+	slices.Sort(found)
+
+	return found
+}

--- a/token/services/metricsdoc/testdata/metrics.golden
+++ b/token/services/metricsdoc/testdata/metrics.golden
@@ -1,0 +1,56 @@
+panurus_core_common_metrics_auditor_service_duration_seconds | histogram | network,channel,namespace,method | token/core/common/metrics/auditor.go | Duration of AuditorService method calls in seconds
+panurus_core_common_metrics_auditor_service_errors_total | counter | network,channel,namespace,method | token/core/common/metrics/auditor.go | Total number of AuditorService method errors
+panurus_core_common_metrics_auditor_service_operations_total | counter | network,channel,namespace,method | token/core/common/metrics/auditor.go | Total number of AuditorService method invocations
+panurus_core_common_metrics_cache_level | gauge | network,channel,namespace | token/services/identity/idemix/cache/metrics.go | Level of the idemix cache
+panurus_core_common_metrics_cache_provision_failures_total | counter | network,channel,namespace | token/services/identity/idemix/cache/metrics.go | Failed attempts to pre-provision idemix identities
+panurus_core_common_metrics_identity_get_signer_duration_seconds | histogram | network,channel,namespace,path | token/services/identity/metrics.go | Histogram of GetSigner wall-clock time in seconds, labeled by resolution path
+panurus_core_common_metrics_identity_signer_resolutions_total | counter | network,channel,namespace,outcome | token/services/identity/metrics.go | Total number of GetSigner calls by outcome (cache, routed, fallback)
+panurus_core_common_metrics_identity_signer_router_no_probe_errors_total | counter | network,channel,namespace | token/services/identity/metrics.go | Total number of errors from the SignerRouter's probe-free signer deserialization path
+panurus_core_common_metrics_identity_signer_router_registrations_total | counter | network,channel,namespace | token/services/identity/metrics.go | Total number of conf_id-to-KeyManager bindings registered with the SignerRouter
+panurus_core_common_metrics_issue_service_duration_seconds | histogram | network,channel,namespace,method | token/core/common/metrics/issue.go | Duration of IssueService method calls in seconds
+panurus_core_common_metrics_issue_service_errors_total | counter | network,channel,namespace,method | token/core/common/metrics/issue.go | Total number of IssueService method errors
+panurus_core_common_metrics_issue_service_operations_total | counter | network,channel,namespace,method | token/core/common/metrics/issue.go | Total number of IssueService method invocations
+panurus_core_common_metrics_recipient_data_cache_level | gauge | network,channel,namespace | token/services/identity/role/metrics.go | Level of the wallet recipient data cache
+panurus_core_common_metrics_recipient_data_provision_failures_total | counter | network,channel,namespace | token/services/identity/role/metrics.go | Failed attempts to pre-provision wallet recipient data
+panurus_core_common_metrics_tokens_service_duration_seconds | histogram | network,channel,namespace,method | token/core/common/metrics/tokens.go | Duration of TokensService method calls in seconds
+panurus_core_common_metrics_tokens_service_errors_total | counter | network,channel,namespace,method | token/core/common/metrics/tokens.go | Total number of TokensService method errors
+panurus_core_common_metrics_tokens_service_operations_total | counter | network,channel,namespace,method | token/core/common/metrics/tokens.go | Total number of TokensService method invocations
+panurus_core_common_metrics_tokens_upgrade_service_duration_seconds | histogram | network,channel,namespace,method | token/core/common/metrics/upgrade.go | Duration of TokensUpgradeService method calls in seconds
+panurus_core_common_metrics_tokens_upgrade_service_errors_total | counter | network,channel,namespace,method | token/core/common/metrics/upgrade.go | Total number of TokensUpgradeService method errors
+panurus_core_common_metrics_tokens_upgrade_service_operations_total | counter | network,channel,namespace,method | token/core/common/metrics/upgrade.go | Total number of TokensUpgradeService method invocations
+panurus_core_common_metrics_transfer_service_duration_seconds | histogram | network,channel,namespace,method | token/core/common/metrics/transfer.go | Duration of TransferService method calls in seconds
+panurus_core_common_metrics_transfer_service_errors_total | counter | network,channel,namespace,method | token/core/common/metrics/transfer.go | Total number of TransferService method errors
+panurus_core_common_metrics_transfer_service_operations_total | counter | network,channel,namespace,method | token/core/common/metrics/transfer.go | Total number of TransferService method invocations
+panurus_services_auditor_auditor_append_duration_seconds | histogram | - | token/services/auditor/metrics.go | Histogram of Append() processing time per transaction, in seconds
+panurus_services_auditor_auditor_append_errors_total | counter | - | token/services/auditor/metrics.go | Total number of Append() calls that failed to write to the audit database
+panurus_services_auditor_auditor_audit_duration_seconds | histogram | - | token/services/auditor/metrics.go | Histogram of Audit() processing time per transaction (including lock acquisition), in seconds
+panurus_services_auditor_auditor_audit_lock_conflicts_total | counter | - | token/services/auditor/metrics.go | Total number of Audit() calls that failed to acquire enrollment-ID locks
+panurus_services_auditor_auditor_releases_total | counter | - | token/services/auditor/metrics.go | Total number of Release() calls (explicit and deferred)
+panurus_services_certifier_interactive_certification_dropped_tokens_total | counter | channel,namespace | token/services/certifier/interactive/metrics.go | Total number of tokens dropped because the certification buffer was full.
+panurus_services_certifier_interactive_certification_errors_total | counter | channel,namespace | token/services/certifier/interactive/metrics.go | Total number of failed certification request attempts.
+panurus_services_certifier_interactive_certification_pending_tokens | gauge | channel,namespace | token/services/certifier/interactive/metrics.go | Current number of tokens waiting in the certification input buffer.
+panurus_services_certifier_interactive_certification_request_duration_seconds | histogram | channel,namespace | token/services/certifier/interactive/metrics.go | Histogram of certification batch request durations in seconds.
+panurus_services_certifier_interactive_certified_tokens | counter | network,channel,namespace | token/services/certifier/interactive/metrics.go | The number of tokens certified.
+panurus_services_network_fabricx_finality_queue_finality_queue_enqueue_drops_total | counter | - | token/services/network/fabricx/finality/queue/metrics.go | Total number of finality events dropped because the queue was full
+panurus_services_network_fabricx_finality_queue_finality_queue_pending_events | gauge | - | token/services/network/fabricx/finality/queue/metrics.go | Current number of finality events waiting in the queue buffer
+panurus_services_network_fabricx_finality_queue_finality_queue_processing_duration_seconds | histogram | - | token/services/network/fabricx/finality/queue/metrics.go | Histogram of successful event processing time in worker goroutines (seconds)
+panurus_services_network_fabricx_finality_queue_finality_queue_processing_errors_total | counter | - | token/services/network/fabricx/finality/queue/metrics.go | Total number of errors returned by event.Process in worker goroutines
+panurus_services_selector_sherdlock_selection_duration_seconds | histogram | - | token/services/selector/sherdlock/metrics.go | Duration of a token selection call in seconds
+panurus_services_selector_sherdlock_selection_immediate_retries | histogram | - | token/services/selector/sherdlock/metrics.go | Distribution of immediate retry counts per token selection call
+panurus_services_selector_sherdlock_selection_outcome_total | counter | outcome | token/services/selector/sherdlock/metrics.go | Total number of token selection outcomes by result type
+panurus_services_selector_sherdlock_unspent_tokens_invocations | counter | fetcher_type | token/services/selector/sherdlock/metrics.go | The number of invocations
+panurus_services_ttx_accepted_transactions | counter | network,channel,namespace | token/services/ttx/metrics.go | The number of accepted transactions.
+panurus_services_ttx_audit_approval_duration_seconds | histogram | network,channel,namespace | token/services/ttx/metrics.go | Duration of the auditor approval phase including validation, append, and signing.
+panurus_services_ttx_audit_approved_transactions | counter | network,channel,namespace | token/services/ttx/metrics.go | The number of approved transactions by the auditor.
+panurus_services_ttx_endorsed_transactions | counter | network,channel,namespace | token/services/ttx/metrics.go | The number of endorsed transactions.
+panurus_services_ttx_endorsement_duration_seconds | histogram | network,channel,namespace | token/services/ttx/metrics.go | Duration of the full endorsement collection phase including signatures, audit, and chaincode approval.
+panurus_services_ttx_finality_finality_listener_confirmed_total | counter | - | token/services/ttx/finality/metrics.go | Total number of transactions confirmed on the ledger and successfully committed to local storage
+panurus_services_ttx_finality_finality_listener_deleted_total | counter | - | token/services/ttx/finality/metrics.go | Total number of transactions marked as deleted due to an invalid ledger status or token-request hash mismatch
+panurus_services_ttx_finality_finality_listener_hash_mismatch_total | counter | - | token/services/ttx/finality/metrics.go | Total number of transactions rejected because the committed token-request hash did not match the locally stored one
+panurus_services_ttx_finality_finality_listener_on_status_duration_seconds | histogram | - | token/services/ttx/finality/metrics.go | Histogram of total OnStatus processing time per transaction (including retries), in seconds
+panurus_services_ttx_finality_finality_listener_retry_exhausted_total | counter | - | token/services/ttx/finality/metrics.go | Total number of transactions whose finality processing was abandoned after all retries were exhausted
+panurus_services_ttx_ordering_duration_seconds | histogram | network,channel,namespace | token/services/ttx/metrics.go | Duration of the transaction broadcast to the ordering service.
+panurus_services_utils_json_session_ttx_envelope_body_bytes | histogram | type | token/services/utils/json/session/metrics.go | Size of envelope body in bytes
+panurus_services_utils_json_session_ttx_envelope_errors_total | counter | error | token/services/utils/json/session/metrics.go | Total number of envelope validation errors
+panurus_services_utils_json_session_ttx_envelope_received_total | counter | version,type | token/services/utils/json/session/metrics.go | Total number of versioned envelopes received
+panurus_services_utils_json_session_ttx_envelope_sent_total | counter | version,type | token/services/utils/json/session/metrics.go | Total number of versioned envelopes sent

--- a/token/services/network/fabricx/finality/queue/metrics.go
+++ b/token/services/network/fabricx/finality/queue/metrics.go
@@ -57,6 +57,14 @@ func newMetrics(p metrics.Provider) *Metrics {
 	}
 }
 
+// NewMetrics creates a new Metrics instance with the given provider.
+// It is exported so that the metrics reference guard can instantiate the queue
+// instrumentation without starting a worker pool; see
+// docs/development/metrics.md.
+func NewMetrics(p metrics.Provider) *Metrics {
+	return newMetrics(p)
+}
+
 // noopProvider is a metrics.Provider that discards all observations.
 // It is used when no provider is configured (e.g. in tests).
 type noopProvider struct{}


### PR DESCRIPTION
Fixes #1745

## Problem

Panurus exports 54 metrics and documented none of them under the name Prometheus actually serves.

Nothing in the SDK spells those names out. The fully-qualified name is assembled at registration time
from the Go package of the *caller*, and the TMS-scoped provider in `token/core/common/metrics` adds a
stack frame — so metrics created through it are exported under *that* package, not their own. Docs
written from the bare `Name` field therefore list names no query matches. That is why #1749 was closed.

## What this PR does

**1. Documents the exported names** — `docs/development/metrics.md`: how a name is derived, one table
per subsystem (exported name, type, labels, meaning, source), PromQL examples, and a ranked
`## Coverage gaps` section on what a node still cannot report.

**2. Guards the page** — `token/services/metricsdoc` instantiates all 16 metrics constructors the way
production wires them, reads the names back out of a Prometheus registry, and checks them against
`testdata/metrics.golden` and against the page in both directions. It also pins the wiring the names
depend on: the two token drivers are asserted to be the only places a TMS-scoped provider is built, so
dropping that wrapper fails the build instead of silently renaming 21 metrics.

**3. Adds a Grafana dashboard** — `docs/monitoring/grafana/token-sdk.json`, revived from #1749 with the
correct names, plus a row for the four `identity_*` metrics that had no panel. All 54 metrics covered,
19 panels over 9 rows. Its queries are guarded too: every metric must be registered, every name must
carry its package prefix, every label filtered or grouped on must be declared, every `$variable` must
exist. These are the failures Grafana renders as "No data" rather than as an error.

**4. Corrects `docs/drivers/metrics.md`**, which listed declared names as if they were queryable, and
makes `docs/development/monitoring.md` the entry point.

`NewMetrics`/`NewClientMetrics` are exported in the auditor, certification and Fabric-X queue packages
so the guard can build their instrumentation without constructing the surrounding service.

## Verification

- All 54 names read out of a live Prometheus registry, not transcribed from source.
- Each guard check proven to fire by mutating the source: renamed metric, dropped TMS wrapper, stale
  wiring entry, truncated name in the page, absent label, undeclared variable.
- Run against #1749's original dashboard, the query guard reports 53 findings — that PR's defect would
  have failed the build.
- `make checks` and `make lint` exit 0; package green under `-count=3 -race -shuffle=on`.

## Known limitation

The dashboard guard checks **names, not rendering**. PromQL is not parsed (it would need a new
dependency, the exprs contain Grafana variables that are not valid PromQL, and it is the one failure
mode Grafana surfaces itself), and the file has not been imported into a live Grafana against a live
Prometheus — so panel presentation is unverified.

## Follow-up

The metric-hygiene items in the gap analysis (package attribution, stuttering names, missing
`network`/`channel`/`namespace` labels) all change exported names, so they belong in a single
deliberate follow-up with a release note rather than here.
