### PR TITLE
fix(ttx): give StreamExternalWalletSignerClient's receive goroutine a way out

### DIFF
--- a/docs/services/ttx.md
+++ b/docs/services/ttx.md
@@ -513,6 +513,44 @@ The `CollectEndorsementsView` is responsible for gathering all signatures requir
 *   **Auditor Signatures**: If the TMS is configured with an auditor, the transaction must be approved via the `AuditApproveView`.
 *   **Network Endorsements**: The service delegates to the **Network Service** to obtain backend-specific endorsements (e.g., Fabric chaincode endorsements).
 
+### Streaming signer for external wallets (`external.go`)
+
+When the signing key for a wallet does not live on the node, `ttx.WithExternalWalletSigner(walletID, ews)`
+registers an `ExternalWalletSigner` (`Sign(party, message)` plus `Done()`) that
+`CollectEndorsementsView` calls instead of the local signature service. `external.go` provides an
+implementation of that interface on top of an FSC stream, so the wallet holder can be the
+application that invoked the view over `StreamCallView`:
+
+*   `StreamExternalWalletSignerServer` sits on the view's end of the stream. It is constructed
+    with the view's stream and passed to `WithExternalWalletSigner`; each `Sign` call sends a
+    `SigRequest` message and blocks for the matching `SignResponse`, and `Done` sends a `Done`
+    message once no further signatures are needed.
+*   `StreamExternalWalletSignerClient` sits on the application's end. It is constructed with a
+    `SignerProvider` over the local wallet, and its `Respond()` loop signs each incoming
+    `SigRequest` and writes back a `SignResponse` until the `Done` message arrives.
+
+All three message kinds travel inside a `StreamExternalWalletMsg` envelope (`Type` plus
+JSON-encoded `Raw`).
+
+`Respond()` returns `nil` once the peer signals `Done`. Otherwise it returns the failure that
+terminated the exchange:
+
+*   a signing failure (no signer for the party, or the signer itself failing) or a failure
+    sending the response back;
+*   a failure receiving or JSON-decoding a request. These are detected by the client's internal
+    receive goroutine and handed to `Respond()` over a buffered error channel, so the caller
+    gets the real transport or decoding error. The buffering matters: it lets that goroutine
+    complete its send and exit rather than blocking forever on a channel nobody reads;
+*   `Timeout waiting for stream input exceeded` if no message arrives within the configured
+    timeout. `NewStreamExternalWalletSignerClient` defaults to one hour; use
+    `NewStreamExternalWalletSignerClientWithTimeout` to choose another value. A timeout now means
+    what it says — the stream went quiet — rather than masking a stream error.
+
+However `Respond()` ends, it signals its receive goroutine to stop before returning, so a
+request decoded after the caller has given up is dropped rather than left waiting for a
+consumer that will never come. The client is therefore single-use: once `Respond()` has
+returned, no further signatures are served on that stream.
+
 ## Distribution and Ordering
 
 Once fully endorsed, the transaction metadata is distributed to all recipients so they can track and spend their new tokens. The initiator then uses the `OrderingView` to broadcast the transaction envelope to the network's ordering service.

