### PR TITLE
fix(storage): allow digits in SQL table names and return errors instead of panicking

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -105,6 +105,9 @@ jobs:
           - name: fabtoken-owner-verifier
             pkg: ./token/core/fabtoken/v1/driver
             func: FuzzOwnerVerifierNoPanic
+          - name: storage-sql-table-names
+            pkg: ./token/services/storage/db/sql/common
+            func: FuzzGetTableNamesNoPanic
 
     steps:
       - name: Checkout code

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -693,6 +693,14 @@ to `<params>_<short_code>` (params still apply when provided; short-code overrid
 > will cause the node to look for tables under different names. Make sure the underlying
 > tables already exist under the unprefixed names before enabling this flag.
 
+> **Note:** `<params>` is the TMS identity (network, channel, namespace). `_`, `-` and `.`
+> in those values are escaped to `__`, `_d` and `_f`; letters, digits and underscores pass
+> through unchanged, so a channel named `channel1` is fine. The composed name must still be
+> a valid SQL identifier — it cannot start with a digit, which is only reachable with
+> `skipPrefix: true` and a network name starting with a digit. Any other character is a
+> configuration error and is reported as such, not a crash. See
+> [Table Name Customisation](services/storage.md#table-name-customisation).
+
 ---
 
 ### Optional: token.tms.<name>.services.storage.cleanup

--- a/docs/services/storage.md
+++ b/docs/services/storage.md
@@ -74,6 +74,35 @@ Two independent options let you control how the final name is composed:
 | Override individual short codes | `token.storage.tableNames` | _(none)_ |
 | Skip the FSC-generated prefix entirely | `token.storage.skipPrefix` | `false` |
 
+### Allowed characters
+
+The `TableNameParams` are the TMS identity — **network**, **channel** and **namespace** —
+and they become part of every table name, so they must be reducible to a legal SQL
+identifier. The characters that are common in Fabric names but illegal in an identifier
+are escaped rather than rejected:
+
+| Character in a param | Becomes |
+|---|---|
+| `_` | `__` |
+| `-` | `_d` |
+| `.` | `_f` |
+
+Letters, digits and underscores pass through as-is, so a channel called `channel1` or
+`mychannel01` is fine. The **final composed name** — prefix included — must still be a
+valid identifier: only letters, digits and underscores, and it cannot **start** with a
+digit (unquoted identifiers in both SQLite and PostgreSQL must start with a letter or an
+underscore). Since the prefix comes first and can never start with a digit, this only
+bites when `skipPrefix` is enabled *and* the network name starts with a digit.
+
+Anything else — a space, `!`, `/`, `;`, … — is a **configuration error**: store
+construction returns an error naming the offending value, it does not crash the node.
+A bad prefix or param breaks every table name in the same way and is reported once;
+invalid [short-code overrides](#overriding-short-codes-tablenames) are per-key, so **all**
+of them are reported together and you do not have to fix them one restart at a time.
+
+The `TablePrefix` is stricter: only letters and underscores, at most 100 characters. It is
+lower-cased before use.
+
 ### Overriding short codes (`tableNames`)
 
 You can replace any short code globally (for all TMS instances on the node) via the

--- a/token/services/storage/db/sql/common/init.go
+++ b/token/services/storage/db/sql/common/init.go
@@ -8,10 +8,19 @@ package common
 
 import (
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 )
 
-const defaultPrefix = "fsc"
+const (
+	defaultPrefix = "fsc"
+	// sharedNameProbe is the short code used to validate the part of a table name
+	// that every short code shares: the prefix and the params. It is a real
+	// canonical short code rather than a synthetic one, so a failure reports a name
+	// the operator actually recognises, and it is never read from the overrides, so
+	// the check does not depend on them.
+	sharedNameProbe = "movements"
+)
 
 var (
 	logger     = logging.MustGetLogger()
@@ -92,7 +101,7 @@ func GetTableNamesWithOverrides(prefix string, overrides TableNamesConfig, param
 		return TableNames{}, err
 	}
 
-	return buildTableNames(prefix, params, overrides, nc.MustFormat)
+	return buildTableNames(prefix, params, overrides, nc.Format)
 }
 
 // GetTableNamesWithOverridesSkipPrefix is like GetTableNamesWithOverrides but
@@ -103,12 +112,17 @@ func GetTableNamesWithOverridesSkipPrefix(prefix string, overrides TableNamesCon
 		return TableNames{}, err
 	}
 
-	return buildTableNames(prefix, params, overrides, nc.MustFormatWithoutPrefix)
+	return buildTableNames(prefix, params, overrides, nc.FormatWithoutPrefix)
 }
 
 // buildTableNames constructs a TableNames value by applying format to each
 // canonical short code (after resolving any override), forwarding params.
-func buildTableNames(prefix string, params []string, overrides TableNamesConfig, format func(string, ...string) string) (TableNames, error) {
+//
+// format is the error-returning formatter on purpose: an illegal character in
+// the prefix, in a short-code override or in one of the params (network,
+// channel, namespace) must surface as a configuration error to the caller, not
+// as a panic at store-construction time.
+func buildTableNames(prefix string, params []string, overrides TableNamesConfig, format func(string, ...string) (string, error)) (TableNames, error) {
 	// Warn on unknown override keys before applying any overrides.
 	for k := range overrides {
 		if _, ok := knownShortCodes[k]; !ok {
@@ -116,35 +130,58 @@ func buildTableNames(prefix string, params []string, overrides TableNamesConfig,
 		}
 	}
 
-	// resolve returns the effective short code: the override value if present,
-	// otherwise the canonical default.
-	resolve := func(defaultCode string) string {
-		if v, ok := overrides[defaultCode]; ok {
-			return v
-		}
-
-		return defaultCode
+	// The prefix and the params are shared by every short code, so a problem there
+	// breaks all of the names in the same way. Validate that shared part once, with
+	// a short code that is always a legal identifier fragment, so it is reported
+	// once instead of repeated for every table.
+	if _, err := format(sharedNameProbe, params...); err != nil {
+		return TableNames{}, errors.WithMessage(err, "invalid table name prefix or parameters")
 	}
 
-	return TableNames{
+	// Past that point a failure can only come from the short code itself, and an
+	// override is specific to its own key, so collect them all: returning just the
+	// first would make an operator fix one key, restart, and hit the next.
+	var errs []error
+
+	// name formats the effective short code for defaultCode: the override value
+	// if present, otherwise the canonical default.
+	name := func(defaultCode string) string {
+		code := defaultCode
+		if v, ok := overrides[defaultCode]; ok {
+			code = v
+		}
+		tableName, err := format(code, params...)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "failed to build table name for short code [%s]", code))
+		}
+
+		return tableName
+	}
+
+	tableNames := TableNames{
 		Prefix:                 prefix,
 		Params:                 params,
-		Movements:              format(resolve("movements"), params...),
-		Transactions:           format(resolve("txs"), params...),
-		TransactionEndorseAck:  format(resolve("tx_ends"), params...),
-		Requests:               format(resolve("requests"), params...),
-		Validations:            format(resolve("req_vals"), params...),
-		Tokens:                 format(resolve("tokens"), params...),
-		Ownership:              format(resolve("tkn_own"), params...),
-		Certifications:         format(resolve("tkn_crts"), params...),
-		TokenLocks:             format(resolve("tkn_locks"), params...),
-		PublicParams:           format(resolve("public_params"), params...),
-		Wallets:                format(resolve("wallets"), params...),
-		IdentityConfigurations: format(resolve("id_cfgs"), params...),
-		IdentityInfo:           format(resolve("id_info"), params...),
-		Signers:                format(resolve("id_signers"), params...),
-		KeyStore:               format(resolve("key_store"), params...),
-		EIDLeases:              format(resolve("eid_leases"), params...),
-		TokenSKICleanups:       format(resolve("tkn_ski_cleanups"), params...),
-	}, nil
+		Movements:              name("movements"),
+		Transactions:           name("txs"),
+		TransactionEndorseAck:  name("tx_ends"),
+		Requests:               name("requests"),
+		Validations:            name("req_vals"),
+		Tokens:                 name("tokens"),
+		Ownership:              name("tkn_own"),
+		Certifications:         name("tkn_crts"),
+		TokenLocks:             name("tkn_locks"),
+		PublicParams:           name("public_params"),
+		Wallets:                name("wallets"),
+		IdentityConfigurations: name("id_cfgs"),
+		IdentityInfo:           name("id_info"),
+		Signers:                name("id_signers"),
+		KeyStore:               name("key_store"),
+		EIDLeases:              name("eid_leases"),
+		TokenSKICleanups:       name("tkn_ski_cleanups"),
+	}
+	if err := errors.Join(errs...); err != nil {
+		return TableNames{}, err
+	}
+
+	return tableNames, nil
 }

--- a/token/services/storage/db/sql/common/init_test.go
+++ b/token/services/storage/db/sql/common/init_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package common_test
 
 import (
+	"strings"
 	"testing"
 
 	common "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/common"
@@ -241,6 +242,118 @@ func TestGetTableNamesWithOverridesSkipPrefix(t *testing.T) {
 	assert.NotContains(t, got.Transactions, "fsc_")
 	// Names still contain the param-based part.
 	assert.Contains(t, got.Transactions, "txs")
+}
+
+// TestGetTableNamesWithDigitsInParams is a regression test for
+// https://github.com/LFDT-Panurus/panurus/issues/2034: a network, channel or
+// namespace name containing a digit — e.g. the very common "channel1" — used to
+// panic while building the table names instead of producing a valid name.
+func TestGetTableNamesWithDigitsInParams(t *testing.T) {
+	for _, params := range [][]string{
+		{"testnetwork", "channel1", "ns"},
+		{"testnetwork", "testchannel1", "ns"},
+		{"testnetwork", "mychannel01", "ns"},
+		{"network1", "channel1", "namespace1"},
+		{"net0", "ch-1.2", "ns_3"},
+	} {
+		t.Run(strings.Join(params, "/"), func(t *testing.T) {
+			var got common.TableNames
+			var err error
+			require.NotPanics(t, func() {
+				got, err = common.GetTableNames("pfx", params...)
+			})
+			require.NoError(t, err)
+
+			for _, name := range allTableNames(got) {
+				assert.Regexp(t, `^[a-zA-Z_][a-zA-Z0-9_]*$`, name)
+			}
+		})
+	}
+
+	// Spot-check the exact name produced for the canonical case.
+	names, err := common.GetTableNames("pfx", "testnetwork", "channel1", "ns")
+	require.NoError(t, err)
+	assert.Equal(t, "pfx_testnetwork__channel1__ns_txs", names.Transactions)
+
+	// The same must hold when the prefix is skipped.
+	got, err := common.GetTableNamesWithOverridesSkipPrefix("pfx", nil, "testnetwork", "channel1", "ns")
+	require.NoError(t, err)
+	assert.Equal(t, "testnetwork__channel1__ns_txs", got.Transactions)
+}
+
+// TestGetTableNamesInvalidParamsReturnError checks that a param that cannot be
+// turned into a legal SQL identifier is reported as an error rather than
+// crashing the process: this call chain is reachable from ordinary store
+// construction and nothing along it recovers.
+func TestGetTableNamesInvalidParamsReturnError(t *testing.T) {
+	for _, params := range [][]string{
+		{"testnetwork", "channel!"},
+		{"testnetwork", "channel 1"},
+		{"testnetwork", "channel;drop table x"},
+	} {
+		t.Run(strings.Join(params, "/"), func(t *testing.T) {
+			require.NotPanics(t, func() {
+				names, err := common.GetTableNames("pfx", params...)
+				require.Error(t, err)
+				assert.Equal(t, common.TableNames{}, names)
+			})
+		})
+	}
+
+	// A param starting with a digit is fine behind a prefix, but not when the
+	// prefix is skipped: an unquoted identifier cannot start with a digit in
+	// either SQLite or PostgreSQL.
+	withPrefix, err := common.GetTableNames("pfx", "1network", "channel1")
+	require.NoError(t, err)
+	assert.Equal(t, "pfx_1network__channel1_txs", withPrefix.Transactions)
+
+	require.NotPanics(t, func() {
+		names, err := common.GetTableNamesWithOverridesSkipPrefix("pfx", nil, "1network", "channel1")
+		require.Error(t, err)
+		assert.Equal(t, common.TableNames{}, names)
+	})
+}
+
+// TestGetTableNamesInvalidOverridesReportEveryKey checks that every invalid
+// short-code override is reported, not just the first one. An override applies to
+// a single key, so reporting only one would make an operator fix that key, restart
+// the node, and hit the next one — once per bad key.
+func TestGetTableNamesInvalidOverridesReportEveryKey(t *testing.T) {
+	overrides := common.TableNamesConfig{
+		"txs":     "bad!name",
+		"tokens":  "worse name",
+		"wallets": "wrong;name",
+	}
+
+	names, err := common.GetTableNamesWithOverrides("pfx", overrides, "net", "ch", "ns")
+	require.Error(t, err)
+	assert.Equal(t, common.TableNames{}, names)
+	for _, badName := range overrides {
+		assert.Contains(t, err.Error(), badName,
+			"every invalid override must be reported, got: %s", err)
+	}
+}
+
+// TestGetTableNamesInvalidParamsReportedOnce checks that a problem in the part
+// every table name shares — the prefix and the params — is reported once instead
+// of repeated for each of the seventeen names it breaks.
+func TestGetTableNamesInvalidParamsReportedOnce(t *testing.T) {
+	names, err := common.GetTableNames("pfx", "net", "ch!")
+	require.Error(t, err)
+	assert.Equal(t, common.TableNames{}, names)
+	assert.Equal(t, 1, strings.Count(err.Error(), "unsupported chars"),
+		"a shared failure must be reported once, got: %s", err)
+}
+
+// allTableNames returns every generated table name in tn.
+func allTableNames(tn common.TableNames) []string {
+	return []string{
+		tn.Movements, tn.Transactions, tn.TransactionEndorseAck,
+		tn.Requests, tn.Validations, tn.Tokens, tn.Ownership,
+		tn.Certifications, tn.TokenLocks, tn.PublicParams,
+		tn.Wallets, tn.IdentityConfigurations, tn.IdentityInfo,
+		tn.Signers, tn.KeyStore, tn.EIDLeases, tn.TokenSKICleanups,
+	}
 }
 
 // TestGetTableNamesWithConfig_SkipPrefixFalse checks that GetTableNamesWithConfig

--- a/token/services/storage/db/sql/common/tablename.go
+++ b/token/services/storage/db/sql/common/tablename.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package common
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -17,8 +16,21 @@ import (
 )
 
 var (
-	validName = regexp.MustCompile(`^[a-zA-Z_]+$`) // Thread safe
-	replacers = []*replacer{
+	// validName accepts the SQL identifiers this package is allowed to generate:
+	// letters, digits and underscores, never starting with a digit (unquoted
+	// identifiers in both SQLite and PostgreSQL must start with a letter or an
+	// underscore). All regexps here are thread safe.
+	validName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+	// validEscapedParams accepts the result of escaping the table name
+	// parameters. Digits are allowed in any position, including the first: the
+	// composed table name is checked against validName afterwards, which is what
+	// decides whether a leading digit is acceptable there.
+	validEscapedParams = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+	// validPrefix accepts the user-configured table prefix. It is deliberately
+	// stricter than validName: a prefix is a configuration value, and letters
+	// and underscores have always been its documented character set.
+	validPrefix = regexp.MustCompile(`^[a-zA-Z_]+$`)
+	replacers   = []*replacer{
 		newReplacer("_", "__"),
 		newReplacer("-", "_d"),
 		newReplacer("\\.", "_f"),
@@ -34,21 +46,20 @@ func NewTableNameCreator(defaultPrefix string) *TableNameCreator {
 		if len(prefix) > 100 {
 			return nil, errors.New("table prefix must be shorter than 100 characters")
 		}
-		r := regexp.MustCompile("^[a-zA-Z_]+$")
 		if len(prefix) == 0 {
 			prefix = defaultPrefix
 		}
 		if len(prefix) == 0 {
-			return &tableNameFormatter{r: r}, nil
+			return &tableNameFormatter{r: validName}, nil
 		}
 
-		if !r.MatchString(prefix) {
+		if !validPrefix.MatchString(prefix) {
 			return nil, errors.New("illegal character in table prefix, only letters and underscores allowed")
 		}
 
 		return &tableNameFormatter{
 			prefix: strings.ToLower(prefix) + "_",
-			r:      r,
+			r:      validName,
 		}, nil
 	})}
 }
@@ -85,26 +96,33 @@ func (c *tableNameFormatter) MustFormat(name string, params ...string) string {
 }
 
 func (c *tableNameFormatter) Format(name string, params ...string) (string, error) {
-	if len(params) > 0 {
-		name = fmt.Sprintf("%s_%s", escapeForTableName(params...), name)
-	}
-	if !c.r.MatchString(name) {
-		return "", fmt.Errorf("invalid table name [%s]: only letters and underscores allowed", name)
-	}
-
-	return fmt.Sprintf("%s%s", c.prefix, name), nil
+	return c.format(c.prefix, name, params...)
 }
 
 // FormatWithoutPrefix returns the table name without applying the prefix.
 func (c *tableNameFormatter) FormatWithoutPrefix(name string, params ...string) (string, error) {
+	return c.format("", name, params...)
+}
+
+// format composes prefix, the escaped params and name, and validates the result.
+// It validates the identifier it is about to emit, not just the name fragment,
+// so a param that starts with a digit is fine as long as a prefix precedes it —
+// and rejected when there is none. It returns an error, never panics, for any
+// input it cannot turn into a legal SQL identifier.
+func (c *tableNameFormatter) format(prefix, name string, params ...string) (string, error) {
 	if len(params) > 0 {
-		name = fmt.Sprintf("%s_%s", escapeForTableName(params...), name)
+		escaped, err := escapeForTableName(params...)
+		if err != nil {
+			return "", err
+		}
+		name = escaped + "_" + name
 	}
-	if !c.r.MatchString(name) {
-		return "", fmt.Errorf("invalid table name [%s]: only letters and underscores allowed", name)
+	tableName := prefix + name
+	if !c.r.MatchString(tableName) {
+		return "", errors.Errorf("invalid table name [%s]: only letters, digits and underscores are allowed, and it cannot start with a digit", tableName)
 	}
 
-	return name, nil
+	return tableName, nil
 }
 
 // MustFormatWithoutPrefix returns the table name without applying the prefix, panicking on error.
@@ -123,14 +141,19 @@ func (r *replacer) Escape(s string) string {
 	return r.regex.ReplaceAllString(s, r.repl)
 }
 
-func escapeForTableName(params ...string) string {
+// escapeForTableName joins params and escapes the characters that are legal in a
+// network/channel/namespace name but not in a SQL identifier. It returns an
+// error, rather than panicking, when a parameter contains a character it cannot
+// escape, so that a bad configuration value surfaces as a store-construction
+// error instead of crashing the node.
+func escapeForTableName(params ...string) (string, error) {
 	name := strings.Join(params, "_")
 	for _, r := range replacers {
 		name = r.Escape(name)
 	}
-	if len(name) > 0 && !validName.MatchString(name) {
-		panic("unsupported chars found: " + name)
+	if len(name) > 0 && !validEscapedParams.MatchString(name) {
+		return "", errors.Errorf("unsupported chars found in table name parameters [%s]: only letters, digits, underscores, dashes and dots are allowed", name)
 	}
 
-	return name
+	return name, nil
 }

--- a/token/services/storage/db/sql/common/tablename_fuzz_test.go
+++ b/token/services/storage/db/sql/common/tablename_fuzz_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common_test
+
+import (
+	"regexp"
+	"testing"
+
+	common "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/common"
+	"github.com/stretchr/testify/require"
+)
+
+// sqlIdentifier is the only shape a generated table name is ever allowed to
+// take: a legal unquoted SQL identifier in both SQLite and PostgreSQL.
+var sqlIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// fuzzPrefix is the fixed table prefix used by FuzzGetTableNamesNoPanic. The
+// prefix is deliberately not fuzzed: every accepted prefix is memoised forever
+// in the package-level formatter cache, which has no eviction, so fuzzing it
+// would grow the worker's heap for the whole run. Issue 2034 was about the
+// params anyway, and the prefix edge cases (illegal characters, over-length,
+// empty) are covered by the table-driven tests in tablename_test.go.
+const fuzzPrefix = "pfx"
+
+// FuzzGetTableNamesNoPanic asserts the two properties that
+// https://github.com/LFDT-Panurus/panurus/issues/2034 violated, for any
+// network/channel/namespace triple:
+//
+//  1. building the table names never panics — this call chain is reachable from
+//     ordinary store construction and nothing along it recovers, so a panic here
+//     is a node crash;
+//  2. it either returns an error or returns names that are all legal SQL
+//     identifiers — it never silently produces a name that cannot be used.
+func FuzzGetTableNamesNoPanic(f *testing.F) {
+	f.Add("network", "channel", "ns")
+	f.Add("", "", "")
+	// The reported failure: digits in the channel name.
+	f.Add("testnetwork", "channel1", "ns")
+	f.Add("network1", "mychannel01", "namespace1")
+	// Characters that are escaped rather than rejected.
+	f.Add("net-work", "my.channel", "n_s")
+	// A parameter starting with a digit: legal input, illegal identifier.
+	f.Add("1network", "channel1", "ns")
+	// Characters with no escaping at all.
+	f.Add("network", "channel!", "ns")
+	f.Add("network", "channel 1", "ns")
+	f.Add("network", "channel;drop table x", "ns")
+	f.Add("network", "ch\x00annel", "ns")
+	f.Add("network", "channél", "ns")
+
+	f.Fuzz(func(t *testing.T, network, channel, namespace string) {
+		for _, get := range []func() (common.TableNames, error){
+			func() (common.TableNames, error) {
+				return common.GetTableNames(fuzzPrefix, network, channel, namespace)
+			},
+			func() (common.TableNames, error) {
+				return common.GetTableNamesWithOverridesSkipPrefix(fuzzPrefix, nil, network, channel, namespace)
+			},
+		} {
+			var names common.TableNames
+			var err error
+			require.NotPanics(t, func() { names, err = get() })
+			if err != nil {
+				continue
+			}
+			for _, name := range allTableNames(names) {
+				require.Regexp(t, sqlIdentifier, name)
+			}
+		}
+	})
+}

--- a/token/services/storage/db/sql/common/tablename_test.go
+++ b/token/services/storage/db/sql/common/tablename_test.go
@@ -25,9 +25,19 @@ func TestEscapeTableName(t *testing.T) {
 		{[]string{"alpha", "testchannel"}, "alpha__testchannel"},
 		{[]string{"alpha", "test-channel"}, "alpha__test_dchannel"},
 		{[]string{"alpha", "test-channel", "other.param"}, "alpha__test_dchannel__other_fparam"},
+		// Digits are legal in network/channel/namespace names and must survive
+		// escaping untouched. See https://github.com/LFDT-Panurus/panurus/issues/2034.
+		{[]string{"alpha", "channel1"}, "alpha__channel1"},
+		{[]string{"testnetwork", "channel1", "ns"}, "testnetwork__channel1__ns"},
+		{[]string{"alpha", "mychannel01", "ns2"}, "alpha__mychannel01__ns2"},
+		{[]string{"alpha", "test-channel1.0"}, "alpha__test_dchannel1_f0"},
+		{[]string{"1network", "channel1"}, "1network__channel1"},
+		{[]string{"0", "1", "2"}, "0__1__2"},
 	}
 	for _, c := range cases {
-		require.Equal(t, c.expectedOutput, escapeForTableName(c.input...))
+		got, err := escapeForTableName(c.input...)
+		require.NoError(t, err)
+		require.Equal(t, c.expectedOutput, got)
 	}
 }
 
@@ -36,9 +46,19 @@ func TestEscapeTableNameError(t *testing.T) {
 	cases := [][]string{
 		{"alpha", "testchannel!"},
 		{"alpha", "test-#channel"},
+		{"alpha", "channel 1"},
+		{"alpha", "channel/1"},
+		{"alpha", "channel;drop table x"},
 	}
 	for _, c := range cases {
-		require.Panics(t, func() { escapeForTableName(c...) })
+		// An unsupported character must be reported as an error, never as a
+		// panic: this call chain is reachable from ordinary store construction
+		// and nothing along it recovers.
+		require.NotPanics(t, func() {
+			_, err := escapeForTableName(c...)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "unsupported chars found in table name parameters")
+		})
 	}
 }
 
@@ -191,11 +211,36 @@ func TestTableNameCreator_CreateTableName(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid table name")
 	})
 
-	t.Run("name with numbers is invalid", func(t *testing.T) {
+	t.Run("name with numbers is valid", func(t *testing.T) {
 		t.Parallel()
-		_, err := creator.CreateTableName("test", "users123")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid table name")
+		name, err := creator.CreateTableName("test", "users123")
+		require.NoError(t, err)
+		require.Equal(t, "test_users123", name)
+	})
+
+	// The prefix precedes the name, so the emitted identifier is still legal.
+	t.Run("name starting with a number is valid behind a prefix", func(t *testing.T) {
+		t.Parallel()
+		name, err := creator.CreateTableName("test", "123users")
+		require.NoError(t, err)
+		require.Equal(t, "test_123users", name)
+	})
+
+	// Regression for https://github.com/LFDT-Panurus/panurus/issues/2034: a
+	// channel name containing a digit used to panic.
+	t.Run("params with numbers", func(t *testing.T) {
+		t.Parallel()
+		name, err := creator.CreateTableName("test", "users", "testnetwork", "channel1", "ns")
+		require.NoError(t, err)
+		require.Equal(t, "test_testnetwork__channel1__ns_users", name)
+	})
+
+	t.Run("params with unsupported chars return an error", func(t *testing.T) {
+		t.Parallel()
+		require.NotPanics(t, func() {
+			_, err := creator.CreateTableName("test", "users", "testnetwork", "channel!")
+			require.Error(t, err)
+		})
 	})
 }
 
@@ -290,15 +335,88 @@ func TestTableNameFormatter_Format(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid table name")
 	})
 
-	t.Run("invalid name with number", func(t *testing.T) {
+	t.Run("valid name with number", func(t *testing.T) {
 		t.Parallel()
 		formatter := &tableNameFormatter{
 			prefix: "test_",
 			r:      validName,
 		}
-		_, err := formatter.Format("users123")
+		name, err := formatter.Format("users123")
+		require.NoError(t, err)
+		require.Equal(t, "test_users123", name)
+	})
+
+	// The check is on the identifier that is actually emitted, so a leading digit
+	// is fine behind a prefix and rejected without one.
+	t.Run("name starting with a number is valid behind a prefix", func(t *testing.T) {
+		t.Parallel()
+		formatter := &tableNameFormatter{
+			prefix: "test_",
+			r:      validName,
+		}
+		name, err := formatter.Format("123users")
+		require.NoError(t, err)
+		require.Equal(t, "test_123users", name)
+	})
+
+	t.Run("name starting with a number is invalid without a prefix", func(t *testing.T) {
+		t.Parallel()
+		formatter := &tableNameFormatter{
+			prefix: "",
+			r:      validName,
+		}
+		_, err := formatter.Format("123users")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid table name")
+	})
+
+	// Regression for https://github.com/LFDT-Panurus/panurus/issues/2034.
+	t.Run("params with numbers", func(t *testing.T) {
+		t.Parallel()
+		formatter := &tableNameFormatter{
+			prefix: "test_",
+			r:      validName,
+		}
+		name, err := formatter.Format("users", "testnetwork", "channel1", "ns")
+		require.NoError(t, err)
+		require.Equal(t, "test_testnetwork__channel1__ns_users", name)
+	})
+
+	t.Run("params starting with a number are valid behind a prefix", func(t *testing.T) {
+		t.Parallel()
+		formatter := &tableNameFormatter{
+			prefix: "test_",
+			r:      validName,
+		}
+		name, err := formatter.Format("users", "1network", "channel1")
+		require.NoError(t, err)
+		require.Equal(t, "test_1network__channel1_users", name)
+	})
+
+	t.Run("params starting with a number are rejected without a prefix", func(t *testing.T) {
+		t.Parallel()
+		formatter := &tableNameFormatter{
+			prefix: "",
+			r:      validName,
+		}
+		require.NotPanics(t, func() {
+			_, err := formatter.Format("users", "1network", "channel1")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid table name")
+		})
+	})
+
+	t.Run("params with unsupported chars are rejected without a panic", func(t *testing.T) {
+		t.Parallel()
+		formatter := &tableNameFormatter{
+			prefix: "test_",
+			r:      validName,
+		}
+		require.NotPanics(t, func() {
+			_, err := formatter.Format("users", "testnetwork", "channel!")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "unsupported chars found")
+		})
 	})
 
 	t.Run("empty prefix", func(t *testing.T) {
@@ -363,6 +481,27 @@ func TestTableNameFormatter_FormatWithoutPrefix(t *testing.T) {
 		_, err := formatter.FormatWithoutPrefix("invalid-name")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid table name")
+	})
+
+	// Regression for https://github.com/LFDT-Panurus/panurus/issues/2034.
+	t.Run("params with numbers", func(t *testing.T) {
+		t.Parallel()
+		formatter := &tableNameFormatter{prefix: "test_", r: validName}
+		name, err := formatter.FormatWithoutPrefix("users", "testnetwork", "channel1", "ns")
+		require.NoError(t, err)
+		require.Equal(t, "testnetwork__channel1__ns_users", name)
+	})
+
+	// FormatWithoutPrefix puts the parameter first, so a leading digit would
+	// produce an identifier that is illegal in both SQLite and PostgreSQL.
+	t.Run("params starting with a number are rejected", func(t *testing.T) {
+		t.Parallel()
+		formatter := &tableNameFormatter{prefix: "test_", r: validName}
+		require.NotPanics(t, func() {
+			_, err := formatter.FormatWithoutPrefix("users", "1network")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid table name")
+		})
 	})
 }
 
@@ -429,44 +568,64 @@ func TestEscapeForTableName_EdgeCases(t *testing.T) {
 
 	t.Run("single param", func(t *testing.T) {
 		t.Parallel()
-		result := escapeForTableName("alpha")
+		result, err := escapeForTableName("alpha")
+		require.NoError(t, err)
 		require.Equal(t, "alpha", result)
 	})
 
 	t.Run("param with all special chars", func(t *testing.T) {
 		t.Parallel()
-		result := escapeForTableName("test-channel.param_value")
+		result, err := escapeForTableName("test-channel.param_value")
+		require.NoError(t, err)
 		require.Equal(t, "test_dchannel_fparam__value", result)
 	})
 
 	t.Run("multiple params with special chars", func(t *testing.T) {
 		t.Parallel()
-		result := escapeForTableName("test-channel", "other.param", "value_name")
+		result, err := escapeForTableName("test-channel", "other.param", "value_name")
+		require.NoError(t, err)
 		require.Equal(t, "test_dchannel__other_fparam__value__name", result)
 	})
 
 	t.Run("param with consecutive underscores", func(t *testing.T) {
 		t.Parallel()
-		result := escapeForTableName("test__value")
+		result, err := escapeForTableName("test__value")
+		require.NoError(t, err)
 		require.Equal(t, "test____value", result)
 	})
 
 	t.Run("param with consecutive dashes", func(t *testing.T) {
 		t.Parallel()
-		result := escapeForTableName("test--value")
+		result, err := escapeForTableName("test--value")
+		require.NoError(t, err)
 		require.Equal(t, "test_d_dvalue", result)
 	})
 
 	t.Run("param with consecutive dots", func(t *testing.T) {
 		t.Parallel()
-		result := escapeForTableName("test..value")
+		result, err := escapeForTableName("test..value")
+		require.NoError(t, err)
 		require.Equal(t, "test_f_fvalue", result)
 	})
 
 	t.Run("uppercase letters", func(t *testing.T) {
 		t.Parallel()
-		result := escapeForTableName("TestValue")
+		result, err := escapeForTableName("TestValue")
+		require.NoError(t, err)
 		require.Equal(t, "TestValue", result)
+	})
+
+	// Digits must not be confused with the `_d` / `_f` escape markers, so
+	// escaping stays reversible after digits were allowed through.
+	t.Run("digits do not collide with escape markers", func(t *testing.T) {
+		t.Parallel()
+		distinct := map[string]string{}
+		for _, in := range []string{"a1", "a-1", "a.1", "a_1", "a1d", "a1f", "a_d1", "a-d1"} {
+			got, err := escapeForTableName(in)
+			require.NoError(t, err)
+			require.NotContains(t, distinct, got, "escaping is ambiguous: %q and %q both map to %q", distinct[got], in, got)
+			distinct[got] = in
+		}
 	})
 }
 
@@ -530,6 +689,10 @@ func TestValidNameRegex(t *testing.T) {
 			"a",
 			"A",
 			"_",
+			// Digits are legal anywhere but in first position.
+			"users123",
+			"channel1__ns_users",
+			"_1",
 		}
 		for _, name := range validNames {
 			require.True(t, validName.MatchString(name), "expected %s to be valid", name)
@@ -539,11 +702,11 @@ func TestValidNameRegex(t *testing.T) {
 	t.Run("invalid names", func(t *testing.T) {
 		t.Parallel()
 		invalidNames := []string{
-			"users123",
 			"user-data",
 			"user.data",
 			"user data",
 			"123users",
+			"1",
 			"user@data",
 			"",
 		}

--- a/token/services/storage/db/sql/common/transactions.go
+++ b/token/services/storage/db/sql/common/transactions.go
@@ -94,13 +94,22 @@ func newTransactionStore(
 }
 
 // PrefixedTableName returns the formatted table name for the given logical name.
+// It falls back to the unformatted name if the prefix or the table parameters
+// cannot produce a valid identifier, rather than panicking: the store is already
+// constructed at this point and a crash here would take the node down.
 func (s *TransactionStore) PrefixedTableName(name string) string {
 	nc, err := ncProvider.GetFormatter(s.tablePrefix)
 	if err != nil {
 		return name
 	}
+	formatted, err := nc.Format(name, s.tableParams...)
+	if err != nil {
+		logger.Warnf("failed to format table name [%s]: %v — using it unformatted", name, err)
 
-	return nc.MustFormat(name, s.tableParams...)
+		return name
+	}
+
+	return formatted
 }
 
 func NewAuditTransactionStore(readDB, writeDB *sql.DB, tables TableNames, ci common3.CondInterpreter, pi common3.PagInterpreter) (*TransactionStore, error) {

--- a/token/services/storage/db/sql/sqlite/tablename_test.go
+++ b/token/services/storage/db/sql/sqlite/tablename_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewStoresWithDigitsInTMSID is a regression test for
+// https://github.com/LFDT-Panurus/panurus/issues/2034.
+//
+// The table names are derived from the TMS identity (network, channel,
+// namespace). Digits were missing from the allow-list used while escaping those
+// parameters, and the check panicked instead of returning an error, so building
+// any store for a channel called e.g. "channel1" — an extremely common name —
+// crashed the node. Nothing between here and the escaping function recovers, so
+// this exercises the real driver-construction path (including CREATE TABLE) and
+// not just the escaping helper in isolation.
+func TestNewStoresWithDigitsInTMSID(t *testing.T) {
+	for _, tmsID := range [][]string{
+		{"testnetwork", "channel1", "ns"},
+		{"testnetwork", "testchannel1", "ns"},
+		{"testnetwork", "mychannel01", "ns"},
+		{"network1", "channel1", "namespace1"},
+		{"net0", "ch-1.2", "ns_3"},
+		// A leading digit is fine: the table prefix precedes it.
+		{"1network", "channel1", "ns"},
+	} {
+		t.Run(tmsID[1], func(t *testing.T) {
+			d := NewDriver(sqliteCfg(t.TempDir(), "tsdk"))
+
+			// Every store type goes through the same table-name construction.
+			requireStore(t, "token", func() (driver.TokenStore, error) { return d.NewToken("", tmsID...) })
+			requireStore(t, "tokenlock", func() (driver.TokenLockStore, error) { return d.NewTokenLock("", tmsID...) })
+			requireStore(t, "wallet", func() (driver.WalletStore, error) { return d.NewWallet("", tmsID...) })
+			requireStore(t, "identity", func() (driver.IdentityStore, error) { return d.NewIdentity("", tmsID...) })
+			requireStore(t, "keystore", func() (driver.KeyStore, error) { return d.NewKeyStore("", tmsID...) })
+			requireStore(t, "audittx", func() (driver.AuditTransactionStore, error) { return d.NewAuditTransaction("", tmsID...) })
+			requireStore(t, "ownertx", func() (driver.TokenTransactionStore, error) { return d.NewOwnerTransaction("", tmsID...) })
+			requireStore(t, "endorser", func() (driver.EndorserStore, error) { return d.NewEndorser("", tmsID...) })
+		})
+	}
+}
+
+// requireStore runs newStore as a subtest and requires that it neither panics
+// nor returns an error.
+func requireStore[V any](t *testing.T, name string, newStore func() (V, error)) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		require.NotPanics(t, func() {
+			_, err := newStore()
+			require.NoError(t, err)
+		})
+	})
+}
+
+// TestNewStoreWithUnsupportedCharsInTMSID checks that a TMS identity that cannot
+// be turned into a legal SQL identifier is reported as an error by the driver
+// rather than crashing the process.
+func TestNewStoreWithUnsupportedCharsInTMSID(t *testing.T) {
+	for _, tmsID := range [][]string{
+		{"testnetwork", "channel!", "ns"},
+		{"testnetwork", "channel 1", "ns"},
+		{"testnetwork", "channel;drop table x", "ns"},
+		{"testnetwork", "chann€l", "ns"},
+	} {
+		t.Run(tmsID[1], func(t *testing.T) {
+			d := NewDriver(sqliteCfg(t.TempDir(), "tsdk"))
+			require.NotPanics(t, func() {
+				var store driver.TokenStore
+				store, err := d.NewToken("", tmsID...)
+				require.Error(t, err)
+				require.Nil(t, store)
+			})
+		})
+	}
+}

--- a/token/services/storage/ttxdb/store_test.go
+++ b/token/services/storage/ttxdb/store_test.go
@@ -46,6 +46,35 @@ func TestDB(t *testing.T) {
 	TEndorserAcks(t, db1, db2)
 }
 
+// TestDBWithDigitsInChannelName is a regression test for
+// https://github.com/LFDT-Panurus/panurus/issues/2034: building a store for a
+// TMS whose channel name contains a digit used to panic while deriving the SQL
+// table names, crashing the node instead of returning an error. It goes through
+// the real NewStoreServiceManager path, and nothing along that path recovers.
+func TestDBWithDigitsInChannelName(t *testing.T) {
+	cp, err := config.NewProvider("./testdata/sqlite")
+	require.NoError(t, err)
+
+	manager := ttxdb.NewStoreServiceManager(
+		tms.NewConfigServiceWrapper(config2.NewService(cp)),
+		multiplexed.NewDriver(cp, sqlite.NewNamedDriver(cp, sqlite2.NewDbProvider())),
+	)
+
+	var db *ttxdb.StoreService
+	require.NotPanics(t, func() {
+		db, err = manager.StoreServiceByTMSId(token.TMSID{Network: "mango1", Channel: "channel1", Namespace: "ns2"})
+	})
+	require.NoError(t, err)
+	require.NotNil(t, db)
+
+	// The tables must really exist and be usable, not just be well-named.
+	ctx := t.Context()
+	require.NoError(t, db.AddTransactionEndorsementAck(ctx, "1", []byte("alice"), []byte("sigma")))
+	acks, err := db.GetTransactionEndorsementAcks(ctx, "1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("sigma"), acks[token.Identity("alice").String()])
+}
+
 func TEndorserAcks(t *testing.T, db1, db2 *ttxdb.StoreService) {
 	t.Helper()
 	ctx := t.Context()

--- a/token/services/storage/ttxdb/testdata/sqlite/core.yaml
+++ b/token/services/storage/ttxdb/testdata/sqlite/core.yaml
@@ -22,3 +22,11 @@ token:
       namespace: ns
       ttxdb:
         persistence: token_persistence
+    # A channel name containing a digit is extremely common. See
+    # https://github.com/LFDT-Panurus/panurus/issues/2034.
+    mango1:
+      network: mango1
+      channel: channel1
+      namespace: ns2
+      ttxdb:
+        persistence: token_persistence


### PR DESCRIPTION
Fixes #2034

`escapeForTableName` omitted digits from its character allow-list **and** panicked on anything outside it, while `buildTableNames` formatted through `MustFormat` — so a channel name like `channel1` crashed the node at store-construction time, with no `recover()` anywhere in the chain.

- digits are now accepted, validated against the identifier actually emitted (prefix included);
- unsupported characters return a configuration error instead of panicking.

Regression tests cover the real driver-construction and `NewStoreServiceManager` paths, not just the escaping helper, plus a `FuzzGetTableNamesNoPanic` target wired into the nightly fuzz matrix.