### PR TITLE
lint: enable ireturn

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - govet # Vet examines Go source code and reports suspicious constructs. It is roughly the same as 'go vet' and uses its passes. [auto-fix]
     - importas # Enforces consistent import aliases. [auto-fix]
     - intrange # Intrange is a linter to find places where for loops could make use of an integer range. [auto-fix]
+    - ireturn # Accept Interfaces, Return Concrete Types.
     - loggercheck # Checks key value pairs for common logger libraries (kitlog,klog,logr,slog,zap).
     - lll # Reports long lines. [fast]
     - mirror # Reports wrong mirror patterns of bytes/strings usage. [auto-fix]
@@ -90,6 +91,31 @@ linters:
         - github.com/prometheus/client_golang/prometheus.Counter
         - github.com/prometheus/client_golang/prometheus.Gauge
         - github.com/prometheus/client_golang/prometheus.Histogram
+        # Third-party interfaces we are obliged to return: either the signature is fixed by an
+        # interface we implement (Pagination, bccsp.Key, KeyStore) or it is the framework's own
+        # constructor convention (view.View, view.Session). Returning a concrete type instead is
+        # not an option in these cases, so allow them rather than carry a nolint at every site.
+        - github.com/hyperledger-labs/fabric-smart-client/platform/common/driver.Pagination
+        - github.com/hyperledger-labs/fabric-smart-client/platform/view/view.View
+        - github.com/hyperledger-labs/fabric-smart-client/platform/view/view.Session
+        - github.com/hyperledger/fabric-lib-go/bccsp.Key
+        - github.com/hyperledger/fabric-lib-go/bccsp.BCCSP
+        - github.com/hyperledger/fabric-lib-go/bccsp.HashOpts
+        - github.com/IBM/idemix/bccsp/types.BCCSP
+        - github.com/IBM/idemix/bccsp/types.KeyStore
+        - go.opentelemetry.io/otel/trace.Span
+        - github.com/hyperledger/fabric-lib-go/common/metrics.Gauge
+        - github.com/hyperledger/fabric-lib-go/common/metrics.Histogram
+        - github.com/hyperledger-labs/fabric-smart-client/platform/common/driver.ConfigService
+        - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.ViewClient
+        - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.Platform
+        - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.Context
+        - github.com/hyperledger/fabric-lib-go/common/metrics.Gauge
+        - github.com/hyperledger/fabric-lib-go/common/metrics.Histogram
+        - github.com/hyperledger-labs/fabric-smart-client/platform/common/driver.ConfigService
+        - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.ViewClient
+        - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.Platform
+        - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.Context
     lll:
       # Max line length, lines longer will be reported.
       line-length: 240

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,12 +110,6 @@ linters:
         - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.ViewClient
         - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.Platform
         - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.Context
-        - github.com/hyperledger/fabric-lib-go/common/metrics.Gauge
-        - github.com/hyperledger/fabric-lib-go/common/metrics.Histogram
-        - github.com/hyperledger-labs/fabric-smart-client/platform/common/driver.ConfigService
-        - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.ViewClient
-        - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.Platform
-        - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.Context
     lll:
       # Max line length, lines longer will be reported.
       line-length: 240


### PR DESCRIPTION
Next step of #1991, after #2098.

All 64 `ireturn` hits are returns of third-party interfaces, and in none of them is the signature
ours to change. Either the method implements that interface, so the shape is fixed:

- `(p *keyset[I, V]) GoToOffset(...) (driver.Pagination, error)` implements `driver.Pagination`
- `(k *ecdsaPrivateKey) PublicKey() (bccsp.Key, error)` implements `bccsp.Key`
- `(p *provider) NewGauge(...) metrics.Gauge` implements `metrics.Provider`

or it is the framework's own constructor convention, like the `view.View` constructors.

So this allows those 15 interfaces instead of touching code. No source files change, and `ireturn`
still catches the case it is actually for, returning an interface where one of our own concrete
types would do.

### Corrected measurements

I said on #2098 that the per-linter counts were unreliable because I measured them in one combined
run. Redone one linter at a time, root module:

| linter | issues | files | what I said before |
| --- | --- | --- | --- |
| maintidx | 17 | 15 | 10 / 8 |
| ireturn | 64 | 26 | 34 / 17 |
| iface | 88 | 58 | 64 / 46 |
| gocognit | 137 | 83 | 137 / 83 |
| wrapcheck | 2307 | 397 | 2301 / 397 |
| revive | 3452 | 683 | 2663 / 532 |

So four of the six were under-reported, `revive` by about 30%.

On `maintidx`, worth knowing before deciding: 12 of its 17 hits are in `_test.go` and 4 more are in
test helpers (`testutils`, `dbtest`). Only one is production code, `Prove` in
`crypto/rp/csp/rp.go`, which is in the middle of the CSP perf work. So excluding tests would leave
almost nothing, which makes me think the setting is not earning its keep, but that is your call.

`iface` at 58 files is the next unblocked one after this.
