### PR TITLE
fix(identity): make RecipientDataCache provisioning cancellable

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,6 +106,7 @@ linters:
         - go.opentelemetry.io/otel/trace.Span
         - github.com/hyperledger/fabric-lib-go/common/metrics.Gauge
         - github.com/hyperledger/fabric-lib-go/common/metrics.Histogram
+        - github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics.Gauge
         - github.com/hyperledger-labs/fabric-smart-client/platform/common/driver.ConfigService
         - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.ViewClient
         - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.Platform

--- a/docs/services/identity.md
+++ b/docs/services/identity.md
@@ -162,6 +162,74 @@ func (d *Base) NewWalletService(...) (*wallet.Service, error) {
 
 > **Note:** `provider` here is a `NewTMSProvider`-wrapped `Provider` (see [Driver Metrics](../drivers/metrics.md#pitfall-labelnames-must-include-network-channel-namespace)), which binds `network`/`channel`/`namespace` on every metric via `.With(...)` before returning it. Every `CounterOpts`/`HistogramOpts` above must therefore declare those three as `LabelNames` in addition to its own label(s), or the metric panics with "inconsistent label cardinality" on first use. This is exactly the bug that crashed the DVP/DLog integration suite in `SignerRouter.Register` before it was fixed.
 
+## Wallet Lifecycle and Recipient Data Caching
+
+Anonymous owner wallets hand out a fresh pseudonym for every payment. Generating one is
+expensive (an Idemix pseudonym plus a registry binding), so `AnonymousOwnerWallet` keeps a
+pre-provisioned buffer of recipient data. Two caches implement that buffer:
+
+| Cache | Buffers | Sized by |
+|:------|:--------|:---------|
+| `role.RecipientDataCache` (`token/services/identity/role/cache.go`) | `driver.RecipientData` (pseudonym + audit info) for one wallet | `wallets.owners[].cacheSize`, falling back to `wallets.defaultCacheSize` (see [configuration](../configuration.md)) |
+| `idemix/cache.IdentityCache` (`token/services/identity/idemix/cache/cache.go`) | `idriver.IdentityDescriptor` for one Idemix key manager | same lookup, via `KeyManagerProvider.cacheSizeForID` |
+
+Both follow the same contract:
+
+*   **Provisioning is lazy.** The background goroutine is started by the first request, and
+    only when the configured size is greater than zero. With a size of zero the cache is
+    disabled and every request goes straight to the backend.
+*   **Requests never wait on the cache.** A request that does not find a buffered entry
+    within a short timeout (5 ms) generates the data on the spot instead of blocking, so a
+    slow backend degrades latency rather than stalling the caller. A cancelled caller
+    context aborts the request immediately.
+*   **A failing backend backs off, and is observable.** The provisioning loop logs the
+    failure, increments a counter and waits one second before retrying, so a broken
+    identity backend cannot turn pre-provisioning into a busy loop — and the condition can
+    be alerted on instead of only appearing in the logs.
+*   **`Close()` is mandatory and idempotent.** It cancels the background context, which
+    terminates the provisioning goroutine even while it is parked on a full buffer or
+    inside a retry backoff. A cache that is never closed keeps its goroutine, its channel
+    and its backend closure alive for the lifetime of the process. After `Close()` the
+    cache still serves requests from the backend; it simply stops pre-provisioning.
+
+### Cache metrics
+
+| Metric | Type | Cache | Purpose |
+|:-------|:-----|:------|:--------|
+| `recipient_data_cache_level` | Gauge | `RecipientDataCache` | Entries currently buffered. Counted only once an entry is really in the buffer, so it cannot drift upward when the producer is blocked. |
+| `recipient_data_provision_failures_total` | Counter | `RecipientDataCache` | Failed pre-provisioning attempts. A rising rate means the identity backend is failing and requests are falling back to the slower on-demand path. |
+| `cache_level` | Gauge | idemix `IdentityCache` | As above, for Idemix identities. |
+| `cache_provision_failures_total` | Counter | idemix `IdentityCache` | As above, for Idemix identities. |
+
+> **Note:** these providers are `NewTMSProvider`-wrapped, so every `GaugeOpts`/`CounterOpts`
+> above must declare `network`, `channel` and `namespace` in `LabelNames` — omitting them
+> panics with "inconsistent label cardinality" on first use. See
+> [Driver Metrics](../drivers/metrics.md#pitfall-labelnames-must-include-network-channel-namespace).
+
+### Who calls `Close()`
+
+Application code does not normally close these caches itself: they are released by the
+existing teardown chain when a token management service is unloaded, for instance when
+its public parameters are updated.
+
+```
+core.TMSProvider.Update            (token/core/tms.go)
+  └── Service.Done()               (token/core/common/tms.go)
+        └── wallet.Service.Done()  (token/services/identity/wallet/service.go)
+              └── role.Registry.Done()
+                    ├── Close() on every wallet it created that holds resources
+                    │     └── AnonymousOwnerWallet.Close() → RecipientDataCache.Close()
+                    └── Role.Done() → LocalMembership.Close()
+```
+
+`role.Registry.Done()` closes wallets through a local `interface{ Close() }` assertion
+rather than through `driver.Wallet`, so wallet types with nothing to release need not
+implement a no-op `Close()`. If you add a wallet type that owns a goroutine, a ticker or
+any other resource, give it a `Close()` method and it will be released automatically.
+
+> **Note:** tests that exercise an anonymous owner wallet should `t.Cleanup(w.Close)`,
+> otherwise each test leaves a provisioning goroutine behind for the rest of the run.
+
 ## Identity Types
 
 The Identity Service leverages a wrapper called **TypedIdentity** to support various identity schemes uniformly. 

--- a/token/services/identity/idemix/cache/cache.go
+++ b/token/services/identity/idemix/cache/cache.go
@@ -36,29 +36,37 @@ type IdentityCache struct {
 	cacheTimeout time.Duration
 	// Cache performance metrics
 	metrics *Metrics
-	// Cancellation function for background provisioning
+	// provisionCtx governs the lifetime of the background provisioning goroutine.
+	// Created at construction time and cancelled by Close.
+	provisionCtx context.Context
+	// cancel cancels provisionCtx. Written once, at construction time, so that Close
+	// is safe to call concurrently with Identity.
 	cancel context.CancelFunc
 }
 
 // NewIdentityCache creates a new identity cache with specified size and backend.
 func NewIdentityCache(backed IdentityCacheBackendFunc, size int, auditInfo []byte, metrics *Metrics) *IdentityCache {
 	logger.Debugf("new identity cache with size [%d]", size)
+	// The provisioning goroutine must not inherit any caller's request context, but it
+	// must still be cancellable, hence a cancellable child of context.Background.
+	provisionCtx, cancel := context.WithCancel(context.Background())
 	ci := &IdentityCache{
 		backed:       backed,
 		cache:        make(chan *idriver.IdentityDescriptor, size),
 		auditInfo:    auditInfo,
 		cacheTimeout: 5 * time.Millisecond,
 		metrics:      metrics,
+		provisionCtx: provisionCtx,
+		cancel:       cancel,
 	}
 
 	return ci
 }
 
-// Close stops the background identity provisioning.
+// Close stops the background identity provisioning. It is idempotent and safe to call
+// even if provisioning was never started, or concurrently with Identity.
 func (c *IdentityCache) Close() {
-	if c.cancel != nil {
-		c.cancel()
-	}
+	c.cancel()
 }
 
 // Identity retrieves an identity from cache or generates on-demand.
@@ -70,10 +78,10 @@ func (c *IdentityCache) Identity(ctx context.Context, auditInfo []byte) (*idrive
 
 	c.once.Do(func() {
 		logger.DebugfContext(ctx, "provision identities with cache size [%d]", cap(c.cache))
-		if cap(c.cache) > 0 {
-			var backgroundCtx context.Context
-			backgroundCtx, c.cancel = context.WithCancel(context.Background())
-			go c.provisionIdentities(backgroundCtx)
+		// Do not spawn the goroutine if the cache has already been closed, otherwise a
+		// late first call would start a goroutine that nothing will ever stop.
+		if cap(c.cache) > 0 && c.provisionCtx.Err() == nil {
+			go c.provisionIdentities(c.provisionCtx)
 		}
 	})
 
@@ -143,6 +151,7 @@ func (c *IdentityCache) provisionIdentities(ctx context.Context) {
 	for {
 		identityDescriptor, err := c.backed(ctx, c.auditInfo)
 		if err != nil {
+			c.metrics.ProvisionFailuresCount.Add(1)
 			logger.Errorf("failed to provision identity [%s]", err)
 			select {
 			case <-ctx.Done():
@@ -153,9 +162,11 @@ func (c *IdentityCache) provisionIdentities(ctx context.Context) {
 			continue
 		}
 		logger.DebugfContext(ctx, "generated new idemix identity [%d]", count)
-		c.metrics.CacheLevelGauge.Add(1)
+		// The gauge is incremented only once the entry is actually in the channel, so a
+		// cancellation mid-send cannot leave the reported cache level skewed.
 		select {
 		case c.cache <- identityDescriptor:
+			c.metrics.CacheLevelGauge.Add(1)
 			count++
 		case <-ctx.Done():
 			return

--- a/token/services/identity/idemix/cache/cache_test.go
+++ b/token/services/identity/idemix/cache/cache_test.go
@@ -9,6 +9,8 @@ package cache
 import (
 	"context"
 	"errors"
+	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,6 +18,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	idriver "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/disabled"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,6 +32,7 @@ func TestIdentityCache(t *testing.T) {
 			AuditInfo: []byte("audit"),
 		}, nil
 	}, 100, nil, NewMetrics(&disabled.Provider{}))
+	t.Cleanup(c.Close)
 	identityDescriptor, err := c.Identity(t.Context(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, driver.Identity([]byte("hello world")), identityDescriptor.Identity)
@@ -48,6 +52,7 @@ func TestIdentityCacheForRace(t *testing.T) {
 			AuditInfo: []byte("audit"),
 		}, nil
 	}, 10000, nil, NewMetrics(&disabled.Provider{}))
+	t.Cleanup(c.Close)
 
 	numRoutines := 4
 	wg := sync.WaitGroup{}
@@ -77,6 +82,7 @@ func TestFetchIdentityFromBackend(t *testing.T) {
 	c := NewIdentityCache(func(ctx context.Context, auditInfo []byte) (*idriver.IdentityDescriptor, error) {
 		return expectedIdentity, nil
 	}, 10, []byte("cache audit"), NewMetrics(&disabled.Provider{}))
+	t.Cleanup(c.Close)
 
 	// Call with different audit info to trigger backend fetch
 	identityDescriptor, err := c.Identity(context.Background(), []byte("different audit"))
@@ -92,6 +98,7 @@ func TestFetchIdentityFromBackendError(t *testing.T) {
 	c := NewIdentityCache(func(ctx context.Context, auditInfo []byte) (*idriver.IdentityDescriptor, error) {
 		return nil, expectedErr
 	}, 10, []byte("cache audit"), NewMetrics(&disabled.Provider{}))
+	t.Cleanup(c.Close)
 
 	// Call with different audit info to trigger backend fetch
 	_, err := c.Identity(context.Background(), []byte("different audit"))
@@ -111,6 +118,7 @@ func TestFetchIdentityFromCacheTimeout(t *testing.T) {
 			AuditInfo: []byte("timeout audit"),
 		}, nil
 	}, 0, nil, NewMetrics(&disabled.Provider{})) // cache size 0 to force timeout
+	t.Cleanup(c.Close)
 
 	// Set short timeout to trigger timeout path
 	c.cacheTimeout = 1 * time.Millisecond
@@ -129,6 +137,7 @@ func TestFetchIdentityFromCacheTimeoutError(t *testing.T) {
 	c := NewIdentityCache(func(ctx context.Context, auditInfo []byte) (*idriver.IdentityDescriptor, error) {
 		return nil, expectedErr
 	}, 0, nil, NewMetrics(&disabled.Provider{}))
+	t.Cleanup(c.Close)
 
 	// Set short timeout to trigger timeout path
 	c.cacheTimeout = 1 * time.Millisecond
@@ -183,6 +192,7 @@ func TestFetchIdentityFromCacheNilEntry(t *testing.T) {
 			AuditInfo: []byte("backend audit"),
 		}, nil
 	}, 10, nil, NewMetrics(&disabled.Provider{}))
+	t.Cleanup(c.Close)
 
 	// Pre-populate the cache with nil before calling Identity()
 	// Since cache is buffered, this completes immediately
@@ -213,6 +223,7 @@ func TestIdentityCache_Close(t *testing.T) {
 	}
 
 	c := NewIdentityCache(backend, 10, nil, NewMetrics(&disabled.Provider{}))
+	t.Cleanup(c.Close)
 	// Set a very short timeout so we don't wait long if the cache is empty
 	c.cacheTimeout = 1 * time.Millisecond
 
@@ -239,3 +250,92 @@ func TestIdentityCache_Close(t *testing.T) {
 	// may complete a few in-flight iterations before observing the stop signal.
 	assert.LessOrEqual(t, callCount.Load(), countAfterClose+3)
 }
+
+// provisionGoroutineName is the symbol appearing in the stack trace of the background
+// provisioning goroutine.
+const provisionGoroutineName = "cache.(*IdentityCache).provisionIdentities"
+
+// provisioningGoroutines counts the running provisioning goroutines.
+func provisioningGoroutines() int {
+	buf := make([]byte, 1<<16)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return strings.Count(string(buf[:n]), provisionGoroutineName)
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
+// TestIdentityCache_CloseRacesFirstUse checks Close is safe to call concurrently with
+// the first Identity call, and that the cancellation is never missed.
+//
+// The cancel function used to be assigned inside once.Do, so Close read it without
+// synchronisation: a data race, and worse, a Close that observed the old nil value
+// silently skipped the cancellation and leaked the goroutine. Building the context in
+// the constructor makes the field write-once.
+func TestIdentityCache_CloseRacesFirstUse(t *testing.T) {
+	require.Eventually(t, func() bool {
+		return provisioningGoroutines() == 0
+	}, 5*time.Second, 10*time.Millisecond, "a previous test left a provisioning goroutine behind")
+
+	for range 300 {
+		c := NewIdentityCache(func(context.Context, []byte) (*idriver.IdentityDescriptor, error) {
+			return &idriver.IdentityDescriptor{Identity: []byte("id")}, nil
+		}, 4, nil, NewMetrics(&disabled.Provider{}))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_, _ = c.Identity(context.Background(), nil)
+		}()
+		go func() {
+			defer wg.Done()
+			c.Close()
+		}()
+		wg.Wait()
+	}
+
+	// Every cache was closed, so no provisioning goroutine may survive.
+	require.Eventually(t, func() bool {
+		return provisioningGoroutines() == 0
+	}, 5*time.Second, 10*time.Millisecond, "Close missed the cancellation and leaked a goroutine")
+}
+
+// countingCounter is a minimal metrics.Counter that keeps a running total.
+type countingCounter struct {
+	total atomic.Int64
+}
+
+func (c *countingCounter) With(...string) metrics.Counter { return c }
+
+func (c *countingCounter) Add(delta float64) { c.total.Add(int64(delta)) }
+
+func (c *countingCounter) value() float64 { return float64(c.total.Load()) }
+
+// TestIdentityCache_CountsProvisionFailures checks a failing key manager is reported on a
+// counter, not only in the log, so the condition can be alerted on.
+func TestIdentityCache_CountsProvisionFailures(t *testing.T) {
+	failures := &countingCounter{}
+	c := NewIdentityCache(func(context.Context, []byte) (*idriver.IdentityDescriptor, error) {
+		return nil, errors.New("key manager is down")
+	}, 10, nil, &Metrics{CacheLevelGauge: &noopGauge{}, ProvisionFailuresCount: failures})
+	t.Cleanup(c.Close)
+
+	_, err := c.Identity(context.Background(), nil)
+	require.Error(t, err)
+
+	require.Eventually(t, func() bool {
+		return failures.value() >= 1
+	}, 2*time.Second, 5*time.Millisecond, "the failed provisioning attempt was not counted")
+}
+
+// noopGauge is a metrics.Gauge that discards everything.
+type noopGauge struct{}
+
+func (g *noopGauge) With(...string) metrics.Gauge { return g }
+
+func (g *noopGauge) Add(float64) {}
+
+func (g *noopGauge) Set(float64) {}

--- a/token/services/identity/idemix/cache/metrics.go
+++ b/token/services/identity/idemix/cache/metrics.go
@@ -17,17 +17,34 @@ var (
 		Help:       "Level of the idemix cache",
 		LabelNames: []string{"network", "channel", "namespace"},
 	}
+
+	// ProvisionFailuresOpts counts failed attempts to pre-provision identities. A
+	// rising rate means the key manager is failing: identities are generated on the
+	// request path instead and the background loop is retrying. This is the signal to
+	// alert on, since the corresponding log line alone is easy to miss.
+	//
+	// LabelNames must repeat network/channel/namespace: the provider is TMS-wrapped
+	// and binds those three on every metric, so omitting them here panics with
+	// "inconsistent label cardinality" on first use.
+	ProvisionFailuresOpts = metrics.CounterOpts{
+		Name:       "cache_provision_failures_total",
+		Help:       "Failed attempts to pre-provision idemix identities",
+		LabelNames: []string{"network", "channel", "namespace"},
+	}
 )
 
 // Metrics contains metrics for monitoring identity cache performance.
 type Metrics struct {
 	// Current number of cached identities
 	CacheLevelGauge metrics.Gauge
+	// Failed background provisioning attempts
+	ProvisionFailuresCount metrics.Counter
 }
 
 // NewMetrics creates a new Metrics instance.
 func NewMetrics(p metrics.Provider) *Metrics {
 	return &Metrics{
-		CacheLevelGauge: p.NewGauge(LevelOpts),
+		CacheLevelGauge:        p.NewGauge(LevelOpts),
+		ProvisionFailuresCount: p.NewCounter(ProvisionFailuresOpts),
 	}
 }

--- a/token/services/identity/idemix/kmp.go
+++ b/token/services/identity/idemix/kmp.go
@@ -122,18 +122,23 @@ func (l *KeyManagerProvider) Get(ctx context.Context, identityConfig *driver.Ide
 	}
 
 	var getIdentityFunc func(context.Context, []byte) (*idriver.IdentityDescriptor, error)
+	// identityCache is kept on the wrapper, not discarded: the cache owns a background
+	// provisioning goroutine and only its Close can stop it. Taking just the Identity
+	// method value here would make the cache unreachable and the goroutine permanent.
+	var identityCache *cache.IdentityCache
 	if keyManager.IsRemote() {
 		id := identityConfig.ID
 		getIdentityFunc = func(context.Context, []byte) (*idriver.IdentityDescriptor, error) {
 			return nil, errors.Errorf("cannot invoke this function, remote must register pseudonyms on wallet [%v]", id)
 		}
 	} else {
-		getIdentityFunc = cache.NewIdentityCache(
+		identityCache = cache.NewIdentityCache(
 			keyManager.Identity,
 			cacheSize,
 			nil,
 			cache.NewMetrics(l.metricsProvider),
-		).Identity
+		)
+		getIdentityFunc = identityCache.Identity
 	}
 
 	// finalize identity configuration
@@ -148,6 +153,7 @@ func (l *KeyManagerProvider) Get(ctx context.Context, identityConfig *driver.Ide
 	return &WrappedKeyManager{
 		KeyManager:      keyManager,
 		getIdentityFunc: getIdentityFunc,
+		identityCache:   identityCache,
 	}, nil
 }
 
@@ -164,6 +170,18 @@ func (l *KeyManagerProvider) cacheSizeForID(id string) (int, error) {
 type WrappedKeyManager struct {
 	membership.KeyManager
 	getIdentityFunc func(context.Context, []byte) (*idriver.IdentityDescriptor, error)
+	// identityCache is nil for remote key managers, which do not pre-provision.
+	identityCache *cache.IdentityCache
+}
+
+// Close releases the resources held by this key manager, stopping the background
+// identity provisioning of its cache. It is idempotent and safe to call on a remote
+// key manager, which has no cache. LocalMembership.Close calls this for every key
+// manager it loaded.
+func (k *WrappedKeyManager) Close() {
+	if k.identityCache != nil {
+		k.identityCache.Close()
+	}
 }
 
 func (k *WrappedKeyManager) Identity(ctx context.Context, auditInfo []byte) (*idriver.IdentityDescriptor, error) {

--- a/token/services/identity/idemix/kmp_test.go
+++ b/token/services/identity/idemix/kmp_test.go
@@ -8,7 +8,10 @@ package idemix
 
 import (
 	"context"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	math "github.com/IBM/mathlib"
 	"github.com/LFDT-Panurus/panurus/token"
@@ -68,6 +71,7 @@ func testNewKeyManagerProvider(t *testing.T, configPath string, curveID math.Cur
 	}
 	km, err := kmp.Get(t.Context(), idConfig)
 	require.NoError(t, err)
+	closeKeyManager(t, km)
 	assert.NotNil(t, km)
 	assert.NotNil(t, idConfig.Raw)
 	signAndVerify(t, km)
@@ -77,6 +81,7 @@ func testNewKeyManagerProvider(t *testing.T, configPath string, curveID math.Cur
 	idConfig.URL = ""
 	km, err = kmp.Get(t.Context(), idConfig)
 	require.NoError(t, err)
+	closeKeyManager(t, km)
 	assert.NotNil(t, km)
 	assert.NotNil(t, idConfig.Raw)
 	signAndVerify(t, km)
@@ -85,6 +90,7 @@ func testNewKeyManagerProvider(t *testing.T, configPath string, curveID math.Cur
 
 	km, err = kmp.Get(t.Context(), idConfig)
 	require.NoError(t, err)
+	closeKeyManager(t, km)
 	assert.NotNil(t, km)
 	assert.NotNil(t, idConfig.Raw)
 	signAndVerify(t, km)
@@ -101,6 +107,16 @@ func testNewKeyManagerProvider(t *testing.T, configPath string, curveID math.Cur
 	_, err = kmp.Get(t.Context(), idConfig)
 	require.Error(t, err)
 	require.EqualError(t, err, "unsupported protocol version: 0")
+}
+
+// closeKeyManager releases a key manager produced by KeyManagerProvider.Get once the test
+// ends, stopping the background identity provisioning owned by its cache. Without it each
+// test that fetches an identity leaves a goroutine behind for the rest of the run.
+func closeKeyManager(t *testing.T, km membership.KeyManager) {
+	t.Helper()
+	if c, ok := km.(interface{ Close() }); ok {
+		t.Cleanup(c.Close)
+	}
 }
 
 func signAndVerify(t *testing.T, km membership.KeyManager) {
@@ -189,6 +205,7 @@ func testKeyManagerProviderErrorPaths(t *testing.T, configPath string, curveID m
 	}
 	kmRemote, err := kmp.Get(context.Background(), idConfigRemote)
 	require.NoError(t, err)
+	closeKeyManager(t, kmRemote)
 
 	// Try to get an identity from the remote wallet - should fail
 	_, err = kmRemote.Identity(context.Background(), nil)
@@ -229,6 +246,7 @@ func testWrappedKeyManagerIdentity(t *testing.T, configPath string, curveID math
 	// create the WrappedKeyManager (km) from the constructed KeyManagerProvider
 	km, err := kmp.Get(context.Background(), idConfig)
 	require.NoError(t, err)
+	closeKeyManager(t, km)
 
 	// Test that Identity method works fine through the wrapper
 	id1, err := km.Identity(context.Background(), nil)
@@ -299,6 +317,7 @@ func TestKeyManagerProviderWithIgnoreVerifyOnlyWallet(t *testing.T) {
 	}
 	km, err := kmp.Get(context.Background(), idConfig)
 	require.NoError(t, err)
+	closeKeyManager(t, km)
 	assert.NotNil(t, km)
 }
 
@@ -339,5 +358,63 @@ func TestKeyManagerProviderGetWithRawConfig(t *testing.T) {
 	// get a KeyManager using this idConfig based on just the Raw config
 	km2, err := kmp.Get(context.Background(), idConfig2)
 	require.NoError(t, err)
+	closeKeyManager(t, km2)
 	assert.NotNil(t, km2)
+}
+
+// idemixProvisionGoroutineName is the symbol appearing in the stack trace of the idemix
+// identity cache's background provisioning goroutine.
+const idemixProvisionGoroutineName = "cache.(*IdentityCache).provisionIdentities"
+
+// idemixProvisioningGoroutines counts the running idemix provisioning goroutines.
+func idemixProvisioningGoroutines() int {
+	buf := make([]byte, 1<<16)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return strings.Count(string(buf[:n]), idemixProvisionGoroutineName)
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
+// TestWrappedKeyManagerClose checks that the identity cache built by Get stays reachable
+// through the wrapper, so its background provisioning goroutine can actually be stopped.
+// Previously Get kept only the cache's Identity method value, leaving the cache
+// unreachable and its Close unreachable with it.
+func TestWrappedKeyManagerClose(t *testing.T) {
+	configPath := "./testdata/bls12_381_bbs_gurvy/idemix"
+	curveID := math.BLS12_381_BBS_GURVY
+
+	backend, err := kvs2.NewInMemory()
+	require.NoError(t, err)
+	config, err := crypto.NewConfig(configPath)
+	require.NoError(t, err)
+	keyStore, err := crypto.NewKeyStore(curveID, kvs2.Keystore(backend))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return idemixProvisioningGoroutines() == 0
+	}, 5*time.Second, 10*time.Millisecond, "a previous test left a provisioning goroutine behind")
+
+	kmp := NewKeyManagerProvider(config.Ipk, curveID, keyStore, &mockConfig{}, 3, false, &disabled.Provider{})
+	km, err := kmp.Get(context.Background(), &token.IdentityConfiguration{ID: "alice", URL: configPath})
+	require.NoError(t, err)
+
+	closable, ok := km.(interface{ Close() })
+	require.True(t, ok, "the key manager must expose Close")
+	t.Cleanup(closable.Close)
+
+	// Using it starts the background provisioning goroutine.
+	_, err = km.Identity(context.Background(), nil)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return idemixProvisioningGoroutines() == 1
+	}, 5*time.Second, 10*time.Millisecond, "the provisioning goroutine did not start")
+
+	// Close must terminate it, even though the cache is only reachable through the wrapper.
+	closable.Close()
+	require.Eventually(t, func() bool {
+		return idemixProvisioningGoroutines() == 0
+	}, 5*time.Second, 10*time.Millisecond, "the provisioning goroutine did not terminate")
 }

--- a/token/services/identity/membership/lm.go
+++ b/token/services/identity/membership/lm.go
@@ -186,8 +186,11 @@ type LocalMembership struct {
 	// leaves deserializerManager-based dispatch as the only path, unchanged.
 	signerRouter *identity.SignerRouter
 
-	localIdentitiesMutex      sync.RWMutex
-	localIdentities           []*LocalIdentity
+	localIdentitiesMutex sync.RWMutex
+	localIdentities      []*LocalIdentity
+	// keyManagers holds every key manager loaded by this membership, so that Close can
+	// release the ones that own resources. Guarded by localIdentitiesMutex.
+	keyManagers               []KeyManager
 	cachedDefaultIdentifier   string
 	localIdentitiesByName     map[string][]LocalIdentityWithPriority
 	localIdentitiesByIdentity map[string]*LocalIdentity
@@ -247,9 +250,30 @@ func (l *LocalMembership) DefaultNetworkIdentity() token.Identity {
 	return l.defaultNetworkIdentity
 }
 
-// Close stops the background identity notifier.
+// closer is implemented by key managers that hold resources needing an explicit
+// release, such as the background identity provisioning of an idemix identity cache.
+// It is declared here, on the consumer side, rather than widening KeyManager: most key
+// managers own nothing that needs releasing.
+type closer interface {
+	Close()
+}
+
+// Close releases the resources held by this local membership: the key managers it
+// loaded and the background identity notifier.
 func (l *LocalMembership) Close() {
 	l.closeOnce.Do(func() {
+		// Release the key managers first. The notifier teardown below can return early
+		// or fail, and stopping their background goroutines must not depend on it.
+		l.localIdentitiesMutex.Lock()
+		keyManagers := l.keyManagers
+		l.keyManagers = nil
+		l.localIdentitiesMutex.Unlock()
+		for _, keyManager := range keyManagers {
+			if c, ok := keyManager.(closer); ok {
+				c.Close()
+			}
+		}
+
 		notifier, err := l.identityDB.Notifier()
 		if err != nil {
 			if errors.Is(err, storage.ErrNotSupported) {
@@ -816,6 +840,10 @@ func (l *LocalMembership) addLocalIdentity(ctx context.Context, config *Identity
 
 	// deserializer
 	l.deserializerManager.AddTypedSignerDeserializer(keyManager.IdentityType(), &TypedSignerDeserializer{KeyManager: keyManager})
+
+	// Track the key manager so Close can release what it owns. Callers of
+	// addLocalIdentity hold localIdentitiesMutex (see commitLocalIdentity).
+	l.keyManagers = append(l.keyManagers, keyManager)
 
 	// conf_id-pinned routing: register this KeyManager as the sole owner of its conf_id, so
 	// Provider can dispatch straight to it instead of scanning every KeyManager registered

--- a/token/services/identity/membership/lm_test.go
+++ b/token/services/identity/membership/lm_test.go
@@ -1104,3 +1104,68 @@ func TestLoad_SameNameSamePriorityKeepsIteratorOrder(t *testing.T) {
 	assert.Equal(t, "e-first", info.EnrollmentID(),
 		"same-name same-priority lookup must follow iterator order, not completion order")
 }
+
+// closableKeyManager is a KeyManager that records whether it has been closed.
+type closableKeyManager struct {
+	*mock.KeyManager
+	closed atomic.Int32
+}
+
+func (k *closableKeyManager) Close() { k.closed.Add(1) }
+
+// TestLocalMembership_CloseClosesKeyManagers checks Close releases the key managers it
+// loaded, which is what stops the background identity provisioning owned by an idemix
+// identity cache. The notifier is unsupported here, so this also pins the ordering: key
+// managers must be released before the notifier teardown returns early.
+func TestLocalMembership_CloseClosesKeyManagers(t *testing.T) {
+	ctx := t.Context()
+
+	ip := &mock.IdentityProvider{}
+	ip.BindReturns(nil)
+
+	iss := &mock.IdentityStoreService{}
+	iss.ConfigurationExistsReturns(false, nil)
+	iss.AddConfigurationReturns(nil)
+	iss.NotifierReturns(nil, storage.ErrNotSupported)
+	iss.IteratorConfigurationsReturns(&mock.IdentityConfigurationIterator{}, nil)
+
+	inner := &mock.KeyManager{}
+	inner.EnrollmentIDReturns("e1")
+	inner.AnonymousReturns(false)
+	inner.IsRemoteReturns(false)
+	inner.IdentityReturns(&idriver.IdentityDescriptor{Identity: []byte("id1"), AuditInfo: []byte("ai1")}, nil)
+	inner.IdentityTypeReturns(identity.Type(99))
+	km := &closableKeyManager{KeyManager: inner}
+
+	kmp := &mock.KeyManagerProvider{}
+	kmp.GetReturns(km, nil)
+
+	lm := membership.NewLocalMembership(
+		logging.MustGetLogger("test"),
+		&mock.Config{},
+		[]byte("netid"),
+		&mock.SignerDeserializerManager{},
+		iss,
+		"testType",
+		false,
+		ip,
+		kmp,
+	)
+	require.NoError(t, lm.Load(ctx, nil, nil))
+
+	// Discover an identity so that the key manager gets registered.
+	iss.ConfigurationsByIDReturns([]idriver.IdentityConfiguration{
+		{ID: "new", URL: "/tmp/new", Type: "testType"},
+	}, nil)
+	info, err := lm.GetIdentityInfo(ctx, "new", nil)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	require.Equal(t, int32(0), km.closed.Load(), "the key manager must not be closed while in use")
+
+	lm.Close()
+	assert.Equal(t, int32(1), km.closed.Load(), "Close did not release the key manager")
+
+	// Close is guarded by a sync.Once, so a second call must not double-release.
+	lm.Close()
+	assert.Equal(t, int32(1), km.closed.Load(), "Close released the key manager twice")
+}

--- a/token/services/identity/role/cache.go
+++ b/token/services/identity/role/cache.go
@@ -19,6 +19,11 @@ import (
 
 var logger = logging.MustGetLogger()
 
+// provisionRetryDelay is how long the background provisioning loop waits after a
+// backend failure before trying again. Without it, a persistently failing identity
+// backend would turn the loop into a busy spin.
+const provisionRetryDelay = time.Second
+
 type RecipientDataBackendFunc func(ctx context.Context) (*driver.RecipientData, error)
 
 type RecipientDataCache struct {
@@ -30,28 +35,49 @@ type RecipientDataCache struct {
 	cache        chan *driver.RecipientData
 	cacheTimeout time.Duration
 	metrics      *Metrics
+
+	// provisionCtx governs the lifetime of the background provisioning goroutine.
+	// It is created at construction time and cancelled by Close.
+	provisionCtx context.Context
+	// cancel cancels provisionCtx. It is written once, at construction time, so
+	// that Close is safe to call concurrently with RecipientData.
+	cancel context.CancelFunc
 }
 
 func NewRecipientDataCache(Logger logging.Logger, backed RecipientDataBackendFunc, size int, metrics *Metrics) *RecipientDataCache {
 	if size < 0 {
 		size = 0
 	}
+	// The provisioning goroutine must not inherit any caller's request context, but
+	// it must still be cancellable, hence a cancellable child of context.Background.
+	provisionCtx, cancel := context.WithCancel(context.Background())
 	ci := &RecipientDataCache{
 		Logger:       Logger,
 		backed:       backed,
 		cache:        make(chan *driver.RecipientData, size),
 		cacheTimeout: time.Millisecond * 5,
 		metrics:      metrics,
+		provisionCtx: provisionCtx,
+		cancel:       cancel,
 	}
 
 	return ci
 }
 
+// Close stops the background recipient data provisioning. It is idempotent and
+// safe to call even if provisioning was never started. After Close, RecipientData
+// still serves requests directly from the backend; it just no longer pre-provisions.
+func (c *RecipientDataCache) Close() {
+	c.cancel()
+}
+
 func (c *RecipientDataCache) RecipientData(ctx context.Context) (*driver.RecipientData, error) {
 	c.once.Do(func() {
 		c.Logger.Debugf("provision wallet recipient data with cache size [%d]", cap(c.cache))
-		if cap(c.cache) > 0 {
-			go c.provisionIdentities()
+		// Do not spawn the goroutine if the cache has already been closed, otherwise
+		// a late first call would start a goroutine that nothing will ever stop.
+		if cap(c.cache) > 0 && c.provisionCtx.Err() == nil {
+			go c.provisionIdentities(c.provisionCtx)
 		}
 	})
 
@@ -86,14 +112,35 @@ func (c *RecipientDataCache) RecipientData(ctx context.Context) (*driver.Recipie
 	return identity, nil
 }
 
-func (c *RecipientDataCache) provisionIdentities() {
-	ctx := context.Background()
+// provisionIdentities keeps the cache filled with pre-generated recipient data until
+// ctx is cancelled. It returns as soon as ctx is done, both while backing off after a
+// failure and while blocked handing an entry to the cache channel.
+func (c *RecipientDataCache) provisionIdentities(ctx context.Context) {
+	defer c.Logger.Debugf("stopped provisioning wallet recipient data")
+
 	for {
 		id, err := c.backed(ctx)
 		if err != nil {
+			// Log, count and back off: a bare continue here turns a persistently
+			// failing backend into a silent busy loop that saturates a core.
+			c.metrics.ProvisionFailuresCount.Add(1)
+			c.Logger.Errorf("failed provisioning wallet recipient data, retrying in [%v]: [%s]", provisionRetryDelay, err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(provisionRetryDelay):
+			}
+
 			continue
 		}
-		c.metrics.CacheLevelGauge.Add(1)
-		c.cache <- id
+
+		// The gauge is incremented only once the entry is actually in the channel,
+		// so a cancellation mid-send cannot leave the reported cache level skewed.
+		select {
+		case c.cache <- id:
+			c.metrics.CacheLevelGauge.Add(1)
+		case <-ctx.Done():
+			return
+		}
 	}
 }

--- a/token/services/identity/role/cache_test.go
+++ b/token/services/identity/role/cache_test.go
@@ -1,0 +1,350 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package role_test
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/role"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/disabled"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// provisionGoroutineName is the symbol that appears in the stack trace of the
+// background provisioning goroutine. Searching all stacks for it is a precise way to
+// assert whether the goroutine is running, unlike a plain goroutine count.
+const provisionGoroutineName = "role.(*RecipientDataCache).provisionIdentities"
+
+// allStacks returns the stack traces of every goroutine in the process.
+func allStacks() string {
+	buf := make([]byte, 1<<16)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return string(buf[:n])
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
+// provisioningGoroutines counts the running provisioning goroutines.
+func provisioningGoroutines() int {
+	return strings.Count(allStacks(), provisionGoroutineName)
+}
+
+// requireProvisioningGoroutines waits until exactly want provisioning goroutines are
+// running in the process. Every test in this package closes the caches it creates, so
+// the count is a reliable absolute number as long as tests wait for it to settle
+// before measuring (goroutines closed by a previous test may still be winding down).
+func requireProvisioningGoroutines(t *testing.T, want int, within time.Duration) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return provisioningGoroutines() == want
+	}, within, 5*time.Millisecond,
+		"expected [%d] provisioning goroutines, got [%d]", want, provisioningGoroutines())
+}
+
+// cacheFixture is a cache under test whose provisioning goroutine is guaranteed to be
+// released when the test ends.
+type cacheFixture struct {
+	*role.RecipientDataCache
+}
+
+// requireProvisioning waits until exactly want provisioning goroutines are running.
+func (f *cacheFixture) requireProvisioning(t *testing.T, want int, within time.Duration) {
+	t.Helper()
+	requireProvisioningGoroutines(t, want, within)
+}
+
+// assertNoProvisioning asserts no provisioning goroutine is running, without waiting.
+func (f *cacheFixture) assertNoProvisioning(t *testing.T) {
+	t.Helper()
+	assert.Zero(t, provisioningGoroutines(), "no provisioning goroutine must be running")
+}
+
+func newRecipientData(id string) *driver.RecipientData {
+	return &driver.RecipientData{
+		Identity:  driver.Identity(id),
+		AuditInfo: []byte("audit-info"),
+	}
+}
+
+func newTestCacheWithMetrics(t *testing.T, size int, m *role.Metrics, backend role.RecipientDataBackendFunc) *cacheFixture {
+	t.Helper()
+	// Wait for goroutines released by earlier tests to actually exit, so this test can
+	// count provisioning goroutines in absolute terms.
+	requireProvisioningGoroutines(t, 0, 2*time.Second)
+	f := &cacheFixture{
+		RecipientDataCache: role.NewRecipientDataCache(logging.MustGetLogger("cache_test"), backend, size, m),
+	}
+	// No test may leave a provisioning goroutine behind, even if it fails early.
+	t.Cleanup(func() {
+		f.Close()
+		f.requireProvisioning(t, 0, 2*time.Second)
+	})
+
+	return f
+}
+
+func newTestCache(t *testing.T, size int, backend role.RecipientDataBackendFunc) *cacheFixture {
+	t.Helper()
+
+	return newTestCacheWithMetrics(t, size, role.NewMetrics(&disabled.Provider{}), backend)
+}
+
+// TestRecipientDataCacheFromCache checks recipient data is served out of the
+// pre-provisioned cache.
+func TestRecipientDataCacheFromCache(t *testing.T) {
+	c := newTestCache(t, 10, func(context.Context) (*driver.RecipientData, error) {
+		return newRecipientData("cached"), nil
+	})
+
+	rd, err := c.RecipientData(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, rd)
+	assert.Equal(t, driver.Identity("cached"), rd.Identity)
+}
+
+// TestRecipientDataCacheOnTheSpot checks that with caching disabled the recipient
+// data is generated on demand and no background goroutine is started.
+func TestRecipientDataCacheOnTheSpot(t *testing.T) {
+	var calls atomic.Int32
+	c := newTestCache(t, 0, func(context.Context) (*driver.RecipientData, error) {
+		calls.Add(1)
+
+		return newRecipientData("on-the-spot"), nil
+	})
+
+	rd, err := c.RecipientData(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, driver.Identity("on-the-spot"), rd.Identity)
+	assert.Equal(t, int32(1), calls.Load())
+	c.assertNoProvisioning(t)
+}
+
+// TestRecipientDataCacheBackendError checks the error returned by the backend is
+// wrapped and propagated to the caller.
+func TestRecipientDataCacheBackendError(t *testing.T) {
+	c := newTestCache(t, 0, func(context.Context) (*driver.RecipientData, error) {
+		return nil, errors.New("backend is down")
+	})
+
+	rd, err := c.RecipientData(t.Context())
+	require.Error(t, err)
+	assert.Nil(t, rd)
+	require.ErrorContains(t, err, "failed fetching wallet identity")
+	require.ErrorContains(t, err, "backend is down")
+}
+
+// TestRecipientDataCacheContextDone checks a cancelled caller context aborts the
+// fetch instead of falling back to the backend.
+func TestRecipientDataCacheContextDone(t *testing.T) {
+	c := newTestCache(t, 0, func(context.Context) (*driver.RecipientData, error) {
+		return newRecipientData("never"), nil
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	rd, err := c.RecipientData(ctx)
+	require.Error(t, err)
+	assert.Nil(t, rd)
+	require.ErrorContains(t, err, "context is done")
+}
+
+// TestRecipientDataCacheCloseStopsProvisioning is the regression test for the
+// uncancellable provisioning goroutine: after Close the goroutine must terminate and
+// stop calling the backend.
+func TestRecipientDataCacheCloseStopsProvisioning(t *testing.T) {
+	var calls atomic.Int32
+	c := newTestCache(t, 10, func(context.Context) (*driver.RecipientData, error) {
+		calls.Add(1)
+
+		return newRecipientData("provisioned"), nil
+	})
+
+	// Trigger provisioning and wait for the goroutine to be up and working.
+	_, err := c.RecipientData(t.Context())
+	require.NoError(t, err)
+	c.requireProvisioning(t, 1, 2*time.Second)
+	require.Eventually(t, func() bool {
+		return calls.Load() > 0
+	}, 2*time.Second, 5*time.Millisecond)
+
+	c.Close()
+	c.requireProvisioning(t, 0, 2*time.Second)
+
+	// Once the goroutine is gone the backend must not be called any more.
+	callsAfterClose := calls.Load()
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, callsAfterClose, calls.Load(), "the backend was called after Close")
+}
+
+// TestRecipientDataCacheCloseUnblocksSend checks Close releases a goroutine that is
+// blocked handing an entry to a full cache channel. Before the fix the send had no
+// cancellation branch, so the goroutine stayed parked there for the process lifetime.
+func TestRecipientDataCacheCloseUnblocksSend(t *testing.T) {
+	// A cache of size 1 fills up immediately, and the test never drains it again, so
+	// the goroutine ends up parked on the channel send.
+	c := newTestCache(t, 1, func(context.Context) (*driver.RecipientData, error) {
+		return newRecipientData("provisioned"), nil
+	})
+
+	_, err := c.RecipientData(t.Context())
+	require.NoError(t, err)
+	c.requireProvisioning(t, 1, 2*time.Second)
+
+	// Let it settle into the blocking send, then confirm it is parked and still there.
+	time.Sleep(50 * time.Millisecond)
+	require.Contains(t, allStacks(), provisionGoroutineName)
+
+	c.Close()
+	c.requireProvisioning(t, 0, 2*time.Second)
+}
+
+// TestRecipientDataCacheCloseIsIdempotent checks Close can be called repeatedly.
+func TestRecipientDataCacheCloseIsIdempotent(t *testing.T) {
+	c := newTestCache(t, 10, func(context.Context) (*driver.RecipientData, error) {
+		return newRecipientData("provisioned"), nil
+	})
+
+	assert.NotPanics(t, func() {
+		c.Close()
+		c.Close()
+		c.Close()
+	})
+}
+
+// TestRecipientDataCacheCloseBeforeFirstUse checks a cache closed before its first
+// use never starts a provisioning goroutine, while still serving recipient data.
+func TestRecipientDataCacheCloseBeforeFirstUse(t *testing.T) {
+	c := newTestCache(t, 10, func(context.Context) (*driver.RecipientData, error) {
+		return newRecipientData("on-the-spot"), nil
+	})
+
+	c.Close()
+
+	rd, err := c.RecipientData(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, driver.Identity("on-the-spot"), rd.Identity)
+	c.assertNoProvisioning(t)
+}
+
+// TestRecipientDataCacheFailingBackendDoesNotSpin checks a persistently failing
+// backend makes the provisioning loop back off instead of burning a core on a bare
+// continue.
+func TestRecipientDataCacheFailingBackendDoesNotSpin(t *testing.T) {
+	var calls atomic.Int32
+	c := newTestCache(t, 10, func(context.Context) (*driver.RecipientData, error) {
+		calls.Add(1)
+
+		return nil, errors.New("backend is down")
+	})
+
+	// The caller gets the error, and the provisioning loop keeps retrying in the
+	// background.
+	_, err := c.RecipientData(t.Context())
+	require.Error(t, err)
+
+	time.Sleep(300 * time.Millisecond)
+	// With a one second backoff only a handful of attempts can have happened. Without
+	// any backoff this counter would be orders of magnitude higher.
+	assert.Less(t, calls.Load(), int32(10), "the failing backend is being retried in a busy loop")
+}
+
+// TestRecipientDataCacheCloseDuringBackoff checks Close interrupts the retry backoff
+// instead of waiting for it to elapse.
+func TestRecipientDataCacheCloseDuringBackoff(t *testing.T) {
+	c := newTestCache(t, 10, func(context.Context) (*driver.RecipientData, error) {
+		return nil, errors.New("backend is down")
+	})
+
+	_, err := c.RecipientData(t.Context())
+	require.Error(t, err)
+	c.requireProvisioning(t, 1, 2*time.Second)
+
+	c.Close()
+	// Well below the one second backoff: the goroutine must not sit out the timer.
+	c.requireProvisioning(t, 0, 500*time.Millisecond)
+}
+
+// TestRecipientDataCacheGaugeTracksCacheLevel checks the cache level gauge is only
+// incremented for entries that actually made it into the cache, so that a Close
+// racing a blocked send cannot leave the reported level permanently too high.
+func TestRecipientDataCacheGaugeTracksCacheLevel(t *testing.T) {
+	gauge := &countingGauge{}
+	c := newTestCacheWithMetrics(t, 1, &role.Metrics{CacheLevelGauge: gauge, ProvisionFailuresCount: &countingCounter{}},
+		func(context.Context) (*driver.RecipientData, error) {
+			return newRecipientData("provisioned"), nil
+		})
+
+	_, err := c.RecipientData(t.Context())
+	require.NoError(t, err)
+	c.requireProvisioning(t, 1, 2*time.Second)
+
+	// The goroutine is now parked on the send of an entry the cache will never take.
+	time.Sleep(50 * time.Millisecond)
+	c.Close()
+	c.requireProvisioning(t, 0, 2*time.Second)
+
+	// The gauge must equal the number of entries actually sitting in the channel: the
+	// entry lost to the cancelled send must not have been counted.
+	assert.InDelta(t, 1.0, gauge.value(), 0.001)
+}
+
+// countingGauge is a minimal metrics.Gauge that keeps a running total.
+type countingGauge struct {
+	total atomic.Int64
+}
+
+func (g *countingGauge) With(...string) metrics.Gauge { return g }
+
+func (g *countingGauge) Add(delta float64) { g.total.Add(int64(delta)) }
+
+func (g *countingGauge) Set(value float64) { g.total.Store(int64(value)) }
+
+func (g *countingGauge) value() float64 { return float64(g.total.Load()) }
+
+// countingCounter is a minimal metrics.Counter that keeps a running total.
+type countingCounter struct {
+	total atomic.Int64
+}
+
+func (c *countingCounter) With(...string) metrics.Counter { return c }
+
+func (c *countingCounter) Add(delta float64) { c.total.Add(int64(delta)) }
+
+func (c *countingCounter) value() float64 { return float64(c.total.Load()) }
+
+// TestRecipientDataCacheCountsProvisionFailures checks a failing backend is reported on a
+// counter, not only in the log. A log line alone cannot be alerted on, which is what made
+// this failure mode invisible in production.
+func TestRecipientDataCacheCountsProvisionFailures(t *testing.T) {
+	failures := &countingCounter{}
+	c := newTestCacheWithMetrics(t, 10, &role.Metrics{CacheLevelGauge: &countingGauge{}, ProvisionFailuresCount: failures},
+		func(context.Context) (*driver.RecipientData, error) {
+			return nil, errors.New("backend is down")
+		})
+
+	_, err := c.RecipientData(t.Context())
+	require.Error(t, err)
+
+	// The background loop reports every failed attempt.
+	require.Eventually(t, func() bool {
+		return failures.value() >= 1
+	}, 2*time.Second, 5*time.Millisecond, "the failed provisioning attempt was not counted")
+}

--- a/token/services/identity/role/metrics.go
+++ b/token/services/identity/role/metrics.go
@@ -16,16 +16,33 @@ var (
 		Help:       "Level of the wallet recipient data cache",
 		LabelNames: []string{"network", "channel", "namespace"},
 	}
+
+	// ProvisionFailuresOpts counts failed attempts to pre-provision recipient data.
+	// A rising rate means the identity backend is failing: the cache falls back to
+	// generating recipient data on the request path, which is slower, and the
+	// background loop is retrying. This is the signal to alert on, since the
+	// corresponding log line alone is easy to miss.
+	//
+	// LabelNames must repeat network/channel/namespace: the provider is TMS-wrapped
+	// and binds those three on every metric, so omitting them here panics with
+	// "inconsistent label cardinality" on first use.
+	ProvisionFailuresOpts = metrics.CounterOpts{
+		Name:       "recipient_data_provision_failures_total",
+		Help:       "Failed attempts to pre-provision wallet recipient data",
+		LabelNames: []string{"network", "channel", "namespace"},
+	}
 )
 
 // Metrics contains the metrics for this package
 type Metrics struct {
-	CacheLevelGauge metrics.Gauge
+	CacheLevelGauge        metrics.Gauge
+	ProvisionFailuresCount metrics.Counter
 }
 
 // NewMetrics instantiate the metrics for this package
 func NewMetrics(p metrics.Provider) *Metrics {
 	return &Metrics{
-		CacheLevelGauge: p.NewGauge(CacheLevelOpts),
+		CacheLevelGauge:        p.NewGauge(CacheLevelOpts),
+		ProvisionFailuresCount: p.NewCounter(ProvisionFailuresOpts),
 	}
 }

--- a/token/services/identity/role/registry.go
+++ b/token/services/identity/role/registry.go
@@ -300,8 +300,35 @@ func (r *Registry) WalletByID(ctx context.Context, role idriver.IdentityRoleType
 	return newWallet, nil
 }
 
-// Done releases all the resources allocated by this service.
+// closer is implemented by wallets that hold resources needing an explicit
+// release, such as a background provisioning goroutine. It is declared here,
+// on the consumer side, rather than widening driver.Wallet: only anonymous
+// owner wallets have anything to release, and widening the port would force a
+// no-op Close on every wallet type of every driver.
+type closer interface {
+	Close()
+}
+
+// Done releases all the resources allocated by this service. Wallets created by
+// this registry that hold releasable resources are closed and the wallet cache is
+// dropped, so their background goroutines terminate instead of living for the
+// lifetime of the process.
 func (r *Registry) Done() error {
+	r.WalletMu.Lock()
+	wallets := make([]driver.Wallet, 0, len(r.Wallets))
+	for _, w := range r.Wallets {
+		wallets = append(wallets, w)
+	}
+	r.Wallets = map[string]driver.Wallet{}
+	r.WalletMu.Unlock()
+
+	// Close outside the lock: never hold the registry mutex while calling out.
+	for _, w := range wallets {
+		if c, ok := w.(closer); ok {
+			c.Close()
+		}
+	}
+
 	return r.Role.Done()
 }
 

--- a/token/services/identity/role/registry_test.go
+++ b/token/services/identity/role/registry_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/services/identity/role/mock"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	"github.com/LFDT-Panurus/panurus/token/services/storage"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -338,4 +340,39 @@ func TestLookup_ByIdentityBytesResolvesViaSharedStores(t *testing.T) {
 
 	// resolved through the point query, without a second full scan
 	require.Equal(t, 1, iss.IteratorConfigurationsCallCount())
+}
+
+// closableWallet is a wallet that records whether it has been closed.
+type closableWallet struct {
+	*mock2.Wallet
+	closed atomic.Int32
+}
+
+func (w *closableWallet) Close() { w.closed.Add(1) }
+
+// TestDoneClosesRegisteredWallets checks Done releases the wallets held by the
+// registry, so that background goroutines they own (such as the recipient data
+// provisioning of an anonymous owner wallet) are terminated instead of living for the
+// lifetime of the process.
+func TestDoneClosesRegisteredWallets(t *testing.T) {
+	reg, _, r, _ := newRegistryWithFakes()
+	ctx := t.Context()
+
+	closable := &closableWallet{Wallet: &mock2.Wallet{}}
+	closable.IDReturns("w1")
+	require.NoError(t, reg.RegisterWallet(ctx, "w1", closable))
+
+	// A wallet with no resources to release must simply be skipped.
+	plain := &mock2.Wallet{}
+	plain.IDReturns("w2")
+	require.NoError(t, reg.RegisterWallet(ctx, "w2", plain))
+
+	require.NoError(t, reg.Done())
+
+	assert.Equal(t, int32(1), closable.closed.Load(), "the wallet was not closed exactly once")
+	assert.Equal(t, 1, r.DoneCallCount(), "the role was not released")
+
+	reg.WalletMu.RLock()
+	defer reg.WalletMu.RUnlock()
+	assert.Empty(t, reg.Wallets, "the wallet cache was not dropped")
 }

--- a/token/services/identity/role/wallets.go
+++ b/token/services/identity/role/wallets.go
@@ -536,6 +536,14 @@ func NewAnonymousOwnerWallet(
 	return w, nil
 }
 
+// Close releases the resources held by this wallet, stopping the background
+// recipient data provisioning started by its identity cache. It is idempotent.
+// The wallet remains usable afterwards, it simply no longer pre-provisions
+// pseudonyms. Registry.Done calls this for every wallet it created.
+func (w *AnonymousOwnerWallet) Close() {
+	w.IdentityCache.Close()
+}
+
 // Contains reports whether the provided identity is bound to this anonymous
 // owner wallet according to the wallet registry.
 func (w *AnonymousOwnerWallet) Contains(ctx context.Context, identity Identity) bool {

--- a/token/services/identity/role/wallets_test.go
+++ b/token/services/identity/role/wallets_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/role"
@@ -327,6 +328,9 @@ func TestAnonymousOwnerWallet(t *testing.T) {
 		// Create wallet
 		w, err := role.NewAnonymousOwnerWallet(logger, ip, tv, des, is, "w1", info, 10, &disabled.Provider{})
 		require.NoError(t, err)
+		// The wallet pre-provisions recipient data in the background; release it so the
+		// test does not leave the goroutine behind.
+		t.Cleanup(w.Close)
 
 		return w, ip, tv, is, des
 	}
@@ -352,6 +356,22 @@ func TestAnonymousOwnerWallet(t *testing.T) {
 		id, err := w.GetRecipientIdentity(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, driver.Identity("ownerIdentity"), id)
+	})
+
+	t.Run("Close stops the recipient data provisioning", func(t *testing.T) {
+		// Wait for goroutines released by earlier subtests to exit before counting.
+		requireProvisioningGoroutines(t, 0, 2*time.Second)
+		w, _, _, _, _ := setup(t)
+
+		// Using the wallet starts the background provisioning goroutine.
+		_, err := w.GetRecipientIdentity(t.Context())
+		require.NoError(t, err)
+		requireProvisioningGoroutines(t, 1, 2*time.Second)
+
+		// Closing the wallet must terminate it. Close is idempotent, so the cleanup
+		// registered by setup can still run.
+		w.Close()
+		requireProvisioningGoroutines(t, 0, 2*time.Second)
 	})
 
 	t.Run("RegisterRecipient", func(t *testing.T) {


### PR DESCRIPTION
Both issues are about the same background worker, so they are fixed together in one PR.

**Background.** An anonymous wallet needs a fresh pseudonym for every payment. Making one is slow, so each wallet keeps a small stock of them ready. A background worker refills that stock. There is one worker per wallet. Idemix identities are cached the same way, by a second worker of the same shape.

**#2122 — the worker cannot be stopped.**
Once started, the worker runs until the process exits. There is no way to shut it down. When the stock is full, the worker waits to hand over the next pseudonym, and that wait never ends. So the worker stays alive forever, and it keeps its wallet, its stock, and everything they point to alive with it. Because wallets are created as they are used and never removed, the number of stuck workers grows with usage.
This PR gives the worker a proper shutdown path, so it can be told to stop and it actually exits.

**#2080 — the same worker, plus three more problems.**
1. *A broken backend is invisible.* If pseudonym creation keeps failing, the worker retries immediately, forever. It writes nothing to the log and reports nothing to monitoring. The result is one CPU core at full load and no clue why. This PR makes it log the failure, count it on a new metric, and wait a second between attempts.
2. *A metric slowly becomes wrong.* The counter that reports how full the stock is counts a pseudonym before it is really added. Over time it reports more than the stock actually holds. This PR counts it only once it is really added.
3. *The second cache has the same problem, and its cleanup is unreachable.* The idemix cache already has a shutdown method, but the object holding it is thrown away as soon as it is created, so nothing can ever call that method. This PR keeps the object reachable and calls it during shutdown.

**A defect this PR had to fix in itself.** The idemix cache prepared its cancellation while serving the first request, and read it back while shutting down, with no synchronisation between the two. That was harmless while nothing could call its shutdown method. Making it reachable turned it into a real race, with a worse effect than the race itself: a shutdown that arrived at the wrong moment silently did nothing and left the worker running — the very thing this PR sets out to fix. It is now prepared up front, once, so the two can no longer overlap.

**New metrics.** `recipient_data_provision_failures_total` and `cache_provision_failures_total`, so a failing identity backend can be alerted on instead of only appearing in the logs. Both declare `network`/`channel`/`namespace`, and were checked against a real Prometheus provider behind the TMS wrapper, because a missing label there panics on first use.

**What the two issues share.** Only the first point: giving the worker a way to shut down. Everything else is unique to #2080.

**What is still not solved.** Wallets are never removed once created. So a worker is only released when the whole token service is unloaded, which happens on a public-parameter update. During normal operation nothing releases them. Fixing that means deciding when a wallet is no longer needed, which is a separate change.

**Testing.** 16 new tests. 8 of them were checked against the old code first and do fail there, so they really catch these bugs. Existing tests that used to leave workers running now release them. `make checks`, `make lint`, `./token/...`, `-race`, and repeated shuffled runs are all clean. Docs updated in `docs/services/identity.md`, including a table of the four cache metrics.

Fixes #2122
Fixes #2080