### PR TITLE
fix(auditdb): require matching anchor when refreshing an eid lease

### DIFF
--- a/docs/services/auditor.md
+++ b/docs/services/auditor.md
@@ -94,6 +94,8 @@ token:
 
 The Postgres backend creates an `eid_leases` table (prefixed per TMS persistence settings) and uses lease rows with heartbeat renewal.
 
+**Lease ownership:** each row is keyed by EID and carries the holding replica (`owner`) plus the request it was taken for (`anchor`). An acquisition may only take over an existing row when the lease has expired, or when the row is the same replica's lease for the *same* anchor — a re-acquisition, which just refreshes the deadline. Two different anchors therefore never hold the same EID at once, including two concurrent audits on a single replica; the second one is contended and retried until `acquireDeadline`.
+
 ### Replica owner identity
 
 Every lease row carries an `owner` column, and each replica scopes all of its lease

--- a/token/services/storage/auditdb/locker/postgres/postgres.go
+++ b/token/services/storage/auditdb/locker/postgres/postgres.go
@@ -198,10 +198,17 @@ func (p *Locker) tryAcquireAll(ctx context.Context, anchor string, eIDs []string
 // buildAcquireQuery builds the atomic acquisition statement: an INSERT of one
 // row per enrollment ID that, ON CONFLICT on the eid primary key, overwrites
 // the existing row only when it is safe to steal — the current lease has
-// expired (InPast) or is already owned by this replica. The WHERE clause on the
+// expired (InPast), or the row is this replica's own lease for this very anchor
+// (a re-acquisition, whose lease is simply refreshed). The WHERE clause on the
 // upsert enforces that condition, and RETURNING eid yields exactly the IDs that
 // were claimed, which tryAcquireAll counts. expires_at is set to now()+TTL via
 // an interval-bound parameter.
+//
+// The anchor must be compared as well as the owner: owner is a per-replica
+// constant, so matching on it alone let one node's concurrent audits of two
+// different anchors overwrite each other's live lease for a shared enrollment
+// ID, with both acquisitions reporting success. Requiring anchor equality turns
+// that case back into ordinary contention, which the caller retries.
 func (p *Locker) buildAcquireQuery(anchor string, eIDs []string) (string, []any) {
 	tbl := q.Table(p.table)
 	ins := q.InsertInto(p.table).
@@ -224,7 +231,10 @@ func (p *Locker) buildAcquireQuery(anchor string, eIDs []string) (string, []any)
 		).
 		Where(cond.Or(
 			cond.InPast(tbl.Field("expires_at")),
-			cond.Cmp(tbl.Field("owner"), "=", q.ExcludedValue("owner")),
+			cond.And(
+				cond.Cmp(tbl.Field("owner"), "=", q.ExcludedValue("owner")),
+				cond.Cmp(tbl.Field("anchor"), "=", q.ExcludedValue("anchor")),
+			),
 		)).
 		Returning("eid").
 		Format()

--- a/token/services/storage/auditdb/locker/postgres/postgres_internal_test.go
+++ b/token/services/storage/auditdb/locker/postgres/postgres_internal_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildAcquireQuery_ConflictRequiresOwnerAndAnchor pins the conflict clause
+// of the acquire upsert. owner is a per-replica constant, so matching on it
+// alone let one node's audits of two different anchors overwrite each other's
+// live lease for a shared enrollment ID; the anchor must be compared too.
+//
+// This assertion is deliberately on the generated SQL: it is the whole fix, and
+// it runs without a database.
+func TestBuildAcquireQuery_ConflictRequiresOwnerAndAnchor(t *testing.T) {
+	p := &Locker{table: "tbl", cfg: Config{Owner: "owner-1", TTL: 30 * time.Second}}
+
+	query, args := p.buildAcquireQuery("anchor1", []string{"alice", "bob"})
+
+	require.Contains(t, query, "ON CONFLICT (eid) DO UPDATE")
+	assert.Contains(t, query, "(tbl.owner = excluded.owner) AND (tbl.anchor = excluded.anchor)",
+		"a lease may only be refreshed by the same owner AND the same anchor")
+	assert.Contains(t, query, "tbl.expires_at < NOW()", "an expired lease must still be claimable")
+	assert.Contains(t, query, "RETURNING eid")
+	assert.Equal(t, []any{"anchor1", "owner-1", "30s", "alice", "bob"}, args)
+}

--- a/token/services/storage/auditdb/locker/postgres/postgres_test.go
+++ b/token/services/storage/auditdb/locker/postgres/postgres_test.go
@@ -170,6 +170,164 @@ func TestLocker_OwnerScopingAcrossReplicas(t *testing.T) {
 	l1.ReleaseLocks(ctx, "anchor1")
 }
 
+// TestLocker_SameOwnerDifferentAnchorsCannotShareEID is the regression test for
+// issue #2033: two audits on the same node (hence the same owner) for different
+// anchors that share an enrollment ID. The second acquisition used to overwrite
+// the first one's live lease and report success, leaving both callers believing
+// they held it exclusively. It must now be plain contention.
+func TestLocker_SameOwnerDifferentAnchorsCannotShareEID(t *testing.T) {
+	db := startPostgres(t)
+	table := "test_eid_lease_same_owner"
+	cleanTable(t, db, table)
+	t.Cleanup(func() { cleanTable(t, db, table) })
+
+	l := newLocker(t, db, table, lockerpostgres.Config{
+		TTL: 30 * time.Second, AcquireBackoff: 25 * time.Millisecond,
+		AcquireDeadline: 300 * time.Millisecond, Heartbeat: 10 * time.Second,
+		Owner: "owner-1",
+	})
+
+	ctx := context.Background()
+	require.NoError(t, l.AcquireLocks(ctx, "anchor1", "alice", "bob"))
+
+	// anchor2 shares "alice" with anchor1 and belongs to the same owner.
+	err := l.AcquireLocks(ctx, "anchor2", "alice")
+	require.ErrorIs(t, err, errs.ErrLockContention, "a live lease of another anchor must not be stealable")
+	require.ErrorIs(t, err, errs.ErrLockAcquireTimeout)
+
+	// anchor1 still owns the shared lease, unchanged.
+	var anchor, owner string
+	require.NoError(t, db.QueryRow("SELECT anchor, owner FROM "+table+" WHERE eid = $1", "alice").Scan(&anchor, &owner))
+	assert.Equal(t, "anchor1", anchor, "the shared enrollment ID must still be held by the first anchor")
+	assert.Equal(t, "owner-1", owner)
+	require.NoError(t, l.AssertLocksHeld(ctx, "anchor1"))
+
+	// The failed attempt left nothing behind.
+	var count int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM "+table+" WHERE anchor = $1", "anchor2").Scan(&count))
+	assert.Equal(t, 0, count)
+	require.ErrorIs(t, l.AssertLocksHeld(ctx, "anchor2"), errs.ErrLockNotHeld)
+
+	l.ReleaseLocks(ctx, "anchor1")
+
+	// Once released, the same enrollment ID is claimable by the other anchor.
+	require.NoError(t, l.AcquireLocks(ctx, "anchor2", "alice"))
+	l.ReleaseLocks(ctx, "anchor2")
+}
+
+// TestLocker_SameOwnerSameAnchorRefreshesLease verifies the case the conflict
+// clause is meant to allow: re-acquiring the same enrollment IDs under the same
+// anchor is idempotent and pushes the lease deadline out.
+func TestLocker_SameOwnerSameAnchorRefreshesLease(t *testing.T) {
+	db := startPostgres(t)
+	table := "test_eid_lease_reacquire"
+	cleanTable(t, db, table)
+	t.Cleanup(func() { cleanTable(t, db, table) })
+
+	l := newLocker(t, db, table, lockerpostgres.Config{
+		TTL: 30 * time.Second, AcquireBackoff: 25 * time.Millisecond,
+		AcquireDeadline: 300 * time.Millisecond, Heartbeat: time.Hour,
+		Owner: "owner-1",
+	})
+
+	ctx := context.Background()
+	expiry := func() time.Time {
+		t.Helper()
+		var at time.Time
+		require.NoError(t, db.QueryRow("SELECT expires_at FROM "+table+" WHERE eid = $1", "alice").Scan(&at))
+
+		return at
+	}
+
+	require.NoError(t, l.AcquireLocks(ctx, "anchor1", "alice"))
+	first := expiry()
+
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, l.AcquireLocks(ctx, "anchor1", "alice"), "re-acquiring one's own anchor must succeed")
+	assert.True(t, expiry().After(first), "re-acquisition must refresh the lease deadline")
+
+	require.NoError(t, l.AssertLocksHeld(ctx, "anchor1"))
+	l.ReleaseLocks(ctx, "anchor1")
+}
+
+// TestLocker_ExpiredLeaseIsClaimableByAnotherAnchor verifies the crash-recovery
+// path still works: once a lease expires it may be taken over, even by a
+// different anchor of the same owner. Heartbeat is longer than the TTL so no
+// renewal interferes.
+func TestLocker_ExpiredLeaseIsClaimableByAnotherAnchor(t *testing.T) {
+	db := startPostgres(t)
+	table := "test_eid_lease_expired"
+	cleanTable(t, db, table)
+	t.Cleanup(func() { cleanTable(t, db, table) })
+
+	l := newLocker(t, db, table, lockerpostgres.Config{
+		TTL: 200 * time.Millisecond, AcquireBackoff: 25 * time.Millisecond,
+		AcquireDeadline: 5 * time.Second, Heartbeat: time.Hour,
+		Owner: "owner-1",
+	})
+
+	ctx := context.Background()
+	require.NoError(t, l.AcquireLocks(ctx, "anchor1", "alice"))
+	time.Sleep(400 * time.Millisecond) // outlive the lease
+
+	require.NoError(t, l.AcquireLocks(ctx, "anchor2", "alice"))
+
+	var anchor string
+	require.NoError(t, db.QueryRow("SELECT anchor FROM "+table+" WHERE eid = $1", "alice").Scan(&anchor))
+	assert.Equal(t, "anchor2", anchor)
+	l.ReleaseLocks(ctx, "anchor2")
+}
+
+// TestLocker_ConcurrentSharedEIDSingleWinner is the concurrency shape the issue
+// describes: several audits in flight on one node, all touching the same
+// enrollment ID. Exactly one may hold it; the rest must time out contended.
+func TestLocker_ConcurrentSharedEIDSingleWinner(t *testing.T) {
+	db := startPostgres(t)
+	table := "test_eid_lease_concurrent"
+	cleanTable(t, db, table)
+	t.Cleanup(func() { cleanTable(t, db, table) })
+
+	l := newLocker(t, db, table, lockerpostgres.Config{
+		TTL: 30 * time.Second, AcquireBackoff: 25 * time.Millisecond,
+		AcquireDeadline: 300 * time.Millisecond, Heartbeat: time.Hour,
+		Owner: "owner-1",
+	})
+
+	const audits = 4
+	ctx := context.Background()
+	anchors := []string{"a0", "a1", "a2", "a3"}
+	results := make([]error, audits)
+
+	var wg sync.WaitGroup
+	wg.Add(audits)
+	for i := range audits {
+		go func() {
+			defer wg.Done()
+			// No release: whoever wins keeps the lease for the whole test.
+			results[i] = l.AcquireLocks(ctx, anchors[i], "alice")
+		}()
+	}
+	wg.Wait()
+
+	winners := make([]string, 0, audits)
+	for i, err := range results {
+		if err == nil {
+			winners = append(winners, anchors[i])
+
+			continue
+		}
+		require.ErrorIs(t, err, errs.ErrLockContention, "a losing audit must report contention")
+	}
+	require.Len(t, winners, 1, "exactly one audit may hold the shared enrollment ID, got %v", winners)
+
+	var anchor string
+	require.NoError(t, db.QueryRow("SELECT anchor FROM "+table+" WHERE eid = $1", "alice").Scan(&anchor))
+	assert.Equal(t, winners[0], anchor, "the table must reflect the one audit that reported success")
+	require.NoError(t, l.AssertLocksHeld(ctx, winners[0]))
+
+	l.ReleaseLocks(ctx, winners[0])
+}
+
 func TestLocker_NilDB(t *testing.T) {
 	_, err := lockerpostgres.New(nil, "t", lockerpostgres.Config{}, stubReplicaID{id: "owner"})
 	require.Error(t, err)


### PR DESCRIPTION
Fixes #2033

## The problem

The lease row for an enrollment ID could be overwritten whenever `owner = excluded.owner`. `owner` is the replica ID — the same value for every audit on a node. So two concurrent audits on one node, for different transactions sharing an enrollment ID, both "acquired" it: the second overwrote the first's live row and `AcquireLocks` returned success to both. The mistake only surfaced later, at `AssertLocksHeld` just before the DB write.

## The fix

Also require the anchor to match, so a lease is only refreshed by the same owner *and* the same transaction:

```sql
-- before
WHERE expires_at < NOW() OR owner = excluded.owner

-- after
WHERE expires_at < NOW() OR (owner = excluded.owner AND anchor = excluded.anchor)
```

Same owner, different anchor is now ordinary contention, retried until `acquireDeadline`. Expired leases stay claimable, so crash recovery is unchanged.

## Tests

One query-shape test (no DB) and four against real Postgres: cross-anchor contention, same-anchor refresh, expired takeover, and four concurrent audits on one shared enrollment ID.

Against the old clause three fail — the concurrent one reporting all 4 audits as winners of the same lease. All pass with the fix under `-race`; `go vet` and `golangci-lint` clean.