### PR TITLE
fix(idemix): reject out-of-range curve ids in audit info

### DIFF
--- a/docs/services/identity.md
+++ b/docs/services/identity.md
@@ -296,6 +296,45 @@ An extension of Idemix that uses a **commitment to the Enrollment ID (EID)** as 
 | **Identity Size** | Large (~several KB) | Small (~32-64 bytes) |
 | **Storage Overhead** | High | Low |
 
+#### Audit Info Deserialization (Idemix and IdemixNym)
+
+Audit info is JSON and can arrive from a counterparty (recipient registration, auditing
+flows), so both `crypto.AuditInfo.FromBytes`
+(`token/services/identity/idemix/crypto/audit.go`) and `nym.AuditInfo.FromBytes`
+(`token/services/identity/idemixnym/nym/audit.go`) treat their input as untrusted and reject
+malformed payloads with an error.
+
+`EidNymAuditData` and `RhNymAuditData` embed `mathlib` curve elements, which JSON-encode as
+a curve ID plus the raw element bytes:
+
+```json
+{"EidNymAuditData":{"Nym":{"curve":3,"element":"..."},"Rand":{...},"Attr":{...}}}
+```
+
+`mathlib`'s `UnmarshalJSON` uses that curve ID to index its internal curve table **without a
+bounds check**, so an out-of-range ID raises an `index out of range` panic from inside
+`encoding/json`. Both `FromBytes` implementations therefore run their decode through
+`crypto.UnmarshalAuditInfo`, which recovers that panic and returns it as an ordinary error:
+
+```go
+return crypto.UnmarshalAuditInfo(func() error {
+    return json.Unmarshal(raw, a)
+})
+```
+
+The guard wraps the real decode rather than pre-validating the payload's curve IDs, because
+`mathlib` runs *during* `encoding/json`'s traversal: a separate validation pass has to
+reproduce that traversal exactly to see every curve element the decode reaches, including
+ones that never appear in the decoded result (a duplicate key overwriting an earlier value,
+input after the first JSON value, a curve element following a type error). The same defect
+is contained the same way in `FromG1Proto`
+(`token/core/zkatdlog/nogh/protos-go/utils/proto.go`).
+
+Where curve IDs arrive as plain data rather than through a third-party unmarshaler, prefer an
+explicit bounds check instead — see `curveAt` in
+`token/core/common/encoding/asn1/asn1.go` and `PublicParams.Validate` in
+`token/core/zkatdlog/nogh/v1/setup/setup.go`.
+
 ### Other Identity Types
 
 The architecture supports specialized identity types for complex use cases:

