### PR TITLE
fix(network-driver): clamp fallback scan starting block to the first block

### DIFF
--- a/docs/services/network-fabric.md
+++ b/docs/services/network-fabric.md
@@ -357,6 +357,13 @@ resolved independently: if its query cannot be built, does not reach the chainco
 response that cannot be decoded, only that namespace falls back to the block scan. The keys of the
 other namespaces in the same batch are still resolved and delivered.
 
+The block scan itself is the fallback shared by the lookup service and the
+[finality service](../../token/services/network/fabric/finality/deliveryqs.go): it rewinds
+`NumberPastBlocks` blocks behind the last known block and scans forward from there. The starting
+block is computed by [`blockscan.StartingBlock`](../../token/services/network/fabric/blockscan/blockscan.go),
+which clamps the result to `FirstBlock` so that a chain shorter than the rewind window is scanned
+from its first block rather than from an underflowed block number.
+
 ## State Queries
 
 The Fabric implementation provides efficient state querying through the chaincode:

--- a/token/services/network/fabric/blockscan/blockscan.go
+++ b/token/services/network/fabric/blockscan/blockscan.go
@@ -1,0 +1,28 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package blockscan holds the parameters shared by the Fabric services that fall back to
+// scanning past blocks when a lookup misses on the local view of the ledger.
+package blockscan
+
+const (
+	// NumberPastBlocks is how far back a fallback block scan rewinds from the last known block.
+	NumberPastBlocks = 10
+	// FirstBlock is the earliest block a fallback scan may start from.
+	FirstBlock = 1
+)
+
+// StartingBlock returns the block a fallback scan should start from, given the last known block.
+// The subtraction is underflow-safe: on a chain shorter than NumberPastBlocks the result is clamped
+// to FirstBlock instead of wrapping around to a block number near MaxUint64, which would make the
+// scan silently find nothing.
+func StartingBlock(lastBlock uint64) uint64 {
+	if lastBlock < FirstBlock+NumberPastBlocks {
+		return FirstBlock
+	}
+
+	return lastBlock - NumberPastBlocks
+}

--- a/token/services/network/fabric/blockscan/blockscan_test.go
+++ b/token/services/network/fabric/blockscan/blockscan_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockscan_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/blockscan"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartingBlock(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		lastBlock uint64
+		expected  uint64
+	}{
+		{name: "empty chain", lastBlock: 0, expected: blockscan.FirstBlock},
+		{name: "first block only", lastBlock: 1, expected: blockscan.FirstBlock},
+		{name: "younger than the rewind window", lastBlock: 5, expected: blockscan.FirstBlock},
+		{name: "rewind window not yet complete", lastBlock: 10, expected: blockscan.FirstBlock},
+		{name: "exactly one full rewind window", lastBlock: 11, expected: blockscan.FirstBlock},
+		{name: "just past the rewind window", lastBlock: 12, expected: 2},
+		{name: "well past the rewind window", lastBlock: 100, expected: 90},
+		{name: "max block", lastBlock: math.MaxUint64, expected: math.MaxUint64 - blockscan.NumberPastBlocks},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			startingBlock := blockscan.StartingBlock(tc.lastBlock)
+			assert.Equal(t, tc.expected, startingBlock)
+			assert.GreaterOrEqual(t, startingBlock, uint64(blockscan.FirstBlock),
+				"a scan must never start before the first block")
+			assert.LessOrEqual(t, startingBlock, max(tc.lastBlock, uint64(blockscan.FirstBlock)),
+				"a scan must never start after the last known block")
+		})
+	}
+}

--- a/token/services/network/fabric/finality/deliveryqs.go
+++ b/token/services/network/fabric/finality/deliveryqs.go
@@ -14,11 +14,15 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	events2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/events"
+
+	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/blockscan"
 )
 
 const (
-	NumberPastBlocks = 10
-	FirstBlock       = 1
+	// NumberPastBlocks is how far back the fallback block scan rewinds from the last known block.
+	NumberPastBlocks = blockscan.NumberPastBlocks
+	// FirstBlock is the earliest block the fallback scan may start from.
+	FirstBlock = blockscan.FirstBlock
 )
 
 // ErrTxNotFound is the sentinel returned by txLedger when a transaction does not
@@ -98,7 +102,7 @@ func (q *DeliveryScanQueryByID) queryByID(ctx context.Context, keys []driver.TxI
 		return
 	}
 
-	startingBlock := max(FirstBlock, lastBlock-NumberPastBlocks)
+	startingBlock := blockscan.StartingBlock(lastBlock)
 	logger.DebugfContext(ctx, "start scanning blocks starting from [%d], looking for remaining keys [%s]", startingBlock, keySet)
 
 	// start delivery for the future

--- a/token/services/network/fabric/finality/deliveryqs_test.go
+++ b/token/services/network/fabric/finality/deliveryqs_test.go
@@ -206,3 +206,38 @@ func TestQueryByID_TransientError_ContinuesToNextTx(t *testing.T) {
 	assert.Contains(t, received, wantInfo, "tx2 info must be delivered despite tx1 transient error")
 	assert.True(t, scanner.called, "transient error must trigger delivery scan for tx1")
 }