--- a/token/services/ttx/external.go
+++ b/token/services/ttx/external.go
@@ -8,6 +8,7 @@ package ttx
 
 import (
 	"encoding/json"
+	"sync"
 	"time"
 
 	"github.com/LFDT-Panurus/panurus/token"
@@ -118,21 +119,33 @@ type StreamExternalWalletSignerClient struct {
 	sp      SignerProvider
 	stream  view2.Stream
 	timeout time.Duration
-	input   chan *StreamExternalWalletSignRequest
-	err     chan error
+	// input carries the signature requests decoded by init. It is closed when the remote
+	// wallet signals that no more signatures are required.
+	input chan *StreamExternalWalletSignRequest
+	// err carries the first failure hit by init. It is buffered so that init can always
+	// complete its send and return, even if nobody is receiving anymore.
+	err chan error
+	// done is closed once Respond stops consuming input, so that init never blocks forever
+	// handing over a request that nobody will take.
+	done     chan struct{}
+	doneOnce sync.Once
 }
 
+// NewStreamExternalWalletSignerClient creates a signer client with the default timeout of one hour.
 func NewStreamExternalWalletSignerClient(sp SignerProvider, stream view2.Stream, _ int) *StreamExternalWalletSignerClient {
 	return NewStreamExternalWalletSignerClientWithTimeout(sp, stream, 1*time.Hour)
 }
 
+// NewStreamExternalWalletSignerClientWithTimeout creates a signer client that gives up waiting
+// for the next signature request from the remote wallet after the passed timeout.
 func NewStreamExternalWalletSignerClientWithTimeout(sp SignerProvider, stream view2.Stream, timeout time.Duration) *StreamExternalWalletSignerClient {
 	c := &StreamExternalWalletSignerClient{
 		sp:      sp,
 		stream:  stream,
 		timeout: timeout,
 		input:   make(chan *StreamExternalWalletSignRequest),
-		err:     make(chan error),
+		err:     make(chan error, 1),
+		done:    make(chan struct{}),
 	}
 	go c.init()
 
@@ -158,7 +171,13 @@ func (s *StreamExternalWalletSignerClient) init() {
 
 				return
 			} else {
-				s.input <- req
+				select {
+				case s.input <- req:
+				case <-s.done:
+					logger.Debugf("no responder left for signature request [%d], giving up", i)
+
+					return
+				}
 			}
 		case Done:
 			logger.Debugf("no more signatures required")
@@ -170,7 +189,17 @@ func (s *StreamExternalWalletSignerClient) init() {
 	}
 }
 
+// Respond serves the signature requests sent by the remote wallet until the wallet signals
+// that it is done, a signature cannot be produced, or the stream fails. It returns nil once
+// the remote wallet is done, and otherwise the failure that terminated the exchange: errors
+// hit while receiving or decoding requests are reported by init on s.err and returned here,
+// so the caller sees the real transport or decoding failure rather than a timeout.
+//
+// On return it signals the receive goroutine to stop, so that goroutine never lingers waiting
+// to hand over a request that will no longer be served.
 func (s *StreamExternalWalletSignerClient) Respond() error {
+	defer s.stopConsuming()
+
 	for {
 		select {
 		case req, done := <-s.input:
@@ -185,10 +214,18 @@ func (s *StreamExternalWalletSignerClient) Respond() error {
 				return errors.Wrapf(err, "failed to send back signature, party [%s]", req.Party)
 			}
 			logger.Debugf("process signature request done")
+		case err := <-s.err:
+			return err
 		case <-time.After(s.timeout):
 			return errors.Errorf("Timeout waiting for stream input exceeded: %v", s.timeout)
 		}
 	}
+}
+
+// stopConsuming tells init that no further signature request will be consumed. It is safe to
+// call more than once.
+func (s *StreamExternalWalletSignerClient) stopConsuming() {
+	s.doneOnce.Do(func() { close(s.done) })
 }
 
 func (s *StreamExternalWalletSignerClient) sign(req *StreamExternalWalletSignRequest) (*StreamExternalWalletMsg, error) {

--- a/token/services/ttx/external_internal_test.go
+++ b/token/services/ttx/external_internal_test.go
@@ -1,0 +1,324 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// This white-box (package ttx) file covers StreamExternalWalletSignerClient: the errors that
+// its init goroutine reports on the unexported err channel must reach the caller of Respond
+// instead of being swallowed until the timeout elapses.
+package ttx
+
+import (
+	"bytes"
+	"encoding/json"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recvStep is a single scripted outcome of a call to fakeStream.Recv: either the message to
+// deliver, or the error to return. When after is set, Recv waits for it to be closed before
+// producing the outcome, which lets a test order the stream against Respond's progress.
+type recvStep struct {
+	msg   *StreamExternalWalletMsg
+	err   error
+	after chan struct{}
+}
+
+// fakeStream is a view2.Stream whose Recv calls are scripted. Once the script is exhausted,
+// Recv blocks until the test finishes, mimicking a stream that simply goes quiet. It is used
+// from both the init goroutine (Recv) and the Respond caller (Send), hence the mutex.
+type fakeStream struct {
+	mu      sync.Mutex
+	steps   []recvStep
+	recvIdx int
+	sent    []*StreamExternalWalletMsg
+	sendErr error
+	quiet   chan struct{}
+}
+
+func newFakeStream(t *testing.T, steps ...recvStep) *fakeStream {
+	t.Helper()
+	s := &fakeStream{steps: steps, quiet: make(chan struct{})}
+	// release any Recv still parked on the exhausted script so the init goroutine does not
+	// outlive the test.
+	t.Cleanup(func() { close(s.quiet) })
+
+	return s
+}
+
+func (s *fakeStream) Recv(m any) error {
+	s.mu.Lock()
+	if s.recvIdx >= len(s.steps) {
+		s.mu.Unlock()
+		<-s.quiet
+
+		return errors.New("stream closed")
+	}
+	step := s.steps[s.recvIdx]
+	s.recvIdx++
+	s.mu.Unlock()
+
+	if step.after != nil {
+		select {
+		case <-step.after:
+		case <-s.quiet:
+			return errors.New("stream closed")
+		}
+	}
+	if step.err != nil {
+		return step.err
+	}
+	msg, ok := m.(*StreamExternalWalletMsg)
+	if !ok {
+		return errors.Errorf("unexpected receive target [%T]", m)
+	}
+	*msg = *step.msg
+
+	return nil
+}
+
+func (s *fakeStream) Send(m any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+	msg, ok := m.(*StreamExternalWalletMsg)
+	if !ok {
+		return errors.Errorf("unexpected send value [%T]", m)
+	}
+	s.sent = append(s.sent, msg)
+
+	return nil
+}
+
+func (s *fakeStream) sentMessages() []*StreamExternalWalletMsg {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]*StreamExternalWalletMsg(nil), s.sent...)
+}
+
+// fakeSigner returns a fixed signature, or a fixed error.
+type fakeSigner struct {
+	sigma []byte
+	err   error
+}
+
+func (f *fakeSigner) Sign(_ []byte) ([]byte, error) { return f.sigma, f.err }
+
+// fakeSignerProvider hands out the same signer for every party.
+type fakeSignerProvider struct {
+	signer token.Signer
+	err    error
+}
+
+func (f *fakeSignerProvider) GetSigner(_ view.Identity) (token.Signer, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	return f.signer, nil
+}
+
+func sigRequestMsg(t *testing.T, party view.Identity, message []byte) *StreamExternalWalletMsg {
+	t.Helper()
+	msg, err := NewStreamExternalWalletMsg(SigRequest, &StreamExternalWalletSignRequest{
+		Party:   party,
+		Message: message,
+	})
+	require.NoError(t, err)
+
+	return msg
+}
+
+// respondWithin runs Respond and fails the test if it does not return in time. Every case here
+// is expected to return well before the client timeout; a hang means the error path is broken.
+func respondWithin(t *testing.T, c *StreamExternalWalletSignerClient, d time.Duration) error {
+	t.Helper()
+	res := make(chan error, 1)
+	go func() { res <- c.Respond() }()
+	select {
+	case err := <-res:
+		return err
+	case <-time.After(d):
+		t.Fatal("Respond did not return in time")
+
+		return nil
+	}
+}
+
+// TestStreamExternalWalletSignerClientErrChannelIsBuffered guards the fix for the goroutine
+// leak: with an unbuffered channel the init goroutine blocks forever on its send.
+func TestStreamExternalWalletSignerClientErrChannelIsBuffered(t *testing.T) {
+	c := NewStreamExternalWalletSignerClientWithTimeout(
+		&fakeSignerProvider{signer: &fakeSigner{sigma: []byte("sigma")}},
+		newFakeStream(t),
+		time.Hour,
+	)
+	assert.Equal(t, 1, cap(c.err), "err channel must be buffered so init can always exit")
+}
+
+// TestStreamExternalWalletSignerClientRespondReturnsRecvError checks that a transport failure
+// surfaces as the real error and not as a timeout.
+func TestStreamExternalWalletSignerClientRespondReturnsRecvError(t *testing.T) {
+	stream := newFakeStream(t, recvStep{err: errors.New("connection reset")})
+	c := NewStreamExternalWalletSignerClientWithTimeout(
+		&fakeSignerProvider{signer: &fakeSigner{sigma: []byte("sigma")}},
+		stream,
+		time.Hour,
+	)
+
+	err := respondWithin(t, c, 5*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to receive signature request [0]")
+	assert.Contains(t, err.Error(), "connection reset")
+	assert.NotContains(t, err.Error(), "Timeout waiting for stream input")
+}
+
+// TestStreamExternalWalletSignerClientRespondReturnsUnmarshalError checks the same for a
+// malformed SigRequest payload.
+func TestStreamExternalWalletSignerClientRespondReturnsUnmarshalError(t *testing.T) {
+	stream := newFakeStream(t, recvStep{msg: &StreamExternalWalletMsg{
+		Type: SigRequest,
+		Raw:  []byte("not-json"),
+	}})
+	c := NewStreamExternalWalletSignerClientWithTimeout(
+		&fakeSignerProvider{signer: &fakeSigner{sigma: []byte("sigma")}},
+		stream,
+		time.Hour,
+	)
+
+	err := respondWithin(t, c, 5*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get unmarshal msg type SigRequest")
+	assert.NotContains(t, err.Error(), "Timeout waiting for stream input")
+}
+
+// TestStreamExternalWalletSignerClientRespondSignsUntilDone covers the happy path: every
+// request is signed and answered, and Done terminates the exchange without error.
+func TestStreamExternalWalletSignerClientRespondSignsUntilDone(t *testing.T) {
+	party := view.Identity("alice")
+	stream := newFakeStream(t,
+		recvStep{msg: sigRequestMsg(t, party, []byte("msg-0"))},
+		recvStep{msg: sigRequestMsg(t, party, []byte("msg-1"))},
+		recvStep{msg: &StreamExternalWalletMsg{Type: Done}},
+	)
+	c := NewStreamExternalWalletSignerClientWithTimeout(
+		&fakeSignerProvider{signer: &fakeSigner{sigma: []byte("sigma")}},
+		stream,
+		time.Hour,
+	)
+
+	require.NoError(t, respondWithin(t, c, 5*time.Second))
+
+	sent := stream.sentMessages()
+	require.Len(t, sent, 2)
+	for _, msg := range sent {
+		assert.Equal(t, SignResponse, msg.Type)
+		response := &StreamExternalWalletSignResponse{}
+		require.NoError(t, json.Unmarshal(msg.Raw, response))
+		assert.Equal(t, []byte("sigma"), response.Sigma)
+	}
+}
+
+// TestStreamExternalWalletSignerClientRespondReturnsSignError checks that a signing failure is
+// reported to the caller.
+func TestStreamExternalWalletSignerClientRespondReturnsSignError(t *testing.T) {
+	stream := newFakeStream(t, recvStep{msg: sigRequestMsg(t, view.Identity("alice"), []byte("msg"))})
+	c := NewStreamExternalWalletSignerClientWithTimeout(
+		&fakeSignerProvider{signer: &fakeSigner{err: errors.New("hsm offline")}},
+		stream,
+		time.Hour,
+	)
+
+	err := respondWithin(t, c, 5*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hsm offline")
+}
+
+// requireInitExited waits until no goroutine is parked inside the client's receive loop. It
+// inspects the stack rather than a goroutine count so that unrelated goroutines cannot make it
+// pass or fail by accident.
+func requireInitExited(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	const frame = "(*StreamExternalWalletSignerClient).init"
+	deadline := time.Now().Add(timeout)
+	for {
+		buf := make([]byte, 1<<20)
+		dump := buf[:runtime.Stack(buf, true)]
+		if !bytes.Contains(dump, []byte(frame)) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("receive goroutine still parked after %s:\n%s", timeout, dump)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestStreamExternalWalletSignerClientInitExitsWhenResponderStopped covers the other way the
+// receive goroutine could be stranded: a request decoded after Respond has already returned has
+// nobody to receive it, so the goroutine must give up instead of blocking on the handover.
+//
+// The gate makes the ordering deterministic: the second request is only delivered to the
+// receive goroutine once Respond has returned.
+func TestStreamExternalWalletSignerClientInitExitsWhenResponderStopped(t *testing.T) {
+	party := view.Identity("alice")
+	gate := make(chan struct{})
+	stream := newFakeStream(t,
+		recvStep{msg: sigRequestMsg(t, party, []byte("msg-0"))},
+		recvStep{msg: sigRequestMsg(t, party, []byte("msg-1")), after: gate},
+	)
+	c := NewStreamExternalWalletSignerClientWithTimeout(
+		&fakeSignerProvider{err: errors.New("hsm offline")},
+		stream,
+		time.Hour,
+	)
+
+	// the first request is consumed, then signing fails and Respond gives up
+	err := respondWithin(t, c, 5*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hsm offline")
+
+	close(gate)
+	requireInitExited(t, 5*time.Second)
+}
+
+// TestStreamExternalWalletSignerClientRespondIsIdempotentOnRepeatedCalls checks that calling
+// Respond again after it returned does not panic on the already-signalled done channel.
+func TestStreamExternalWalletSignerClientRespondIsIdempotentOnRepeatedCalls(t *testing.T) {
+	stream := newFakeStream(t, recvStep{msg: &StreamExternalWalletMsg{Type: Done}})
+	c := NewStreamExternalWalletSignerClientWithTimeout(
+		&fakeSignerProvider{signer: &fakeSigner{sigma: []byte("sigma")}},
+		stream,
+		10*time.Millisecond,
+	)
+
+	require.NoError(t, respondWithin(t, c, 5*time.Second))
+	// s.input is closed by now, so the second call returns nil straight away
+	require.NoError(t, respondWithin(t, c, 5*time.Second))
+}
+
+// TestStreamExternalWalletSignerClientRespondTimesOut checks that the timeout still applies
+// when the remote wallet stops talking without failing the stream.
+func TestStreamExternalWalletSignerClientRespondTimesOut(t *testing.T) {
+	c := NewStreamExternalWalletSignerClientWithTimeout(
+		&fakeSignerProvider{signer: &fakeSigner{sigma: []byte("sigma")}},
+		newFakeStream(t),
+		10*time.Millisecond,
+	)
+
+	err := respondWithin(t, c, 5*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Timeout waiting for stream input")
+}


### PR DESCRIPTION
## The problem

`StreamExternalWalletSignerClient` starts a background goroutine. This goroutine reads signature requests from the stream and passes them to `Respond()`. It uses two channels to do this. On both channels, the goroutine could stop forever.

**1. Errors were lost (#2132).** The `err` channel had no buffer, and no code ever read from it. So when the stream failed, or when a request could not be decoded, the goroutine stopped while sending the error. The error never arrived. `Respond()` waited until its timeout (one hour by default), and then returned a timeout error. But the real cause was a broken stream, not a timeout.

**2. Late requests had no reader (#2141).** The `input` channel had the same problem. After `Respond()` returned, no code read from this channel. So if the goroutine decoded one more request, it stopped while passing it.

In both cases the goroutine never ends. It keeps the stream, the two channels and the signer in memory until the process stops. Each failed stream adds one more.

## The fix

- Give `err` a buffer of 1, and read it in `Respond()` with `case err := <-s.err:`. Now the goroutine can finish its send and end, and the caller gets the real error.
- `Respond()` closes a `done` channel when it stops reading. The goroutine uses `select` on `done` when it passes a request, so it can end instead of waiting.

The goroutine can now end at every point where it waits.

Fixes #2132
Fixes #2141

## Why one PR

Both problems are in the same goroutine: one blocked send on each of its two channels. Both fixes change the same `select` in `Respond()`. If we fix only #2132, the goroutine can still stop forever.

## Testing

The new file `token/services/ttx/external_internal_test.go` has 8 tests. If you undo the changes in `external.go`, 4 of them fail: two with `Respond did not return in time`, one on the channel buffer size, and one that finds the goroutine still waiting in `[chan send]`. So both fixes are needed. `make checks` passes, and `-race` passes.

**Not included:** the goroutine can still wait inside `stream.Recv`. This wait ends when the stream ends. We cannot stop it here, because the `view2.Stream` interface has only `Recv` and `Send` — no context and no `Close`. #2128 is not changed.