--- a/token/services/identity/idemix/crypto/audit.go
+++ b/token/services/identity/idemix/crypto/audit.go
@@ -45,7 +45,11 @@ func (a *AuditInfo) Bytes() ([]byte, error) {
 
 // FromBytes deserializes the AuditInfo from JSON format.
 func (a *AuditInfo) FromBytes(raw []byte) error {
-	return json.Unmarshal(raw, a)
+	// raw is untrusted and the pseudonym audit data holds mathlib curve elements,
+	// which panic on an out-of-range curve ID instead of rejecting it.
+	return UnmarshalAuditInfo(func() error {
+		return json.Unmarshal(raw, a)
+	})
 }
 
 // EnrollmentID returns the enrollment ID from Attributes[2].

--- a/token/services/identity/idemix/crypto/audit_fuzz_test.go
+++ b/token/services/identity/idemix/crypto/audit_fuzz_test.go
@@ -7,9 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package crypto
 
 import (
+	"strconv"
 	"testing"
 
 	idemix "github.com/IBM/idemix/bccsp/types"
+	math "github.com/IBM/mathlib"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,13 +25,14 @@ const maxFuzzAuditInfoBytes = 64 << 10
 // indexed into Attributes, and Match dereferenced EidNymAuditData/
 // RhNymAuditData without nil checks).
 func FuzzDeserializeAuditInfoNoPanic(f *testing.F) {
+	attributes := [][]byte{
+		[]byte("attr0"),
+		[]byte("attr1"),
+		[]byte("enrollment-id"),
+		[]byte("revocation-handle"),
+	}
 	valid := &AuditInfo{
-		Attributes: [][]byte{
-			[]byte("attr0"),
-			[]byte("attr1"),
-			[]byte("enrollment-id"),
-			[]byte("revocation-handle"),
-		},
+		Attributes:      attributes,
 		Schema:          "test-schema",
 		EidNymAuditData: &idemix.AttrNymAuditData{},
 		RhNymAuditData:  &idemix.AttrNymAuditData{},
@@ -42,6 +45,40 @@ func FuzzDeserializeAuditInfoNoPanic(f *testing.F) {
 	f.Add([]byte("{}"))
 	f.Add([]byte(`{"Attributes":[[0],[1],[101,105,100],[114,104]],"Schema":""}`))
 	f.Add([]byte(`{"Attributes":[[0]]}`))
+
+	// The seeds above leave the pseudonym audit data zero-valued, which marshals
+	// its mathlib fields as JSON null and so never reaches their UnmarshalJSON.
+	// Seed populated curve elements too, along with a curve ID no curve is
+	// registered under: mathlib indexes math.Curves with that ID unchecked, so
+	// this is the input class that used to panic instead of being rejected.
+	curve := math.Curves[math.BLS12_381]
+	populated := &AuditInfo{
+		Attributes: attributes,
+		Schema:     "test-schema",
+		EidNymAuditData: &idemix.AttrNymAuditData{
+			Nym:  curve.GenG1,
+			Rand: curve.NewZrFromInt(7),
+			Attr: curve.NewZrFromInt(11),
+		},
+		RhNymAuditData: &idemix.AttrNymAuditData{
+			Nym:  curve.GenG1,
+			Rand: curve.NewZrFromInt(13),
+			Attr: curve.NewZrFromInt(17),
+		},
+	}
+	populatedBytes, err := populated.Bytes()
+	require.NoError(f, err)
+	f.Add(populatedBytes)
+	f.Add([]byte(`{"EidNymAuditData":{"Nym":{"curve":999999,"element":"AQID"}}}`))
+	f.Add([]byte(`{"EidNymAuditData":{"Rand":{"curve":-1,"element":"AQID"}}}`))
+	f.Add([]byte(`{"RhNymAuditData":{"Attr":{"curve":` + strconv.Itoa(len(math.Curves)) + `,"element":"AQID"}}}`))
+	// Out-of-range curve ids that a pre-validating version of the guard failed to
+	// see, because encoding/json reaches them but they do not survive into the
+	// decoded result. See TestDeserializeAuditInfoOutOfRangeCurveIDEvasions.
+	f.Add([]byte(`{"EidNymAuditData":5,"RhNymAuditData":{"Nym":{"curve":999999,"element":"AQID"}}}`))
+	f.Add([]byte(`{"RhNymAuditData":{"Attr":{"curve":9}}}0`))
+	f.Add([]byte(`{"EidNymAuditData":{"Nym":{"curve":999999,"element":"AQID"},"Nym":null}}`))
+	f.Add([]byte(`{"eidnymauditdata":{"nym":{"CURVE":999999,"element":"AQID"}}}`))
 
 	f.Fuzz(func(t *testing.T, raw []byte) {
 		if len(raw) > maxFuzzAuditInfoBytes {

--- a/token/services/identity/idemix/crypto/unmarshal.go
+++ b/token/services/identity/idemix/crypto/unmarshal.go
@@ -1,0 +1,37 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package crypto
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// UnmarshalAuditInfo runs decode, converting a panic raised while decoding into
+// an ordinary error.
+//
+// Audit info holds mathlib curve elements, whose UnmarshalJSON indexes mathlib's
+// internal curve table with the "curve" field taken straight from the payload,
+// without bounds-checking it (see marshaler.go in github.com/IBM/mathlib) — so an
+// out-of-range curve ID panics instead of being rejected. mathlib v0.3.0 is the
+// newest published version, so this has to be contained here. The same defect is
+// contained the same way in FromG1Proto, in
+// token/core/zkatdlog/nogh/protos-go/utils.
+//
+// The recover deliberately wraps the real decode rather than pre-validating the
+// payload: mathlib runs during encoding/json's traversal, and a separate
+// validation pass would have to reproduce that traversal exactly to see every
+// curve element it decodes — including ones a later duplicate key overwrites,
+// which never appear in the decoded result at all.
+func UnmarshalAuditInfo(decode func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.Errorf("failed to unmarshal audit info: caught panic [%v]", r)
+		}
+	}()
+
+	return decode()
+}

--- a/token/services/identity/idemix/crypto/unmarshal_test.go
+++ b/token/services/identity/idemix/crypto/unmarshal_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package crypto
+
+import (
+	"strconv"
+	"testing"
+
+	csp "github.com/IBM/idemix/bccsp/types"
+	math "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// auditInfoWithCurveID returns audit info JSON whose EID pseudonym audit data
+// carries the given curve ID in the named field. The curve ID goes in verbatim,
+// so it can be a value no curve is registered under.
+func auditInfoWithCurveID(field string, curveID int) []byte {
+	return []byte(`{"EidNymAuditData":{"` + field + `":{"curve":` +
+		strconv.Itoa(curveID) + `,"element":"AQID"}},"Schema":"test-schema"}`)
+}
+
+// TestDeserializeAuditInfoOutOfRangeCurveID covers the curve IDs no curve is
+// registered under. mathlib uses each of them to index its curve table, so before
+// the guard every one of these payloads killed the process with an
+// "index out of range" panic rather than being rejected.
+func TestDeserializeAuditInfoOutOfRangeCurveID(t *testing.T) {
+	for _, curveID := range []int{-1, len(math.Curves), len(math.Curves) + 1, 999999} {
+		for _, field := range []string{"Nym", "Rand", "Attr"} {
+			t.Run(field+"/"+strconv.Itoa(curveID), func(t *testing.T) {
+				raw := auditInfoWithCurveID(field, curveID)
+
+				var err error
+				require.NotPanics(t, func() {
+					_, err = DeserializeAuditInfo(raw)
+				})
+				require.Error(t, err)
+
+				require.NotPanics(t, func() {
+					err = (&AuditInfo{}).FromBytes(raw)
+				})
+				require.Error(t, err)
+			})
+		}
+	}
+}
+
+// TestDeserializeAuditInfoOutOfRangeCurveIDEvasions collects payloads that hid an
+// out-of-range curve ID from an earlier version of this guard, which pre-validated
+// the raw bytes with its own decode pass instead of wrapping the real one. Each
+// exploits a way that pass diverged from what encoding/json actually traverses,
+// and each panicked while the pre-validation reported the payload as clean.
+func TestDeserializeAuditInfoOutOfRangeCurveIDEvasions(t *testing.T) {
+	for name, raw := range map[string]string{
+		// json.Unmarshal validates the whole input up front and decodes nothing on
+		// a syntax error, but FromBytes' decoder reads one value and ignores what
+		// follows it. Found by FuzzDeserializeAuditInfoNoPanic.
+		"trailing garbage": `{"RhNymAuditData":{"Attr":{"curve":9}}}0`,
+		// mathlib's UnmarshalJSON runs on every occurrence of a key, so the first
+		// one panics even though only the last survives in the decoded result.
+		"duplicate outer key": `{"EidNymAuditData":{"Nym":{"curve":999999,"element":"AQID"}},` +
+			`"EidNymAuditData":{"Nym":null}}`,
+		"duplicate inner key": `{"EidNymAuditData":{"Nym":{"curve":999999,"element":"AQID"},"Nym":null}}`,
+		// encoding/json records a type error and keeps decoding, so the curve
+		// element after it is still reached.
+		"type error first": `{"EidNymAuditData":5,"RhNymAuditData":{"Nym":{"curve":999999,"element":"AQID"}}}`,
+		// Key matching is case-insensitive.
+		"unexpected key casing": `{"eidnymauditdata":{"nym":{"CURVE":999999,"element":"AQID"}}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var err error
+			require.NotPanics(t, func() {
+				_, err = DeserializeAuditInfo([]byte(raw))
+			})
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestUnmarshalAuditInfo covers the guard on its own: a decode that panics becomes
+// an error naming the panic, and anything else is passed through untouched.
+func TestUnmarshalAuditInfo(t *testing.T) {
+	err := UnmarshalAuditInfo(func() error {
+		panic("boom")
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "caught panic")
+	assert.Contains(t, err.Error(), "boom")
+
+	sentinel := errors.New("decode failed")
+	assert.Equal(t, sentinel, UnmarshalAuditInfo(func() error { return sentinel }))
+	require.NoError(t, UnmarshalAuditInfo(func() error { return nil }))
+}
+
+// TestAuditInfoPopulatedCurveElementsRoundTrip makes sure the guard does not get
+// in the way of audit info that actually carries curve elements — the case the
+// fuzz seed corpus used to miss, since a zero-value AttrNymAuditData marshals its
+// mathlib fields as JSON null and never reaches their UnmarshalJSON.
+func TestAuditInfoPopulatedCurveElementsRoundTrip(t *testing.T) {
+	for curveID := range math.Curves {
+		t.Run(strconv.Itoa(curveID), func(t *testing.T) {
+			curve := math.Curves[curveID]
+			auditData := func() *csp.AttrNymAuditData {
+				return &csp.AttrNymAuditData{
+					Nym:  curve.GenG1,
+					Rand: curve.NewZrFromInt(7),
+					Attr: curve.NewZrFromInt(11),
+				}
+			}
+			auditInfo := &AuditInfo{
+				Attributes: [][]byte{
+					[]byte("attr0"),
+					[]byte("attr1"),
+					[]byte("enrollment-id"),
+					[]byte("revocation-handle"),
+				},
+				Schema:          "test-schema",
+				EidNymAuditData: auditData(),
+				RhNymAuditData:  auditData(),
+			}
+			raw, err := auditInfo.Bytes()
+			require.NoError(t, err)
+
+			deserialized, err := DeserializeAuditInfo(raw)
+			require.NoError(t, err)
+			assert.Equal(t, auditInfo.EnrollmentID(), deserialized.EnrollmentID())
+			assert.Equal(t, auditInfo.RevocationHandle(), deserialized.RevocationHandle())
+			assert.True(t, auditInfo.EidNymAuditData.Nym.Equals(deserialized.EidNymAuditData.Nym))
+			assert.True(t, auditInfo.EidNymAuditData.Rand.Equals(deserialized.EidNymAuditData.Rand))
+			assert.True(t, auditInfo.RhNymAuditData.Attr.Equals(deserialized.RhNymAuditData.Attr))
+		})
+	}
+}
+
+// TestDeserializeAuditInfoInRangeCurveIDAccepted checks the guard does not turn
+// every curve ID into an error: the boundary IDs a curve is registered under are
+// still decoded.
+func TestDeserializeAuditInfoInRangeCurveIDAccepted(t *testing.T) {
+	for _, curveID := range []int{0, len(math.Curves) - 1} {
+		t.Run(strconv.Itoa(curveID), func(t *testing.T) {
+			curve := math.Curves[curveID]
+			raw, err := (&AuditInfo{
+				Attributes: [][]byte{{0}, {1}, []byte("eid"), []byte("rh")},
+				EidNymAuditData: &csp.AttrNymAuditData{
+					Nym: curve.GenG1, Rand: curve.NewZrFromInt(1), Attr: curve.NewZrFromInt(2),
+				},
+				RhNymAuditData: &csp.AttrNymAuditData{
+					Nym: curve.GenG1, Rand: curve.NewZrFromInt(3), Attr: curve.NewZrFromInt(4),
+				},
+			}).Bytes()
+			require.NoError(t, err)
+
+			ai, err := DeserializeAuditInfo(raw)
+			require.NoError(t, err)
+			assert.Equal(t, curveID, int(ai.EidNymAuditData.Nym.CurveID()))
+		})
+	}
+}

--- a/token/services/identity/idemixnym/nym/audit.go
+++ b/token/services/identity/idemixnym/nym/audit.go
@@ -22,7 +22,12 @@ type AuditInfo struct {
 
 // FromBytes deserializes the AuditInfo from JSON format.
 func (a *AuditInfo) FromBytes(raw []byte) error {
-	return json.Unmarshal(raw, a)
+	// The embedded crypto.AuditInfo's fields are inlined into this struct's JSON,
+	// so this decode reaches the panicking mathlib curve elements itself rather
+	// than going through crypto.AuditInfo.FromBytes. Guard it here too.
+	return crypto.UnmarshalAuditInfo(func() error {
+		return json.Unmarshal(raw, a)
+	})
 }
 
 func (a *AuditInfo) Match(ctx context.Context, id []byte) error {

--- a/token/services/identity/idemixnym/nym/audit_fuzz_test.go
+++ b/token/services/identity/idemixnym/nym/audit_fuzz_test.go
@@ -8,9 +8,11 @@ package nym
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	idemix "github.com/IBM/idemix/bccsp/types"
+	math "github.com/IBM/mathlib"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/idemix/crypto"
 	"github.com/stretchr/testify/require"
 )
@@ -25,14 +27,15 @@ const maxFuzzNymAuditInfoBytes = 64 << 10
 // RevocationHandle unconditionally indexed into Attributes, and Match
 // dereferenced EidNymAuditData/RhNymAuditData without nil checks).
 func FuzzDeserializeAuditInfoNoPanic(f *testing.F) {
+	attributes := [][]byte{
+		[]byte("attr0"),
+		[]byte("attr1"),
+		[]byte("enrollment-id"),
+		[]byte("revocation-handle"),
+	}
 	valid := &AuditInfo{
 		AuditInfo: &crypto.AuditInfo{
-			Attributes: [][]byte{
-				[]byte("attr0"),
-				[]byte("attr1"),
-				[]byte("enrollment-id"),
-				[]byte("revocation-handle"),
-			},
+			Attributes:      attributes,
 			Schema:          "test-schema",
 			EidNymAuditData: &idemix.AttrNymAuditData{},
 			RhNymAuditData:  &idemix.AttrNymAuditData{},
@@ -47,6 +50,43 @@ func FuzzDeserializeAuditInfoNoPanic(f *testing.F) {
 	f.Add([]byte("{}"))
 	f.Add([]byte(`{"IdemixSignature":"c2ln"}`))
 	f.Add([]byte(`{"AuditInfo":{"Attributes":[[0]]},"IdemixSignature":"c2ln"}`))
+
+	// The seeds above leave the pseudonym audit data zero-valued, which marshals
+	// its mathlib fields as JSON null and so never reaches their UnmarshalJSON.
+	// Seed populated curve elements too, along with a curve ID no curve is
+	// registered under: mathlib indexes math.Curves with that ID unchecked, so
+	// this is the input class that used to panic instead of being rejected.
+	curve := math.Curves[math.BLS12_381]
+	populated := &AuditInfo{
+		AuditInfo: &crypto.AuditInfo{
+			Attributes: attributes,
+			Schema:     "test-schema",
+			EidNymAuditData: &idemix.AttrNymAuditData{
+				Nym:  curve.GenG1,
+				Rand: curve.NewZrFromInt(7),
+				Attr: curve.NewZrFromInt(11),
+			},
+			RhNymAuditData: &idemix.AttrNymAuditData{
+				Nym:  curve.GenG1,
+				Rand: curve.NewZrFromInt(13),
+				Attr: curve.NewZrFromInt(17),
+			},
+		},
+		IdemixSignature: []byte("signature"),
+	}
+	populatedBytes, err := json.Marshal(populated)
+	require.NoError(f, err)
+	f.Add(populatedBytes)
+	f.Add([]byte(`{"EidNymAuditData":{"Nym":{"curve":999999,"element":"AQID"}},"IdemixSignature":"c2ln"}`))
+	f.Add([]byte(`{"EidNymAuditData":{"Rand":{"curve":-1,"element":"AQID"}},"IdemixSignature":"c2ln"}`))
+	f.Add([]byte(`{"RhNymAuditData":{"Attr":{"curve":` + strconv.Itoa(len(math.Curves)) + `,"element":"AQID"}},"IdemixSignature":"c2ln"}`))
+	// Out-of-range curve ids that a pre-validating version of the guard failed to
+	// see, because encoding/json reaches them but they do not survive into the
+	// decoded result. See TestDeserializeAuditInfoOutOfRangeCurveIDEvasions.
+	f.Add([]byte(`{"EidNymAuditData":5,"RhNymAuditData":{"Nym":{"curve":999999,"element":"AQID"}},"IdemixSignature":"c2ln"}`))
+	f.Add([]byte(`{"RhNymAuditData":{"Attr":{"curve":9}},"IdemixSignature":"c2ln"}0`))
+	f.Add([]byte(`{"EidNymAuditData":{"Nym":{"curve":999999,"element":"AQID"},"Nym":null},"IdemixSignature":"c2ln"}`))
+	f.Add([]byte(`{"eidnymauditdata":{"nym":{"CURVE":999999,"element":"AQID"}},"idemixsignature":"c2ln"}`))
 
 	f.Fuzz(func(t *testing.T, raw []byte) {
 		if len(raw) > maxFuzzNymAuditInfoBytes {

--- a/token/services/identity/idemixnym/nym/unmarshal_test.go
+++ b/token/services/identity/idemixnym/nym/unmarshal_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package nym
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	csp "github.com/IBM/idemix/bccsp/types"
+	math "github.com/IBM/mathlib"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/idemix/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeserializeAuditInfoOutOfRangeCurveID covers the curve IDs no curve is
+// registered under. AuditInfo embeds *crypto.AuditInfo, so its pseudonym audit
+// data is inlined at the top level of this JSON and this decode reaches the
+// panicking mathlib elements itself; before the guard, each of these payloads
+// killed the process with an "index out of range" panic.
+func TestDeserializeAuditInfoOutOfRangeCurveID(t *testing.T) {
+	for _, curveID := range []int{-1, len(math.Curves), 999999} {
+		for _, field := range []string{"Nym", "Rand", "Attr"} {
+			t.Run(field+"/"+strconv.Itoa(curveID), func(t *testing.T) {
+				raw := []byte(`{"EidNymAuditData":{"` + field + `":{"curve":` +
+					strconv.Itoa(curveID) + `,"element":"AQID"}},"IdemixSignature":"c2ln"}`)
+
+				var (
+					result *AuditInfo
+					err    error
+				)
+				require.NotPanics(t, func() {
+					result, err = DeserializeAuditInfo(raw)
+				})
+				require.Error(t, err)
+				assert.Nil(t, result)
+
+				require.NotPanics(t, func() {
+					err = (&AuditInfo{}).FromBytes(raw)
+				})
+				require.Error(t, err)
+			})
+		}
+	}
+}
+
+// TestDeserializeAuditInfoOutOfRangeCurveIDEvasions mirrors the crypto package's
+// test of the same name: payloads that hid an out-of-range curve ID from an earlier
+// version of this guard, which pre-validated the raw bytes with its own decode pass
+// instead of wrapping the real one.
+func TestDeserializeAuditInfoOutOfRangeCurveIDEvasions(t *testing.T) {
+	for name, raw := range map[string]string{
+		"trailing garbage": `{"RhNymAuditData":{"Attr":{"curve":9}},"IdemixSignature":"c2ln"}0`,
+		"duplicate outer key": `{"EidNymAuditData":{"Nym":{"curve":999999,"element":"AQID"}},` +
+			`"EidNymAuditData":{"Nym":null},"IdemixSignature":"c2ln"}`,
+		"duplicate inner key": `{"EidNymAuditData":{"Nym":{"curve":999999,"element":"AQID"},` +
+			`"Nym":null},"IdemixSignature":"c2ln"}`,
+		"type error first": `{"EidNymAuditData":5,"RhNymAuditData":` +
+			`{"Nym":{"curve":999999,"element":"AQID"}},"IdemixSignature":"c2ln"}`,
+		"unexpected key casing": `{"eidnymauditdata":{"nym":{"CURVE":999999,"element":"AQID"}},` +
+			`"idemixsignature":"c2ln"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var err error
+			require.NotPanics(t, func() {
+				_, err = DeserializeAuditInfo([]byte(raw))
+			})
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestDeserializeAuditInfoPopulatedCurveElementsRoundTrip makes sure the guard does
+// not get in the way of audit info that actually carries curve elements.
+func TestDeserializeAuditInfoPopulatedCurveElementsRoundTrip(t *testing.T) {
+	for curveID := range math.Curves {
+		t.Run(strconv.Itoa(curveID), func(t *testing.T) {
+			curve := math.Curves[curveID]
+			auditData := func() *csp.AttrNymAuditData {
+				return &csp.AttrNymAuditData{
+					Nym:  curve.GenG1,
+					Rand: curve.NewZrFromInt(7),
+					Attr: curve.NewZrFromInt(11),
+				}
+			}
+			auditInfo := &AuditInfo{
+				AuditInfo: &crypto.AuditInfo{
+					Attributes: [][]byte{
+						[]byte("attr0"),
+						[]byte("attr1"),
+						[]byte("enrollment-id"),
+						[]byte("revocation-handle"),
+					},
+					Schema:          "test-schema",
+					EidNymAuditData: auditData(),
+					RhNymAuditData:  auditData(),
+				},
+				IdemixSignature: []byte("signature"),
+			}
+			raw, err := json.Marshal(auditInfo)
+			require.NoError(t, err)
+
+			deserialized, err := DeserializeAuditInfo(raw)
+			require.NoError(t, err)
+			assert.Equal(t, auditInfo.IdemixSignature, deserialized.IdemixSignature)
+			assert.Equal(t, auditInfo.EnrollmentID(), deserialized.EnrollmentID())
+			assert.True(t, auditInfo.EidNymAuditData.Nym.Equals(deserialized.EidNymAuditData.Nym))
+			assert.True(t, auditInfo.RhNymAuditData.Rand.Equals(deserialized.RhNymAuditData.Rand))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2078

### Problem

Idemix audit info is JSON from a counterparty. Its pseudonym audit data holds mathlib curve elements, which encode the curve as an index into mathlib's curve table:

```json
{"EidNymAuditData":{"Nym":{"curve":999999,"element":"AQID"}}}
```

mathlib's `UnmarshalJSON` does `Curves[ce.CurveID].NewG1FromBytes(...)` with no bounds check, so that payload crashes the process with `index out of range` — from *inside* `json.Unmarshal`, before any validation runs. `mathlib v0.3.0` is the latest release, so this has to be contained here.

Both deserializers were affected: `crypto.AuditInfo` and `nym.AuditInfo` (the latter embeds the former, so the curve elements inline into its own JSON and it decodes them itself).

### Fix

Both decodes now run through `crypto.UnmarshalAuditInfo`, which recovers the panic and returns it as an ordinary error — the same containment `FromG1Proto` already applies to this defect in `token/core/zkatdlog/nogh/protos-go/utils`.

The guard wraps the real decode rather than pre-validating the payload's curve IDs. That was the first attempt, and it was wrong: mathlib runs *during* `encoding/json`'s traversal, so a separate validation pass has to reproduce that traversal exactly. It didn't, five ways — trailing input after the first JSON value (found by the fuzz target), a duplicate key overwriting a bad element at either nesting level, an element following a type error, and case-insensitive key matching. All five are pinned in `TestDeserializeAuditInfoOutOfRangeCurveIDEvasions` and seeded into both fuzz corpora.

Those corpora previously seeded only zero-valued audit data, which marshals as JSON `null` and never entered the vulnerable path at all.