+
+// TestQueryByID_FallbackScanStartingBlock verifies that the fallback block scan never starts from
+// an underflowed block number: on a chain younger than NumberPastBlocks the scan must start from
+// FirstBlock instead of wrapping around to a block near MaxUint64, which would silently find
+// nothing and surface no error.
+func TestQueryByID_FallbackScanStartingBlock(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		lastBlock cdriver.BlockNum
+		expected  uint64
+	}{
+		{name: "young chain clamps to first block", lastBlock: 5, expected: finality.FirstBlock},
+		{name: "mature chain rewinds by the full window", lastBlock: 100, expected: 90},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			scanner := &fakeScanner{}
+			// fakeLedger returns "TXID [tx1] not available" for unknown keys, so tx1 falls back
+			// to the block scan.
+			q := &finality.DeliveryScanQueryByID{
+				Delivery: scanner,
+				Ledger:   &fakeLedger{results: map[string]fakeLedgerResult{}},
+				Mapper:   &fakeMapper{results: map[*fabric.ProcessedTransaction]fakeMapperResult{}},
+			}
+
+			ch, err := q.QueryByID(ctx, tc.lastBlock, evicted("tx1"))
+			require.NoError(t, err)
+			drain(ch)
+
+			require.True(t, scanner.called, "TxNotFound must trigger delivery scan")
+			assert.Equal(t, tc.expected, scanner.startBlock)
+		})
+	}
+}

--- a/token/services/network/fabric/lookup/deliveryqs.go
+++ b/token/services/network/fabric/lookup/deliveryqs.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"slices"
 
+	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/blockscan"
 	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/tcc"
 	slices2 "github.com/LFDT-Panurus/panurus/token/services/utils/slices"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
@@ -20,9 +21,11 @@ import (
 )
 
 const (
-	QueryStates      = tcc.QueryStates
-	NumberPastBlocks = 10
-	FirstBlock       = 1
+	QueryStates = tcc.QueryStates
+	// NumberPastBlocks is how far back the fallback block scan rewinds from the last known block.
+	NumberPastBlocks = blockscan.NumberPastBlocks
+	// FirstBlock is the earliest block the fallback scan may start from.
+	FirstBlock = blockscan.FirstBlock
 )
 
 // stateQuerier is the subset of the Fabric channel used to ask the token chaincode for the
@@ -142,8 +145,7 @@ func (q *DeliveryScanQueryByID) queryByID(ctx context.Context, keys []driver.PKe
 		return
 	}
 
-	startingBlock := max(FirstBlock, lastBlock-NumberPastBlocks)
-	// startingBlock := uint64(0)
+	startingBlock := blockscan.StartingBlock(lastBlock)
 	logger.DebugfContext(ctx, "start scanning blocks starting from [%d], looking for remaining keys [%s]", startingBlock, keySet)
 
 	// start delivery for the future

--- a/token/services/network/fabric/lookup/deliveryqs_test.go
+++ b/token/services/network/fabric/lookup/deliveryqs_test.go
@@ -193,3 +193,33 @@ func TestQueryByID_MissingValueTriggersScan(t *testing.T) {
 	assert.Empty(t, drain(ch))
 	assert.True(t, scanner.called)
 }
+
+// The fallback block scan must never start from an underflowed block number: on a chain younger
+// than NumberPastBlocks it starts from FirstBlock instead of wrapping around to a block near
+// MaxUint64, which would silently find nothing and surface no error.
+func TestQueryByID_FallbackScanStartingBlock(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		lastBlock driver.BlockNum
+		expected  uint64
+	}{
+		{name: "young chain clamps to first block", lastBlock: 5, expected: lookup.FirstBlock},
+		{name: "mature chain rewinds by the full window", lastBlock: 100, expected: 90},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			querier := &fakeQuerier{results: map[driver.Namespace]querierResult{
+				"ns1": {raw: values(t, []byte{})},
+			}}
+			scanner := &fakeScanner{}
+
+			ch, err := newQuery(querier, scanner).QueryByID(t.Context(), tc.lastBlock, evictedFor(map[driver.Namespace]driver.PKey{
+				"ns1": "k1",
+			}))
+			require.NoError(t, err)
+
+			assert.Empty(t, drain(ch))
+			require.True(t, scanner.called, "a missing value must trigger the block scan")
+			assert.Equal(t, tc.expected, scanner.startBlock)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2056

The finality and lookup services both computed the starting block of their fallback block scan as
`max(FirstBlock, lastBlock-NumberPastBlocks)`. `lastBlock` is a `uint64`, so on a chain younger than
`NumberPastBlocks` (10) the subtraction wrapped around and `max` picked a block number near
`MaxUint64`. The scan then found nothing and surfaced no error, silently losing the transaction's
finality outcome (or the looked-up key).

The computation now lives in a new `token/services/network/fabric/blockscan` package, where the
subtraction is guarded so a chain shorter than the rewind window is scanned from `FirstBlock`, and
both services call it instead of duplicating the expression. The same underflow existed in the
lookup copy of the logic (#2054), so extracting the helper removes it there too.

Tests: a table-driven test for `blockscan.StartingBlock` (including 0, 1, 5, 10, 11 and
`MaxUint64`), plus young-chain regression tests for the fallback scan in both `finality` and
`lookup` that assert the scan starts at block 1 rather than at the wrapped value. All three fail
against the previous arithmetic.

`make checks` and `make lint` pass.