### PR TITLE
fix(network-fabric): propagate ledger info failures instead of rescanning from genesis

### DIFF
--- a/docs/services/network-fabric.md
+++ b/docs/services/network-fabric.md
@@ -294,6 +294,58 @@ sequenceDiagram
 - LRU cache for recent transactions
 - Automatic retry on connection failures
 
+#### Choosing the Starting Block
+
+The scan resumes at the peer's current ledger height, read via `GetLedgerInfo`
+([`delivery.go`](../../token/services/network/fabric/finality/delivery.go)). Because that
+one RPC decides the starting block, a failure is retried with an exponentially growing
+delay — 7 attempts spanning ~31.5s by default, aborting early if the context is cancelled.
+Both are configurable via `token.finality.delivery.ledgerInfoAttempts` and
+`ledgerInfoRetryDelay` (see [Finality Configuration](#finality-configuration)).
+
+That budget is deliberately long. Nothing retries `ScanBlock`: FSC's
+`events.ListenerManager` calls it once from a goroutine that only logs the result, so an
+error escaping the retry loop leaves the channel with **no block-based finality until the
+process restarts**. The retries therefore have to outlast a peer restart, not merely a
+dropped packet.
+
+If the height is still unavailable after the last attempt, `ScanBlock` returns the error
+rather than defaulting to block 0. Starting at genesis would rescan the entire chain and
+replay finality notifications for every historical transaction, while the caller would have
+no way to tell a transient RPC failure from a genuinely fresh chain. Block 0 is used only
+when no ledger is configured at all.
+
+The doubling has a ceiling of 30s, so raising `ledgerInfoAttempts` lengthens the budget
+without letting a single pause grow without bound. A `ledgerInfoRetryDelay` larger than the
+ceiling is honoured as configured — the cap limits growth, it does not shorten the delay you
+asked for. The backoff itself is `utils.RetryRunner`, shared with the rest of the SDK rather
+than reimplemented here.
+
+The returned error is classifiable with `errors.Is`, so a caller does not have to match on
+its message. `ErrLedgerHeightUnavailable` is the single test for "the starting block could
+not be resolved, so no scan started" — it accompanies every such failure, including a
+cancelled one:
+
+| Sentinel | Meaning |
+| --- | --- |
+| `finality.ErrLedgerHeightUnavailable` | the height could not be read, so no scan started |
+| `finality.ErrNoLedgerInfo` | **some** attempt saw the ledger return neither info nor an error — a driver contract violation |
+| `context.Canceled` / `context.DeadlineExceeded` | a wait between attempts was cut short, or the scan itself was cancelled |
+
+Every attempt's failure is reported, so `ErrNoLedgerInfo` is present whenever the contract
+was violated at least once, even intermittently. The context error is not a discriminator on
+its own: the same context governs the scan, so it does not say which phase ended — pair it
+with `ErrLedgerHeightUnavailable` to tell a cancelled height read from a cancelled scan.
+
+The underlying ledger errors are preserved in every case. An error that does not match
+`ErrLedgerHeightUnavailable` comes from the block scan itself rather than from resolving the
+starting block.
+
+There is no in-tree caller that inspects these sentinels yet — today the sole consumer logs
+the error and stops. Classifying the failure is what a future caller needs to react
+(fall back to query-based finality, retry, or restart the manager) rather than a description
+of current behaviour.
+
 ### Notification Mode
 
 Uses asynchronous event notifications from the FSC layer:
@@ -434,7 +486,14 @@ token:
       blockProcessParallelism: 10  # Parallel block processors
       lruSize: 30                  # Cache size for recent transactions
       listenerTimeout: 10s         # Timeout for listener notifications
+      ledgerInfoAttempts: 7        # Attempts at reading the starting ledger height
+      ledgerInfoRetryDelay: 500ms  # First retry pause; doubles each attempt (~31.5s total)
 ```
+
+`ledgerInfoAttempts` and `ledgerInfoRetryDelay` bound the ledger-height read that decides
+where a block scan starts — see [Choosing the Starting Block](#choosing-the-starting-block).
+Non-positive values are ignored in favour of the defaults: zero attempts would refuse every
+scan, and a non-positive delay would busy loop.
 
 ### Endorsement Configuration
 

--- a/token/services/network/fabric/config/config.go
+++ b/token/services/network/fabric/config/config.go
@@ -19,19 +19,35 @@ type ListenerManagerConfig interface {
 	DeliveryListenerTimeout() time.Duration
 	DeliveryLRUSize() int
 	DeliveryLRUBuffer() int
+	DeliveryLedgerInfoAttempts() int
+	DeliveryLedgerInfoRetryDelay() time.Duration
 }
 
 const (
-	DeliveryMapperParallelism              = "token.finality.delivery.mapperParallelism"
-	DeliveryBlockProcessParallelism        = "token.finality.delivery.blockProcessParallelism"
-	DeliveryLRUSize                        = "token.finality.delivery.lruSize"
-	DeliveryLRUBuffer                      = "token.finality.delivery.lruBuffer"
-	DeliveryListenerTimeout                = "token.finality.delivery.listenerTimeout"
+	DeliveryMapperParallelism       = "token.finality.delivery.mapperParallelism"
+	DeliveryBlockProcessParallelism = "token.finality.delivery.blockProcessParallelism"
+	DeliveryLRUSize                 = "token.finality.delivery.lruSize"
+	DeliveryLRUBuffer               = "token.finality.delivery.lruBuffer"
+	DeliveryListenerTimeout         = "token.finality.delivery.listenerTimeout"
+	// DeliveryLedgerInfoAttempts bounds how many times the current ledger height is
+	// read before the block scan is refused. See finality.Delivery.
+	DeliveryLedgerInfoAttempts = "token.finality.delivery.ledgerInfoAttempts"
+	// DeliveryLedgerInfoRetryDelay is the pause before the first retry of that read;
+	// it doubles on each further attempt, up to a ceiling that keeps a large
+	// attempt budget from growing the pause without bound. See finality.Delivery.
+	DeliveryLedgerInfoRetryDelay           = "token.finality.delivery.ledgerInfoRetryDelay"
 	DefaultDeliveryMapperParallelism       = 10
 	DefaultDeliveryBlockProcessParallelism = 10
 	DefaultDeliveryLRUSize                 = 30
 	DefaultDeliveryLRUBuffer               = 15
 	DefaultDeliveryListenerTimeout         = 10 * time.Second
+	// DefaultDeliveryLedgerInfoAttempts and DefaultDeliveryLedgerInfoRetryDelay
+	// span ~31.5s of retries (0.5s + 1s + 2s + 4s + 8s + 16s). The budget has to
+	// outlast a peer restart rather than a dropped packet: nothing retries the
+	// block scan, so a height that stays unreadable costs the channel its
+	// block-based finality until the process restarts.
+	DefaultDeliveryLedgerInfoAttempts   = 7
+	DefaultDeliveryLedgerInfoRetryDelay = 500 * time.Millisecond
 )
 
 type ManagerType string
@@ -88,6 +104,30 @@ func (c *serviceListenerManagerConfig) DeliveryListenerTimeout() time.Duration {
 	return DefaultDeliveryListenerTimeout
 }
 
+func (c *serviceListenerManagerConfig) DeliveryLedgerInfoAttempts() int {
+	if v := c.c.GetInt(DeliveryLedgerInfoAttempts); v > 0 {
+		return v
+	}
+
+	return DefaultDeliveryLedgerInfoAttempts
+}
+
+func (c *serviceListenerManagerConfig) DeliveryLedgerInfoRetryDelay() time.Duration {
+	if v := c.c.GetDuration(DeliveryLedgerInfoRetryDelay); v > 0 {
+		return v
+	}
+
+	return DefaultDeliveryLedgerInfoRetryDelay
+}
+
 func (c *serviceListenerManagerConfig) String() string {
-	return fmt.Sprintf("Delivery [mapperParalellism: %d, lru: (%d, %d), listenerTimeout: %v]", c.DeliveryMapperParallelism(), c.DeliveryLRUSize(), c.DeliveryLRUBuffer(), c.DeliveryListenerTimeout())
+	return fmt.Sprintf(
+		"Delivery [mapperParalellism: %d, lru: (%d, %d), listenerTimeout: %v, ledgerInfo: (%d, %v)]",
+		c.DeliveryMapperParallelism(),
+		c.DeliveryLRUSize(),
+		c.DeliveryLRUBuffer(),
+		c.DeliveryListenerTimeout(),
+		c.DeliveryLedgerInfoAttempts(),
+		c.DeliveryLedgerInfoRetryDelay(),
+	)
 }

--- a/token/services/network/fabric/config/config_test.go
+++ b/token/services/network/fabric/config/config_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// mapConfigService is a driver.ConfigService backed by two maps: whatever the test
+// puts in them is "set", everything else reads as a zero value, which is what an
+// absent YAML key looks like.
+type mapConfigService struct {
+	ints      map[string]int
+	durations map[string]time.Duration
+}
+
+func (c *mapConfigService) GetInt(key string) int                { return c.ints[key] }
+func (c *mapConfigService) GetDuration(key string) time.Duration { return c.durations[key] }
+func (c *mapConfigService) GetString(string) string              { return "" }
+func (c *mapConfigService) GetBool(string) bool                  { return false }
+func (c *mapConfigService) GetStringSlice(string) []string       { return nil }
+func (c *mapConfigService) IsSet(string) bool                    { return false }
+func (c *mapConfigService) UnmarshalKey(string, any) error       { return nil }
+func (c *mapConfigService) ConfigFileUsed() string               { return "" }
+func (c *mapConfigService) GetPath(string) string                { return "" }
+func (c *mapConfigService) TranslatePath(path string) string     { return path }
+
+// TestLedgerInfoRetryDefaults pins the defaults an unconfigured deployment gets.
+// The attempt budget matters beyond taste: nothing retries the block scan, so a
+// height that stays unreadable costs the channel its block-based finality until
+// the process restarts, and the budget has to outlast a peer restart.
+func TestLedgerInfoRetryDefaults(t *testing.T) {
+	c := config.NewListenerManagerConfig(&mapConfigService{})
+
+	assert.Equal(t, config.DefaultDeliveryLedgerInfoAttempts, c.DeliveryLedgerInfoAttempts())
+	assert.Equal(t, config.DefaultDeliveryLedgerInfoRetryDelay, c.DeliveryLedgerInfoRetryDelay())
+	assert.GreaterOrEqual(t, totalRetryWait(c.DeliveryLedgerInfoAttempts(), c.DeliveryLedgerInfoRetryDelay()), 20*time.Second,
+		"the default budget must outlast a peer restart, not just a dropped packet")
+}
+
+// TestLedgerInfoRetryReadsConfiguredValues covers the point of the exercise: an
+// operator can shorten or lengthen the budget without a rebuild.
+func TestLedgerInfoRetryReadsConfiguredValues(t *testing.T) {
+	c := config.NewListenerManagerConfig(&mapConfigService{
+		ints:      map[string]int{config.DeliveryLedgerInfoAttempts: 12},
+		durations: map[string]time.Duration{config.DeliveryLedgerInfoRetryDelay: 250 * time.Millisecond},
+	})
+
+	assert.Equal(t, 12, c.DeliveryLedgerInfoAttempts())
+	assert.Equal(t, 250*time.Millisecond, c.DeliveryLedgerInfoRetryDelay())
+}
+
+// TestLedgerInfoRetryRejectsNonPositiveValues covers the values a hand-edited YAML
+// can hold: 0 attempts would refuse every scan and a negative delay would busy
+// loop, so both fall back to the default rather than being honoured.
+func TestLedgerInfoRetryRejectsNonPositiveValues(t *testing.T) {
+	for _, attempts := range []int{0, -1} {
+		c := config.NewListenerManagerConfig(&mapConfigService{ints: map[string]int{config.DeliveryLedgerInfoAttempts: attempts}})
+		assert.Equal(t, config.DefaultDeliveryLedgerInfoAttempts, c.DeliveryLedgerInfoAttempts(), "attempts %d must not be honoured", attempts)
+	}
+
+	for _, delay := range []time.Duration{0, -time.Second} {
+		c := config.NewListenerManagerConfig(&mapConfigService{durations: map[string]time.Duration{config.DeliveryLedgerInfoRetryDelay: delay}})
+		assert.Equal(t, config.DefaultDeliveryLedgerInfoRetryDelay, c.DeliveryLedgerInfoRetryDelay(), "delay %v must not be honoured", delay)
+	}
+}
+
+// TestStringReportsLedgerInfoBudget keeps the startup log line informative: the
+// budget is otherwise invisible to an operator diagnosing a missing finality.
+func TestStringReportsLedgerInfoBudget(t *testing.T) {
+	s := config.NewListenerManagerConfig(&mapConfigService{}).String()
+
+	assert.Contains(t, s, "ledgerInfo:")
+}
+
+// totalRetryWait sums the doubling schedule ledgerHeight sleeps through: one wait
+// less than the number of attempts, each twice the previous.
+func totalRetryWait(attempts int, first time.Duration) time.Duration {
+	var total time.Duration
+	for i, delay := 0, first; i < attempts-1; i, delay = i+1, delay*2 {
+		total += delay
+	}
+
+	return total
+}

--- a/token/services/network/fabric/finality/delivery.go
+++ b/token/services/network/fabric/finality/delivery.go
@@ -8,27 +8,201 @@ package finality
 
 import (
 	"context"
+	"time"
 
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/token/services/utils"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 )
 
-type Delivery struct {
-	*fabric.Delivery
-	*fabric.Ledger
-	Logger logging.Logger
+const (
+	// defaultLedgerInfoAttempts is how many times ScanBlock asks the ledger for
+	// its current height before giving up. A transient RPC hiccup must not
+	// decide the starting block, so the call is retried rather than trusted once.
+	//
+	// The budget is sized to outlast a peer restart, not just a dropped packet:
+	// nothing retries ScanBlock (see the ledgerHeight comment), so a failure that
+	// escapes here disables block-based finality until the process restarts.
+	defaultLedgerInfoAttempts = 7
+	// defaultLedgerInfoRetryDelay is the pause before the first retry. It doubles
+	// on each further attempt, so the defaults wait ~31.5s in total (0.5s + 1s +
+	// 2s + 4s + 8s + 16s over six retries).
+	defaultLedgerInfoRetryDelay = 500 * time.Millisecond
+	// defaultLedgerInfoMaxRetryDelay caps the doubling. Without a ceiling a large
+	// configured attempt budget grows the pause without bound — past ~35 doublings
+	// of the default delay a single wait exceeds a human lifetime, and the int64
+	// nanosecond duration eventually wraps negative — so the scan would never
+	// resume and never fail either. The cap only limits growth: a configured delay
+	// larger than this is honoured as-is (see ledgerHeight).
+	defaultLedgerInfoMaxRetryDelay = 30 * time.Second
+	// ledgerInfoBackoffMultiplier doubles the delay on each further attempt.
+	ledgerInfoBackoffMultiplier = 2.0
+)
+
+var (
+	// ErrNoLedgerInfo reports that the ledger returned neither info nor an error,
+	// so no height could be read. It signals a driver contract violation rather
+	// than a transient failure: retrying it is not expected to help.
+	ErrNoLedgerInfo = errors.New("ledger returned no info")
+	// ErrLedgerHeightUnavailable reports that the current ledger height could not
+	// be read, so the block scan was refused instead of restarted from genesis.
+	// Every failure to resolve the starting block carries it — whether the attempt
+	// budget ran out or the context ended the retries — so it is the single test
+	// for "no scan started"; an error without it comes from the scan. Every cause
+	// observed along the way remains inspectable with errors.Is.
+	ErrLedgerHeightUnavailable = errors.New("ledger height unavailable")
+)
+
+// blockFromScanner is the subset of fabric.Delivery used by Delivery: the block
+// scan, parameterized by the block to start from.
+type blockFromScanner interface {
+	ScanBlockFrom(ctx context.Context, block uint64, callback fabric.BlockCallback) error
 }
 
+// ledgerHeightProvider is the subset of fabric.Ledger used by Delivery: the
+// current ledger height, which is where a fresh block scan resumes.
+type ledgerHeightProvider interface {
+	GetLedgerInfo() (*fabric.LedgerInfo, error)
+}
+
+// LedgerInfoRetry is the retry budget for the ledger-height read that decides
+// where a block scan starts, as carried from configuration to a Delivery. A zero
+// value selects the defaults.
+type LedgerInfoRetry struct {
+	// Attempts bounds the number of GetLedgerInfo calls.
+	Attempts int
+	// Delay is the pause before the first retry; it doubles on each further
+	// attempt, up to defaultLedgerInfoMaxRetryDelay or Delay itself, whichever is
+	// larger.
+	Delay time.Duration
+}
+
+type Delivery struct {
+	Delivery blockFromScanner
+	Ledger   ledgerHeightProvider
+	Logger   logging.Logger
+
+	// LedgerInfoAttempts bounds the number of GetLedgerInfo attempts made by
+	// ScanBlock. Zero or negative selects defaultLedgerInfoAttempts.
+	LedgerInfoAttempts int
+	// LedgerInfoRetryDelay is the pause before the first GetLedgerInfo retry; it
+	// doubles on each further attempt, bounded as described on
+	// defaultLedgerInfoMaxRetryDelay. Zero or negative selects
+	// defaultLedgerInfoRetryDelay.
+	LedgerInfoRetryDelay time.Duration
+}
+
+// ScanBlock scans blocks starting from the current ledger height.
+//
+// The height is read from the ledger, retried a bounded number of times so a
+// transient RPC failure does not decide where the scan starts. If the height
+// remains unavailable, the error is returned instead of falling back to block 0:
+// on a chain with history that fallback silently turns a passing RPC hiccup into
+// a full rescan from genesis, with duplicate finality notifications and no error
+// for the caller to distinguish it from a genuinely fresh chain.
+//
+// A nil Ledger is the one case that still starts at block 0 — there is no height
+// to read, so the whole chain is the intended range.
+//
+// The returned error is classifiable without inspecting its message. Every
+// failure to resolve the starting block matches ErrLedgerHeightUnavailable, and
+// no scan has started in that case; an error that does not match it came from the
+// scan. Two further sentinels refine the height failure:
+//
+//   - ErrNoLedgerInfo, when some attempt saw a ledger return neither info nor an
+//     error. Every attempt's failure is reported, so this is present whenever the
+//     contract was violated at least once, even intermittently.
+//   - context.Canceled or context.DeadlineExceeded, when the context ended the
+//     retries. This one is not a discriminator on its own: the same context
+//     governs the scan, so a context error alone does not say which of the two
+//     ended. Pair it with ErrLedgerHeightUnavailable to tell a cancelled height
+//     read from a cancelled scan.
 func (d *Delivery) ScanBlock(background context.Context, callback fabric.BlockCallback) error {
 	startingBlock := uint64(0)
 	if d.Ledger != nil {
-		info, err := d.GetLedgerInfo()
-		if err == nil {
-			startingBlock = info.Height
-		} else {
-			d.Logger.ErrorfContext(background, "failed to get ledger info: %s", err)
+		height, err := d.ledgerHeight(background)
+		if err != nil {
+			return err
 		}
+		startingBlock = height
 	}
 
-	return d.ScanBlockFrom(background, startingBlock, callback)
+	return d.Delivery.ScanBlockFrom(background, startingBlock, callback)
+}
+
+// ledgerHeight returns the current ledger height, retrying transient failures
+// with an exponentially growing but capped delay. It gives up as soon as the
+// context is cancelled, and reports every observed failure once the attempts run
+// out.
+//
+// The budget is generous because nothing retries the caller: FSC's
+// events.ListenerManager calls ScanBlock once from a goroutine that only logs the
+// result, so an error escaping here leaves the channel without block-based
+// finality until the process restarts. Absorbing a peer restart here is therefore
+// worth more than failing fast.
+//
+// The backoff is delegated to utils.RetryRunner rather than hand-rolled, so the
+// growth is bounded by its maximum delay instead of doubling indefinitely. The
+// cap is raised to the configured delay when that is larger, so it limits growth
+// without silently shortening a pause an operator asked for.
+//
+// Failures are joined with a sentinel rather than described only in the message,
+// so callers classify them with errors.Is: ErrLedgerHeightUnavailable on both
+// exits, additionally ErrNoLedgerInfo for a driver returning (nil, nil) and the
+// context error for a cancelled wait. The underlying ledger errors are preserved
+// in every case.
+func (d *Delivery) ledgerHeight(ctx context.Context) (uint64, error) {
+	attempts := d.LedgerInfoAttempts
+	if attempts <= 0 {
+		attempts = defaultLedgerInfoAttempts
+	}
+	delay := d.LedgerInfoRetryDelay
+	if delay <= 0 {
+		delay = defaultLedgerInfoRetryDelay
+	}
+	maxDelay := max(defaultLedgerInfoMaxRetryDelay, delay)
+
+	var (
+		height   uint64
+		failures []error
+		attempt  int
+	)
+	runner := utils.NewRetryRunnerWithJitter(d.Logger, attempts, delay, maxDelay, ledgerInfoBackoffMultiplier, 0)
+	err := runner.RunWithErrorsContext(ctx, func() (bool, error) {
+		attempt++
+		info, err := d.Ledger.GetLedgerInfo()
+		switch {
+		case err != nil:
+			failures = append(failures, err)
+		case info == nil:
+			// A driver that reports neither info nor error would otherwise nil
+			// deref below; treat it as a failure to read the height.
+			failures = append(failures, ErrNoLedgerInfo)
+		default:
+			height = info.Height
+
+			return true, nil
+		}
+
+		lastErr := failures[len(failures)-1]
+		d.Logger.ErrorfContext(ctx, "failed to get ledger info (attempt %d/%d): %s", attempt, attempts, lastErr)
+
+		// Terminate on the last attempt instead of letting the runner exhaust its
+		// budget: it sleeps at the end of every iteration, so falling out of the
+		// loop would add one final pause that no further attempt follows.
+		return attempt == attempts, lastErr
+	})
+	if err == nil {
+		return height, nil
+	}
+
+	// ctx.Err() is nil unless the retries were cancelled, and Join drops nils, so
+	// the same causes serve both exits.
+	causes := errors.Join(append([]error{ErrLedgerHeightUnavailable, ctx.Err()}, failures...)...)
+	if ctx.Err() != nil {
+		return 0, errors.Wrapf(causes, "cancelled while getting ledger info after %d attempt(s)", attempt)
+	}
+
+	return 0, errors.Wrapf(causes, "failed to get ledger info after %d attempt(s), refusing to rescan from genesis", attempts)
 }

--- a/token/services/network/fabric/finality/delivery_test.go
+++ b/token/services/network/fabric/finality/delivery_test.go
@@ -1,0 +1,325 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package finality_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/finality"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// heightLedgerResult is one scripted GetLedgerInfo outcome.
+type heightLedgerResult struct {
+	info *fabric.LedgerInfo
+	err  error
+}
+
+// fakeHeightLedger returns scripted GetLedgerInfo results, replaying the last
+// one once the script is exhausted, and counts how often it was called.
+type fakeHeightLedger struct {
+	results []heightLedgerResult
+	calls   atomic.Int32
+	// onCall, when set, runs after the nth call has been counted. It lets a test
+	// cancel the context from inside an attempt, which is the only way to observe
+	// a cancellation that interrupts the retry wait rather than one that precedes
+	// the first attempt.
+	onCall func(n int)
+}
+
+func (l *fakeHeightLedger) GetLedgerInfo() (*fabric.LedgerInfo, error) {
+	n := int(l.calls.Add(1))
+	r := l.results[min(n, len(l.results))-1]
+	if l.onCall != nil {
+		l.onCall(n)
+	}
+
+	return r.info, r.err
+}
+
+// recordingBlockDelivery records the block ScanBlockFrom was asked to start
+// from, and whether it was called at all — the observable difference between
+// "resumed at the current height", "rescanned from genesis", and "did not scan".
+type recordingBlockDelivery struct {
+	called        bool
+	startingBlock uint64
+	callback      fabric.BlockCallback
+	err           error
+}
+
+func (d *recordingBlockDelivery) ScanBlockFrom(_ context.Context, block uint64, callback fabric.BlockCallback) error {
+	d.called = true
+	d.startingBlock = block
+	d.callback = callback
+
+	return d.err
+}
+
+// newTestDelivery builds a Delivery over the two fakes, with a retry delay short
+// enough to keep the tests fast.
+func newTestDelivery(l *fakeHeightLedger, d *recordingBlockDelivery) *finality.Delivery {
+	return &finality.Delivery{
+		Delivery:             d,
+		Ledger:               l,
+		Logger:               logging.MustGetLogger(),
+		LedgerInfoRetryDelay: time.Millisecond,
+	}
+}
+
+// TestScanBlock_StartsFromCurrentLedgerHeight covers the happy path: the scan
+// resumes at the height reported by the ledger, with the caller's callback
+// passed through untouched.
+func TestScanBlock_StartsFromCurrentLedgerHeight(t *testing.T) {
+	ledger := &fakeHeightLedger{results: []heightLedgerResult{{info: &fabric.LedgerInfo{Height: 42}}}}
+	delivery := &recordingBlockDelivery{}
+
+	callbackInvoked := false
+	callback := func(context.Context, *common.Block) (bool, error) {
+		callbackInvoked = true
+
+		return false, nil
+	}
+
+	require.NoError(t, newTestDelivery(ledger, delivery).ScanBlock(context.Background(), callback))
+
+	assert.True(t, delivery.called)
+	assert.Equal(t, uint64(42), delivery.startingBlock)
+	assert.Equal(t, int32(1), ledger.calls.Load(), "a successful GetLedgerInfo must not be retried")
+
+	require.NotNil(t, delivery.callback)
+	_, err := delivery.callback(context.Background(), nil)
+	require.NoError(t, err)
+	assert.True(t, callbackInvoked, "the caller's callback must be the one handed to ScanBlockFrom")
+}
+
+// TestScanBlock_PropagatesLedgerInfoErrorInsteadOfRescanningFromGenesis is the
+// regression test for issue #2058: a persistent GetLedgerInfo failure used to be
+// logged and swallowed, leaving startingBlock at 0 and silently triggering a full
+// rescan from genesis. The error must now reach the caller, and no scan must start.
+func TestScanBlock_PropagatesLedgerInfoErrorInsteadOfRescanningFromGenesis(t *testing.T) {
+	transient := errors.New("peer connection reset")
+	ledger := &fakeHeightLedger{results: []heightLedgerResult{{err: transient}}}
+	delivery := &recordingBlockDelivery{}
+
+	err := newTestDelivery(ledger, delivery).ScanBlock(context.Background(), nil)
+
+	require.Error(t, err, "GetLedgerInfo failure must be propagated, not swallowed after a log line")
+	require.ErrorIs(t, err, transient, "the underlying ledger error must stay inspectable")
+	require.ErrorIs(t, err, finality.ErrLedgerHeightUnavailable, "the caller must classify this without matching on the message")
+	require.NotErrorIs(t, err, finality.ErrNoLedgerInfo, "an unreachable peer is not a driver returning no info")
+	assert.False(t, delivery.called, "no scan may start from genesis when the ledger height is unknown")
+}
+
+// TestScanBlock_RetriesTransientLedgerInfoFailure verifies the transient case the
+// issue describes — an ordinary RPC hiccup — is absorbed by a retry and resumes at
+// the real height, rather than either failing or rescanning from block 0.
+func TestScanBlock_RetriesTransientLedgerInfoFailure(t *testing.T) {
+	ledger := &fakeHeightLedger{results: []heightLedgerResult{
+		{err: errors.New("peer connection reset")},
+		{info: &fabric.LedgerInfo{Height: 7}},
+	}}
+	delivery := &recordingBlockDelivery{}
+
+	require.NoError(t, newTestDelivery(ledger, delivery).ScanBlock(context.Background(), nil))
+
+	assert.Equal(t, int32(2), ledger.calls.Load())
+	assert.True(t, delivery.called)
+	assert.Equal(t, uint64(7), delivery.startingBlock, "must resume at the height read on the retry, not at genesis")
+}
+
+// TestScanBlock_RetriesAreBounded verifies the retry loop honours the configured
+// attempt budget instead of spinning on a permanently failing ledger.
+func TestScanBlock_RetriesAreBounded(t *testing.T) {
+	ledger := &fakeHeightLedger{results: []heightLedgerResult{{err: errors.New("peer connection reset")}}}
+	delivery := &recordingBlockDelivery{}
+
+	d := newTestDelivery(ledger, delivery)
+	d.LedgerInfoAttempts = 5
+
+	require.Error(t, d.ScanBlock(context.Background(), nil))
+	assert.Equal(t, int32(5), ledger.calls.Load())
+	assert.False(t, delivery.called)
+}
+
+// TestScanBlock_NilLedgerInfoIsReportedNotDereferenced covers a driver that
+// reports neither info nor error: that used to be a nil dereference waiting on
+// info.Height, and must instead surface as an error.
+func TestScanBlock_NilLedgerInfoIsReportedNotDereferenced(t *testing.T) {
+	ledger := &fakeHeightLedger{results: []heightLedgerResult{{}}}
+	delivery := &recordingBlockDelivery{}
+
+	err := newTestDelivery(ledger, delivery).ScanBlock(context.Background(), nil)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, finality.ErrNoLedgerInfo, "the (nil, nil) contract violation must be identifiable, not just described")
+	require.ErrorIs(t, err, finality.ErrLedgerHeightUnavailable, "it is also a failure to read the height")
+	require.NotErrorIs(t, err, context.Canceled, "a nil-info driver is not a cancellation")
+	assert.False(t, delivery.called)
+}
+
+// TestScanBlock_CancelledContextStopsRetrying verifies shutdown does not have to
+// wait out the retry budget: a cancelled context ends the loop with its own error.
+func TestScanBlock_CancelledContextStopsRetrying(t *testing.T) {
+	transient := errors.New("peer connection reset")
+	ledger := &fakeHeightLedger{results: []heightLedgerResult{{err: transient}}}
+	delivery := &recordingBlockDelivery{}
+
+	d := newTestDelivery(ledger, delivery)
+	d.LedgerInfoAttempts = 100
+	d.LedgerInfoRetryDelay = time.Hour // only cancellation can end this loop in time
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancelled from inside the first attempt, so the cancellation lands on the
+	// retry wait: a context cancelled beforehand would return before any attempt
+	// ran, leaving no ledger failure to report alongside it.
+	ledger.onCall = func(int) { cancel() }
+
+	done := make(chan error, 1)
+	go func() { done <- d.ScanBlock(ctx, nil) }()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+		require.ErrorIs(t, err, transient, "the failure that was being retried must stay inspectable alongside the cancellation")
+		require.ErrorIs(t, err, finality.ErrLedgerHeightUnavailable,
+			"cancellation is still a failure to resolve the starting block: ErrLedgerHeightUnavailable is the single test for \"no scan started\"")
+		assert.Equal(t, int32(1), ledger.calls.Load(), "must not keep retrying after cancellation")
+		assert.False(t, delivery.called)
+	case <-time.After(10 * time.Second):
+		t.Fatal("ScanBlock kept retrying after its context was cancelled")
+	}
+}
+
+// TestScanBlock_CancellationDuringNilInfoKeepsBothSentinels pins the corner where
+// the two refining sentinels coincide: a (nil, nil) driver whose retry wait is
+// then cancelled. ErrNoLedgerInfo must survive alongside the context error, and
+// ErrLedgerHeightUnavailable must still be present — documentation states it
+// accompanies every height failure, so this path may not be the exception.
+func TestScanBlock_CancellationDuringNilInfoKeepsBothSentinels(t *testing.T) {
+	ledger := &fakeHeightLedger{results: []heightLedgerResult{{}}}
+	delivery := &recordingBlockDelivery{}
+
+	d := newTestDelivery(ledger, delivery)
+	d.LedgerInfoAttempts = 100
+	d.LedgerInfoRetryDelay = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ledger.onCall = func(int) { cancel() }
+
+	done := make(chan error, 1)
+	go func() { done <- d.ScanBlock(ctx, nil) }()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+		require.ErrorIs(t, err, finality.ErrNoLedgerInfo, "the contract violation being retried must stay inspectable")
+		require.ErrorIs(t, err, finality.ErrLedgerHeightUnavailable)
+		assert.False(t, delivery.called)
+	case <-time.After(10 * time.Second):
+		t.Fatal("ScanBlock kept retrying after its context was cancelled")
+	}
+}
+
+// TestScanBlock_EveryObservedFailureIsClassified pins the reach of the refining
+// sentinels: failures accumulate across attempts, so an earlier (nil, nil) stays
+// inspectable even when a later attempt fails differently. The contract is "any
+// attempt", not "the last one".
+func TestScanBlock_EveryObservedFailureIsClassified(t *testing.T) {
+	transient := errors.New("peer connection reset")
+	ledger := &fakeHeightLedger{results: []heightLedgerResult{{}, {err: transient}}}
+	delivery := &recordingBlockDelivery{}
+
+	d := newTestDelivery(ledger, delivery)
+	d.LedgerInfoAttempts = 2
+
+	err := d.ScanBlock(context.Background(), nil)
+
+	require.ErrorIs(t, err, finality.ErrLedgerHeightUnavailable)
+	require.ErrorIs(t, err, transient, "the last attempt's failure must be inspectable")
+	require.ErrorIs(t, err, finality.ErrNoLedgerInfo,
+		"an earlier contract violation must not be dropped just because a later attempt failed differently")
+	assert.False(t, delivery.called)
+}
+
+// TestScanBlock_ContextCancelledBeforeFirstAttempt covers shutdown racing the
+// start of a scan: the height read is abandoned without touching the ledger, and
+// the failure still classifies as "no scan started" so the caller does not have
+// to special-case it.
+func TestScanBlock_ContextCancelledBeforeFirstAttempt(t *testing.T) {
+	ledger := &fakeHeightLedger{results: []heightLedgerResult{{info: &fabric.LedgerInfo{Height: 9}}}}
+	delivery := &recordingBlockDelivery{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := newTestDelivery(ledger, delivery).ScanBlock(ctx, nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, finality.ErrLedgerHeightUnavailable)
+	assert.Equal(t, int32(0), ledger.calls.Load(), "an already-cancelled context must not cost an RPC")
+	assert.False(t, delivery.called)
+}
+
+// TestScanBlock_DefaultAttemptBudgetOutlastsAPeerRestart guards the sizing
+// decision: nothing retries ScanBlock, so a single transient failure must not
+// disable block-based finality, and the default budget has to cover a peer
+// restart rather than just a dropped packet. Only the attempt count is asserted —
+// the real delay would make this test sleep for the whole ~31.5s schedule, so it
+// is overridden and the schedule itself is pinned by the const comments.
+func TestScanBlock_DefaultAttemptBudgetOutlastsAPeerRestart(t *testing.T) {
+	const minimumAttempts = 7
+
+	ledger := &fakeHeightLedger{results: []heightLedgerResult{{err: errors.New("peer connection reset")}}}
+	delivery := &recordingBlockDelivery{}
+
+	// LedgerInfoAttempts left unset so the default applies.
+	d := &finality.Delivery{
+		Delivery:             delivery,
+		Ledger:               ledger,
+		Logger:               logging.MustGetLogger(),
+		LedgerInfoRetryDelay: time.Millisecond,
+	}
+
+	require.Error(t, d.ScanBlock(context.Background(), nil))
+	assert.GreaterOrEqual(t, int(ledger.calls.Load()), minimumAttempts,
+		"the default attempt budget must absorb a peer restart: nothing retries ScanBlock, so a failure here is terminal")
+	assert.False(t, delivery.called)
+}
+
+// TestScanBlock_NilLedgerScansFromGenesis pins the one remaining path that
+// legitimately starts at block 0: no ledger is configured, so there is no height
+// to resume from and the whole chain is the intended range.
+func TestScanBlock_NilLedgerScansFromGenesis(t *testing.T) {
+	delivery := &recordingBlockDelivery{}
+	d := &finality.Delivery{Delivery: delivery, Logger: logging.MustGetLogger()}
+
+	require.NoError(t, d.ScanBlock(context.Background(), nil))
+	assert.True(t, delivery.called)
+	assert.Equal(t, uint64(0), delivery.startingBlock)
+}
+
+// TestScanBlock_PropagatesScanError verifies the scan's own error is returned
+// unchanged once the starting block has been resolved.
+func TestScanBlock_PropagatesScanError(t *testing.T) {
+	scanErr := errors.New("delivery stream broken")
+	ledger := &fakeHeightLedger{results: []heightLedgerResult{{info: &fabric.LedgerInfo{Height: 3}}}}
+	delivery := &recordingBlockDelivery{err: scanErr}
+
+	err := newTestDelivery(ledger, delivery).ScanBlock(context.Background(), nil)
+
+	require.ErrorIs(t, err, scanErr)
+	require.NotErrorIs(t, err, finality.ErrLedgerHeightUnavailable, "a scan failure must not be mistaken for a failure to read the height")
+	assert.Equal(t, uint64(3), delivery.startingBlock)
+}

--- a/token/services/network/fabric/finality/deliveryflm.go
+++ b/token/services/network/fabric/finality/deliveryflm.go
@@ -103,28 +103,52 @@ func (i TxInfo) ID() driver2.TxID {
 }
 
 type deliveryBasedFLMProvider struct {
-	fnsp           *fabric.NetworkServiceProvider
-	tracerProvider trace.TracerProvider
-	config         events.DeliveryListenerManagerConfig
-	newMapper      newTxInfoMapper
+	fnsp            *fabric.NetworkServiceProvider
+	tracerProvider  trace.TracerProvider
+	config          events.DeliveryListenerManagerConfig
+	newMapper       newTxInfoMapper
+	ledgerInfoRetry LedgerInfoRetry
 }
 
-func NewDeliveryBasedFLMProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, config events.DeliveryListenerManagerConfig, newMapper newTxInfoMapper) *deliveryBasedFLMProvider {
-	return &deliveryBasedFLMProvider{
+// FLMProviderOption customizes a delivery-based finality listener manager provider.
+type FLMProviderOption func(*deliveryBasedFLMProvider)
+
+// WithLedgerInfoRetry sets the retry budget each manager applies to the
+// ledger-height read that decides where its block scan starts. Zero fields select
+// the Delivery defaults.
+func WithLedgerInfoRetry(retry LedgerInfoRetry) FLMProviderOption {
+	return func(p *deliveryBasedFLMProvider) {
+		p.ledgerInfoRetry = retry
+	}
+}
+
+func NewDeliveryBasedFLMProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, config events.DeliveryListenerManagerConfig, newMapper newTxInfoMapper, opts ...FLMProviderOption) *deliveryBasedFLMProvider {
+	p := &deliveryBasedFLMProvider{
 		fnsp:           fnsp,
 		tracerProvider: tracerProvider,
 		config:         config,
 		newMapper:      newMapper,
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
 }
 
-func newEndorserDeliveryBasedFLMProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, keyTranslator translator.KeyTranslator, config events.DeliveryListenerManagerConfig) *deliveryBasedFLMProvider {
+func newEndorserDeliveryBasedFLMProvider(
+	fnsp *fabric.NetworkServiceProvider,
+	tracerProvider trace.TracerProvider,
+	keyTranslator translator.KeyTranslator,
+	config events.DeliveryListenerManagerConfig,
+	opts ...FLMProviderOption,
+) *deliveryBasedFLMProvider {
 	return NewDeliveryBasedFLMProvider(fnsp, tracerProvider, config, func(network, _ string) events.EventInfoMapper[TxInfo] {
 		return &EndorserTxInfoMapper{
 			Network:       network,
 			KeyTranslator: keyTranslator,
 		}
-	})
+	}, opts...)
 }
 
 func (p *deliveryBasedFLMProvider) NewManager(network, channel string) (ListenerManager, error) {
@@ -142,9 +166,11 @@ func (p *deliveryBasedFLMProvider) NewManager(network, channel string) (Listener
 		logger,
 		p.config,
 		&Delivery{
-			Delivery: ch.Delivery(),
-			Ledger:   ch.Ledger(),
-			Logger:   logger,
+			Delivery:             ch.Delivery(),
+			Ledger:               ch.Ledger(),
+			Logger:               logger,
+			LedgerInfoAttempts:   p.ledgerInfoRetry.Attempts,
+			LedgerInfoRetryDelay: p.ledgerInfoRetry.Delay,
 		},
 		&DeliveryScanQueryByID{
 			Delivery: ch.Delivery(),

--- a/token/services/network/fabric/finality/manager.go
+++ b/token/services/network/fabric/finality/manager.go
@@ -31,5 +31,8 @@ func NewListenerManagerProvider(fnsp *fabric.NetworkServiceProvider, tracerProvi
 		ListenerTimeout:         lmConfig.DeliveryListenerTimeout(),
 		LRUSize:                 lmConfig.DeliveryLRUSize(),
 		LRUBuffer:               lmConfig.DeliveryLRUBuffer(),
-	})
+	}, WithLedgerInfoRetry(LedgerInfoRetry{
+		Attempts: lmConfig.DeliveryLedgerInfoAttempts(),
+		Delay:    lmConfig.DeliveryLedgerInfoRetryDelay(),
+	}))
 }

--- a/token/services/network/fabric/lookup/deliveryllm.go
+++ b/token/services/network/fabric/lookup/deliveryllm.go
@@ -76,22 +76,46 @@ func (i KeyInfo) ID() driver2.PKey {
 }
 
 type deliveryBasedLLMProvider struct {
-	fnsp           *fabric.NetworkServiceProvider
-	tracerProvider trace.TracerProvider
-	config         events.DeliveryListenerManagerConfig
-	newMapper      newTxInfoMapper
+	fnsp            *fabric.NetworkServiceProvider
+	tracerProvider  trace.TracerProvider
+	config          events.DeliveryListenerManagerConfig
+	newMapper       newTxInfoMapper
+	ledgerInfoRetry finality2.LedgerInfoRetry
 }
 
-func NewDeliveryBasedLLMProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, config events.DeliveryListenerManagerConfig, newMapper newTxInfoMapper) *deliveryBasedLLMProvider {
-	return &deliveryBasedLLMProvider{
+// LLMProviderOption customizes a delivery-based lookup listener manager provider.
+type LLMProviderOption func(*deliveryBasedLLMProvider)
+
+// WithLedgerInfoRetry sets the retry budget each manager applies to the
+// ledger-height read that decides where its block scan starts. Zero fields select
+// the finality.Delivery defaults.
+func WithLedgerInfoRetry(retry finality2.LedgerInfoRetry) LLMProviderOption {
+	return func(p *deliveryBasedLLMProvider) {
+		p.ledgerInfoRetry = retry
+	}
+}
+
+func NewDeliveryBasedLLMProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, config events.DeliveryListenerManagerConfig, newMapper newTxInfoMapper, opts ...LLMProviderOption) *deliveryBasedLLMProvider {
+	p := &deliveryBasedLLMProvider{
 		fnsp:           fnsp,
 		tracerProvider: tracerProvider,
 		config:         config,
 		newMapper:      newMapper,
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
 }
 
-func newEndorserDeliveryBasedLLMProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, keyTranslator translator.KeyTranslator, config events.DeliveryListenerManagerConfig) *deliveryBasedLLMProvider {
+func newEndorserDeliveryBasedLLMProvider(
+	fnsp *fabric.NetworkServiceProvider,
+	tracerProvider trace.TracerProvider,
+	keyTranslator translator.KeyTranslator,
+	config events.DeliveryListenerManagerConfig,
+	opts ...LLMProviderOption,
+) *deliveryBasedLLMProvider {
 	prefix, err := keyTranslator.TransferActionMetadataKeyPrefix()
 	if err != nil {
 		panic(err)
@@ -106,7 +130,7 @@ func newEndorserDeliveryBasedLLMProvider(fnsp *fabric.NetworkServiceProvider, tr
 			network:  network,
 			prefixes: []string{prefix, setupKey},
 		}
-	})
+	}, opts...)
 }
 
 func (p *deliveryBasedLLMProvider) NewManager(network, channel string) (ListenerManager, error) {
@@ -123,9 +147,11 @@ func (p *deliveryBasedLLMProvider) NewManager(network, channel string) (Listener
 		logger,
 		p.config,
 		&finality2.Delivery{
-			Delivery: ch.Delivery(),
-			Ledger:   ch.Ledger(),
-			Logger:   logger,
+			Delivery:             ch.Delivery(),
+			Ledger:               ch.Ledger(),
+			Logger:               logger,
+			LedgerInfoAttempts:   p.ledgerInfoRetry.Attempts,
+			LedgerInfoRetryDelay: p.ledgerInfoRetry.Delay,
 		},
 		&DeliveryScanQueryByID{
 			Delivery: ch.Delivery(),

--- a/token/services/network/fabric/lookup/manager.go
+++ b/token/services/network/fabric/lookup/manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	"github.com/LFDT-Panurus/panurus/token/services/network/common/rws/translator"
 	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/config"
+	finality2 "github.com/LFDT-Panurus/panurus/token/services/network/fabric/finality"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/events"
 	"go.opentelemetry.io/otel/trace"
@@ -35,5 +36,8 @@ func NewListenerManagerProvider(fnsp *fabric.NetworkServiceProvider, tracerProvi
 		ListenerTimeout:         lmConfig.DeliveryListenerTimeout(),
 		LRUSize:                 lmConfig.DeliveryLRUSize(),
 		LRUBuffer:               lmConfig.DeliveryLRUBuffer(),
-	})
+	}, WithLedgerInfoRetry(finality2.LedgerInfoRetry{
+		Attempts: lmConfig.DeliveryLedgerInfoAttempts(),
+		Delay:    lmConfig.DeliveryLedgerInfoRetryDelay(),
+	}))
 }


### PR DESCRIPTION
Fixes #2058

## The issue

`ScanBlock` asks the peer for the current ledger height to know where to resume the block scan. If that call failed, the error was only logged and the height stayed 0, so the scan silently restarted from genesis — rescanning the whole chain and replaying finality notifications for every past transaction, with no error for the caller.

## The fix

Retry the height lookup a few times, and if it still fails return the error instead of starting from block 0. A passing RPC hiccup is absorbed by the retry; a real outage is reported.

## Before

```
ScanBlock(callback):
    start = 0
    if ledger exists:
        info, err = GetLedgerInfo()
        if err == nil: start = info.Height
        else:          log(err)          # error dropped, start stays 0
    return ScanBlockFrom(start, callback)
```

One failed RPC → scan restarts from genesis, caller sees no error.

## After

```
ScanBlock(callback):
    start = 0
    if ledger exists:
        start, err = LedgerHeight()
        if err != nil: return err        # no scan at all
    return ScanBlockFrom(start, callback)

LedgerHeight():
    delay = LedgerInfoRetryDelay        # default 500ms
    for attempt = 1 .. LedgerInfoAttempts:   # default 7
        info, err = GetLedgerInfo()
        if err == nil and info != nil:
            return info.Height           # done
        log(err)
        if attempt == last: break
        wait delay or return if context cancelled
        delay = delay * 2
    return error "refusing to rescan from genesis"
```

## What an attempt does

One attempt is one `GetLedgerInfo` RPC to the peer:

1. If it returns a height, use it and start the scan there. Height is the next block to be delivered, so nothing is replayed.
2. If it returns an error — or `(nil, nil)`, which used to nil-deref — remember the error and log it as `attempt N/M`.
3. On the last attempt, stop looping. Otherwise wait `delay`, then double it. A cancelled context ends the wait immediately and returns.

Defaults: 7 attempts, 0.5s + 1s + 2s + 4s + 8s + 16s of waiting, ~31.5s worst case. Both bounds are configurable — see below.

## If every attempt fails

- The error is returned, wrapping the last ledger error so `errors.Is` still reaches it: `failed to get ledger info after 7 attempt(s), refusing to rescan from genesis`.
- `ScanBlockFrom` is never called — no scan, so no genesis rescan and no duplicate finality notifications.
- The caller, FSC's `ListenerManager.start()`, logs the error, so block-delivery finality does not start for that manager. Finality is degraded, not lost: timed-out listeners are queried directly against the ledger (`QueryByID` → `fetchTxs`), and the recovery service re-registers listeners for pending transactions.
- Not a regression: if the peer cannot answer `GetLedgerInfo` across ~31.5s of retries, the `ScanBlockFrom` stream to that same peer would have failed too. The old code just failed later, after starting a full-chain rescan.

Block 0 is still used in one case only: no ledger configured at all.

## Notes

- Retry, not just propagate: `ListenerManager.start()` calls `ScanBlock` once and only logs the error, so returning on the first hiccup would leave block-based finality dead until the process restarts. That is also why the budget has to outlast a peer restart rather than a dropped packet.
- `*fabric.Delivery` / `*fabric.Ledger` replaced by two small interfaces so the code is unit-testable. Field names unchanged, wiring untouched.

## Tests

`delivery_test.go`, 11 cases: height resumption, error propagated with no scan started, transient failure retried, attempt budget honoured, nil info, cancelled context, nil ledger → block 0, scan error propagated, plus the cancellation/nil-info sentinel overlap, last-failure-only classification, and the default attempt budget.

`config/config_test.go`, 4 cases (the package had none): defaults, configured values, non-positive rejection, and the budget appearing in `String()`.

Against the old code 4 fail and one panics. All pass with the fix under `-count=2 -race`; `gofmt`, `go vet`, `golangci-lint`, `go build ./...` clean.

## Configurable retry budget

The 7-attempt default is a judgement call, not a measurement: it is the smallest count on the existing doubling schedule that clears ~30s, chosen as a rough proxy for how long a peer restart takes. How long a peer actually takes to come back is a deployment property, so both bounds are exposed alongside the five existing `token.finality.delivery.*` settings rather than baked in:

```yaml
token:
  finality:
    delivery:
      ledgerInfoAttempts: 7        # attempts at reading the starting height
      ledgerInfoRetryDelay: 500ms  # first retry pause; doubles each attempt
```

Non-positive values fall back to the defaults: zero attempts would refuse every scan, and a non-positive delay would busy loop.

`lookup` is wired too, not just `finality` — it constructs the same `Delivery`, so leaving it out would have silently kept the old budget for lookup listeners. The exported provider constructors (`NewDeliveryBasedFLMProvider`, `NewDeliveryBasedLLMProvider`) take the values through a variadic option, so their existing signatures stay source-compatible for downstream callers.

## Error classification

Failures are classifiable with `errors.Is`, so a caller never has to match on message text:

| Sentinel | Meaning |
| --- | --- |
| `ErrLedgerHeightUnavailable` | the starting block could not be resolved, so no scan started |
| `ErrNoLedgerInfo` | the **last** attempt saw the ledger return neither info nor an error — a driver contract violation |
| `context.Canceled` / `context.DeadlineExceeded` | a wait between attempts was cut short, or the scan itself was cancelled |

`ErrLedgerHeightUnavailable` accompanies *every* failure to resolve the starting block, including a cancelled one, which makes it the single test for "no scan started" — and makes "an error without it came from the scan" true.

The two refining sentinels are deliberately documented as *not* discriminators on their own:

- `ErrNoLedgerInfo` reports only the last observed failure, so a driver that violates the contract intermittently may surface an ordinary ledger error instead. Its absence is not proof the contract was kept.
- The same context governs the scan, so a context error alone does not say which phase ended. Pair it with `ErrLedgerHeightUnavailable` to tell a cancelled height read from a cancelled scan.

No in-tree caller inspects these sentinels yet — today the sole consumer logs the error and stops. Retry or restart around `ScanBlock` belongs to FSC's `events.ListenerManager` and is out of scope here: the wider budget shrinks that window but does not close it.
