### PR TITLE
fix(identity): derive the enrollment ID of a boolpolicy identity from its members

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -60,6 +60,9 @@ jobs:
           - name: identity-idemixnym-audit-info-deserializer
             pkg: ./token/services/identity/idemixnym/nym
             func: FuzzDeserializeAuditInfoNoPanic
+          - name: identity-boolpolicy-audit-info-deserializer
+            pkg: ./token/services/identity/boolpolicy
+            func: FuzzDeserializeAuditInfoNoPanic
           - name: common-request-limits
             pkg: ./token/core/common
             func: FuzzRequestResourceLimits

--- a/docs/services/identity.md
+++ b/docs/services/identity.md
@@ -440,7 +440,7 @@ Located in `token/services/identity/boolpolicy`.
     - `identities` (SEQUENCE OF OCTET STRING): ordered list of raw component identity bytes; `$N` indexes into this list.
 *   **Audit Info**: JSON-encoded `AuditInfo` structure.
     - `IdentityAuditInfos` (array of `IdentityAuditInfo`): per-component audit info blobs in the same order as `identities`.
-*   **Enrollment ID**: When the audit-info deserializer is built with the parent multiplex deserializer (`NewAuditInfoDeserializer`), the policy identity reports the enrollment ID shared by all component identities. Components with no enrollment ID of their own (e.g. a nested composite spanning enrollments) or disagreeing components yield an empty enrollment ID; an unresolvable component or a component count mismatch is an error.
+*   **Enrollment ID**: When the audit-info deserializer is built with the parent multiplex deserializer (`NewAuditInfoDeserializer`), the policy identity reports the enrollment ID shared by all component identities. Components with no enrollment ID of their own (e.g. a nested composite spanning enrollments), components whose audit info is missing (e.g. an identity not registered locally), or disagreeing components yield an empty enrollment ID; an unresolvable component or a component count mismatch is an error.
 *   **Encoding**:
     - `TypedIdentity` payload: ASN.1 DER.
     - Audit Info: JSON.

--- a/docs/services/identity.md
+++ b/docs/services/identity.md
@@ -440,7 +440,7 @@ Located in `token/services/identity/boolpolicy`.
     - `identities` (SEQUENCE OF OCTET STRING): ordered list of raw component identity bytes; `$N` indexes into this list.
 *   **Audit Info**: JSON-encoded `AuditInfo` structure.
     - `IdentityAuditInfos` (array of `IdentityAuditInfo`): per-component audit info blobs in the same order as `identities`.
-*   **Enrollment ID**: When the audit-info deserializer is built with the parent multiplex deserializer (`NewAuditInfoDeserializer`), the policy identity reports the enrollment ID shared by all component identities. Components with no enrollment ID of their own (e.g. a nested composite spanning enrollments), components whose audit info is missing (e.g. an identity not registered locally), or disagreeing components yield an empty enrollment ID; an unresolvable component or a component count mismatch is an error.
+*   **Enrollment ID**: When the audit-info deserializer is built with the parent multiplex deserializer (`NewAuditInfoDeserializer`), the policy identity reports the enrollment ID shared by all component identities. Components with no enrollment ID of their own (e.g. a nested composite spanning enrollments), components whose audit info is missing (e.g. an identity not registered locally), or disagreeing components yield an empty enrollment ID; a missing component audit info takes precedence over subtype resolution, so an unknown component identity type carrying no audit info also yields an empty enrollment ID. A non-empty component audit info that cannot be resolved, an invalid component identity, or a component count mismatch is an error.
 *   **Encoding**:
     - `TypedIdentity` payload: ASN.1 DER.
     - Audit Info: JSON.

--- a/docs/services/identity.md
+++ b/docs/services/identity.md
@@ -440,6 +440,7 @@ Located in `token/services/identity/boolpolicy`.
     - `identities` (SEQUENCE OF OCTET STRING): ordered list of raw component identity bytes; `$N` indexes into this list.
 *   **Audit Info**: JSON-encoded `AuditInfo` structure.
     - `IdentityAuditInfos` (array of `IdentityAuditInfo`): per-component audit info blobs in the same order as `identities`.
+*   **Enrollment ID**: When the audit-info deserializer is built with the parent multiplex deserializer (`NewAuditInfoDeserializer`), the policy identity reports the enrollment ID shared by all component identities. Components with no enrollment ID of their own (e.g. a nested composite spanning enrollments) or disagreeing components yield an empty enrollment ID; an unresolvable component or a component count mismatch is an error.
 *   **Encoding**:
     - `TypedIdentity` payload: ASN.1 DER.
     - Audit Info: JSON.

--- a/token/core/fabtoken/v1/driver/deserializer.go
+++ b/token/core/fabtoken/v1/driver/deserializer.go
@@ -52,7 +52,7 @@ func NewEIDRHDeserializer() *EIDRHDeserializer {
 	d.AddDeserializer(x509.IdentityType, &x509.AuditInfoDeserializer{})
 	d.AddDeserializer(htlc2.ScriptType, htlc.NewAuditDeserializer(d))
 	d.AddDeserializer(multisig.Multisig, &multisig.AuditInfoDeserializer{})
-	d.AddDeserializer(boolpolicy.Policy, &boolpolicy.AuditInfoDeserializer{})
+	d.AddDeserializer(boolpolicy.Policy, boolpolicy.NewAuditInfoDeserializer(d))
 
 	return d
 }

--- a/token/core/zkatdlog/nogh/v1/driver/deserializer.go
+++ b/token/core/zkatdlog/nogh/v1/driver/deserializer.go
@@ -94,7 +94,7 @@ func NewEIDRHDeserializer() *EIDRHDeserializer {
 	d.AddDeserializer(x509.IdentityType, &x509.AuditInfoDeserializer{})
 	d.AddDeserializer(htlc2.ScriptType, htlc.NewAuditDeserializer(d))
 	d.AddDeserializer(multisig.Multisig, &multisig.AuditInfoDeserializer{})
-	d.AddDeserializer(boolpolicy.Policy, &boolpolicy.AuditInfoDeserializer{})
+	d.AddDeserializer(boolpolicy.Policy, boolpolicy.NewAuditInfoDeserializer(d))
 
 	return d
 }

--- a/token/services/identity/boolpolicy/audit_fuzz_test.go
+++ b/token/services/identity/boolpolicy/audit_fuzz_test.go
@@ -59,6 +59,9 @@ func FuzzDeserializeAuditInfoNoPanic(f *testing.F) {
 	// member count mismatch
 	innerMismatch, _, wrappedOne := fuzzPolicy(f, "$0 OR $1", [][]byte{m0, m1}, [][]byte{ai0})
 	f.Add(innerMismatch, wrappedOne)
+	// missing component audit info
+	innerMissing, _, wrappedMissing := fuzzPolicy(f, "$0 OR $1", [][]byte{m0, m1}, [][]byte{ai0, nil})
+	f.Add(innerMissing, wrappedMissing)
 	// unknown member identity type
 	unknown, err := identity.WrapWithType(identity.Type(99), []byte("cert-x"))
 	require.NoError(f, err)

--- a/token/services/identity/boolpolicy/audit_fuzz_test.go
+++ b/token/services/identity/boolpolicy/audit_fuzz_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package boolpolicy
+
+import (
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/x509"
+	"github.com/stretchr/testify/require"
+)
+
+const maxFuzzAuditInfoBytes = 64 << 10
+
+// fuzzMember returns a typed x509 member identity and its audit info bytes.
+func fuzzMember(f *testing.F, name, eid string) ([]byte, []byte) {
+	f.Helper()
+	member, err := identity.WrapWithType(x509.IdentityType, []byte(name))
+	require.NoError(f, err)
+	auditInfo, err := (&x509.AuditInfo{EID: eid, RH: []byte("rh-" + eid)}).Bytes()
+	require.NoError(f, err)
+
+	return member, auditInfo
+}
+
+// fuzzPolicy wraps members into a policy identity (inner DER and typed
+// envelope) and the matching composite audit info blob.
+func fuzzPolicy(f *testing.F, policy string, members, auditInfos [][]byte) (inner, envelope, wrapped []byte) {
+	f.Helper()
+	inner, err := (&PolicyIdentity{Policy: policy, Identities: members}).Serialize()
+	require.NoError(f, err)
+	envelope, err = identity.WrapWithType(Policy, inner)
+	require.NoError(f, err)
+	wrapped, err = WrapAuditInfo(auditInfos)
+	require.NoError(f, err)
+
+	return inner, envelope, wrapped
+}
+
+func FuzzDeserializeAuditInfoNoPanic(f *testing.F) {
+	m0, ai0 := fuzzMember(f, "cert-zero", "wallet-42")
+	m1, ai1 := fuzzMember(f, "cert-one", "wallet-43")
+
+	// valid single- and two-member policies, both identity encodings
+	inner1, envelope1, wrapped1 := fuzzPolicy(f, "$0", [][]byte{m0}, [][]byte{ai0})
+	f.Add(inner1, wrapped1)
+	f.Add(envelope1, wrapped1)
+	inner2, _, wrapped2 := fuzzPolicy(f, "$0 OR $1", [][]byte{m0, m1}, [][]byte{ai0, ai1})
+	f.Add(inner2, wrapped2)
+	// empty and truncated inputs
+	f.Add([]byte{}, []byte{})
+	f.Add(inner2[:len(inner2)/2], wrapped2[:len(wrapped2)/2])
+	f.Add(inner2, []byte(`{"IdentityAuditInfos":`))
+	f.Add(inner1, []byte(`{}`))
+	// member count mismatch
+	innerMismatch, _, wrappedOne := fuzzPolicy(f, "$0 OR $1", [][]byte{m0, m1}, [][]byte{ai0})
+	f.Add(innerMismatch, wrappedOne)
+	// unknown member identity type
+	unknown, err := identity.WrapWithType(identity.Type(99), []byte("cert-x"))
+	require.NoError(f, err)
+	innerUnknown, _, wrappedUnknown := fuzzPolicy(f, "$0", [][]byte{unknown}, [][]byte{ai0})
+	f.Add(innerUnknown, wrappedUnknown)
+	// nested and deeply nested policies
+	nestedID, nestedInfo := m0, ai0
+	for range 5 {
+		_, nestedID, nestedInfo = fuzzPolicy(f, "$0", [][]byte{nestedID}, [][]byte{nestedInfo})
+	}
+	innerDeep, _, wrappedDeep := fuzzPolicy(f, "$0", [][]byte{nestedID}, [][]byte{nestedInfo})
+	f.Add(innerDeep, wrappedDeep)
+
+	f.Fuzz(func(t *testing.T, rawID, rawInfo []byte) {
+		if len(rawID) > maxFuzzAuditInfoBytes || len(rawInfo) > maxFuzzAuditInfoBytes {
+			t.Skip()
+		}
+		require.NotPanics(t, func() {
+			_, _ = NewAuditInfoDeserializer(newEIDRHDeserializer()).DeserializeAuditInfo(t.Context(), rawID, rawInfo)
+		})
+	})
+}

--- a/token/services/identity/boolpolicy/audit_test.go
+++ b/token/services/identity/boolpolicy/audit_test.go
@@ -135,6 +135,19 @@ func TestPolicyEnrollmentIDUnresolvableMember(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to deserialize audit info of component")
 }
 
+func TestPolicyEnrollmentIDUnknownTypeWithoutAuditInfo(t *testing.T) {
+	// a missing component audit info is exempted before the member's identity
+	// type is resolved, so an unknown type with no audit info yields no common
+	// EID rather than the unresolvable-component error
+	m0, err := identity.WrapWithType(identity.Type(99), []byte("cert-zero"))
+	require.NoError(t, err)
+	policyID, wrapped := newPolicyIdentity(t, "$0", [][]byte{m0}, [][]byte{nil})
+
+	eid, _, err := newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.NoError(t, err)
+	assert.Empty(t, eid)
+}
+
 func TestPolicyEnrollmentIDMemberCountMismatch(t *testing.T) {
 	// malformed: two members but a single component audit info
 	m0, ai0 := newX509Member(t, "cert-zero", "wallet-42")

--- a/token/services/identity/boolpolicy/audit_test.go
+++ b/token/services/identity/boolpolicy/audit_test.go
@@ -7,11 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 package boolpolicy
 
 import (
+	"context"
 	"testing"
 
 	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/deserializer"
+	driver2 "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/x509"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -227,6 +230,51 @@ func TestPolicyEnrollmentIDMissingThenMalformedMember(t *testing.T) {
 	_, _, err = newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to deserialize audit info of component")
+}
+
+func TestPolicyEnrollmentIDInvalidComponentIdentities(t *testing.T) {
+	// component identities rejected by DeserializeVerifier must not be
+	// attributed on the audit path either, which never runs the verifier
+	m0, ai0 := newX509Member(t, "cert-zero", "wallet-42")
+	cases := []struct {
+		name    string
+		members [][]byte
+		wantErr string
+	}{
+		{"duplicate member", [][]byte{m0, m0}, "duplicate of an earlier identity"},
+		{"empty member", [][]byte{m0, nil}, "must not be empty"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			policyID, wrapped := newPolicyIdentity(t, "$0 AND $1", tc.members, [][]byte{ai0, ai0})
+
+			_, _, err := newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// nilAuditInfoDeserializer reports neither audit info nor error.
+type nilAuditInfoDeserializer struct{}
+
+func (nilAuditInfoDeserializer) DeserializeAuditInfo(context.Context, driver.Identity, []byte) (driver2.AuditInfo, error) {
+	return nil, nil
+}
+
+func TestPolicyEnrollmentIDNilMemberAuditInfo(t *testing.T) {
+	// an inner deserializer returning (nil, nil) must yield no common EID
+	// rather than a panic
+	m0, ai0 := newX509Member(t, "cert-zero", "wallet-42")
+	policyID, wrapped := newPolicyIdentity(t, "$0", [][]byte{m0}, [][]byte{ai0})
+
+	d := deserializer.NewEIDRHDeserializer()
+	d.AddDeserializer(Policy, NewAuditInfoDeserializer(nilAuditInfoDeserializer{}))
+
+	eid, rh, err := d.GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.NoError(t, err)
+	assert.Empty(t, eid)
+	assert.Empty(t, rh)
 }
 
 func TestPolicyEnrollmentIDCrossEIDThenMalformedMember(t *testing.T) {

--- a/token/services/identity/boolpolicy/audit_test.go
+++ b/token/services/identity/boolpolicy/audit_test.go
@@ -191,6 +191,44 @@ func TestPolicyAuditInfoGarbageStillErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestPolicyEnrollmentIDMissingMemberAuditInfo(t *testing.T) {
+	// a member's audit info may be legally missing (e.g. an identity not
+	// registered locally): no common EID, not an error
+	m0, _ := newX509Member(t, "cert-zero", "wallet-42")
+	policyID, wrapped := newPolicyIdentity(t, "$0", [][]byte{m0}, [][]byte{nil})
+
+	eid, _, err := newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.NoError(t, err)
+	assert.Empty(t, eid)
+}
+
+func TestPolicyEnrollmentIDMissingAndPresentMemberAuditInfo(t *testing.T) {
+	// one resolvable member plus one with missing audit info: no common EID
+	m0, ai0 := newX509Member(t, "cert-zero", "wallet-42")
+	m1, _ := newX509Member(t, "cert-one", "wallet-42")
+	policyID, wrapped := newPolicyIdentity(t, "$0 OR $1", [][]byte{m0, m1}, [][]byte{ai0, nil})
+
+	eid, _, err := newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.NoError(t, err)
+	assert.Empty(t, eid)
+}
+
+func TestPolicyEnrollmentIDMissingThenMalformedMember(t *testing.T) {
+	// a missing member audit info must not mask corruption in a later member
+	unresolvable, err := identity.WrapWithType(identity.Type(99), []byte("cert-one"))
+	require.NoError(t, err)
+	unresolvableInfo, err := (&x509.AuditInfo{EID: "wallet-43"}).Bytes()
+	require.NoError(t, err)
+
+	m0, _ := newX509Member(t, "cert-zero", "wallet-42")
+	policyID, wrapped := newPolicyIdentity(t, "$0 OR $1",
+		[][]byte{m0, unresolvable}, [][]byte{nil, unresolvableInfo})
+
+	_, _, err = newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to deserialize audit info of component")
+}
+
 func TestPolicyEnrollmentIDCrossEIDThenMalformedMember(t *testing.T) {
 	// members legitimately span enrollments, but a later member is malformed:
 	// the corruption must surface as an error, not be masked by the

--- a/token/services/identity/boolpolicy/audit_test.go
+++ b/token/services/identity/boolpolicy/audit_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package boolpolicy
+
+import (
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/deserializer"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/x509"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newX509Member returns a typed x509 member identity and its audit info bytes.
+func newX509Member(t *testing.T, name, eid string) ([]byte, []byte) {
+	t.Helper()
+	member, err := identity.WrapWithType(x509.IdentityType, []byte(name))
+	require.NoError(t, err)
+	auditInfo, err := (&x509.AuditInfo{EID: eid, RH: []byte("rh-" + eid)}).Bytes()
+	require.NoError(t, err)
+
+	return member, auditInfo
+}
+
+// newPolicyIdentity wraps the members into a typed policy identity and the
+// matching composite audit info blob.
+func newPolicyIdentity(t *testing.T, policy string, members [][]byte, auditInfos [][]byte) (token.Identity, []byte) {
+	t.Helper()
+	inner, err := (&PolicyIdentity{Policy: policy, Identities: members}).Serialize()
+	require.NoError(t, err)
+	policyID, err := identity.WrapWithType(Policy, inner)
+	require.NoError(t, err)
+	wrapped, err := WrapAuditInfo(auditInfos)
+	require.NoError(t, err)
+
+	return policyID, wrapped
+}
+
+// newEIDRHDeserializer mirrors the driver wiring: x509 plus a recursive
+// boolpolicy audit-info deserializer.
+func newEIDRHDeserializer() *deserializer.EIDRHDeserializer {
+	d := deserializer.NewEIDRHDeserializer()
+	d.AddDeserializer(x509.IdentityType, &x509.AuditInfoDeserializer{})
+	d.AddDeserializer(Policy, NewAuditInfoDeserializer(d))
+
+	return d
+}
+
+func TestPolicyEnrollmentIDCommonMembers(t *testing.T) {
+	m0, ai0 := newX509Member(t, "cert-zero", "wallet-42")
+	m1, ai1 := newX509Member(t, "cert-one", "wallet-42")
+	policyID, wrapped := newPolicyIdentity(t, "$0 OR $1", [][]byte{m0, m1}, [][]byte{ai0, ai1})
+
+	eid, rh, err := newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.NoError(t, err)
+	assert.Equal(t, "wallet-42", eid)
+	assert.Empty(t, rh)
+}
+
+func TestPolicyEnrollmentIDSingleMember(t *testing.T) {
+	m0, ai0 := newX509Member(t, "cert-zero", "wallet-7")
+	policyID, wrapped := newPolicyIdentity(t, "$0", [][]byte{m0}, [][]byte{ai0})
+
+	eid, _, err := newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.NoError(t, err)
+	assert.Equal(t, "wallet-7", eid)
+}
+
+func TestPolicyEnrollmentIDConflictingMembers(t *testing.T) {
+	m0, ai0 := newX509Member(t, "cert-zero", "wallet-42")
+	m1, ai1 := newX509Member(t, "cert-one", "wallet-43")
+	policyID, wrapped := newPolicyIdentity(t, "$0 OR $1", [][]byte{m0, m1}, [][]byte{ai0, ai1})
+
+	eid, _, err := newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.NoError(t, err)
+	assert.Empty(t, eid)
+}
+
+func TestPolicyEnrollmentIDEmptyMemberEID(t *testing.T) {
+	// a member with no enrollment ID of its own: no common EID, not an error
+	// (a nested composite spanning enrollments reports the same way)
+	m0, ai0 := newX509Member(t, "cert-zero", "")
+	policyID, wrapped := newPolicyIdentity(t, "$0", [][]byte{m0}, [][]byte{ai0})
+
+	eid, _, err := newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.NoError(t, err)
+	assert.Empty(t, eid)
+}
+
+func TestPolicyEnrollmentIDNestedPolicy(t *testing.T) {
+	// a member may itself be a policy identity, resolved recursively through
+	// the parent multiplex deserializer
+	cases := []struct {
+		name     string
+		innerEID [2]string
+		want     string
+	}{
+		{"inner members share an enrollment", [2]string{"wallet-42", "wallet-42"}, "wallet-42"},
+		{"inner members span enrollments", [2]string{"wallet-42", "wallet-43"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m0, ai0 := newX509Member(t, "cert-zero", tc.innerEID[0])
+			m1, ai1 := newX509Member(t, "cert-one", tc.innerEID[1])
+			innerID, innerInfo := newPolicyIdentity(t, "$0 OR $1", [][]byte{m0, m1}, [][]byte{ai0, ai1})
+			outerID, wrapped := newPolicyIdentity(t, "$0", [][]byte{innerID}, [][]byte{innerInfo})
+
+			eid, _, err := newEIDRHDeserializer().GetEIDAndRH(t.Context(), outerID, wrapped)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, eid)
+		})
+	}
+}
+
+func TestPolicyEnrollmentIDUnresolvableMember(t *testing.T) {
+	// malformed: member typed with an identity type that has no registered
+	// deserializer
+	m0, err := identity.WrapWithType(identity.Type(99), []byte("cert-zero"))
+	require.NoError(t, err)
+	ai0, err := (&x509.AuditInfo{EID: "wallet-42"}).Bytes()
+	require.NoError(t, err)
+	policyID, wrapped := newPolicyIdentity(t, "$0", [][]byte{m0}, [][]byte{ai0})
+
+	_, _, err = newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to deserialize audit info of component")
+}
+
+func TestPolicyEnrollmentIDMemberCountMismatch(t *testing.T) {
+	// malformed: two members but a single component audit info
+	m0, ai0 := newX509Member(t, "cert-zero", "wallet-42")
+	m1, _ := newX509Member(t, "cert-one", "wallet-42")
+	policyID, wrapped := newPolicyIdentity(t, "$0 OR $1", [][]byte{m0, m1}, [][]byte{ai0})
+
+	_, _, err := newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "component audit infos")
+}
+
+func TestPolicyEnrollmentIDEmptyAuditInfoList(t *testing.T) {
+	// malformed: one member but an empty audit info blob must still hit the
+	// count check, not short-circuit to "no common EID"
+	m0, _ := newX509Member(t, "cert-zero", "wallet-42")
+	policyID, _ := newPolicyIdentity(t, "$0", [][]byte{m0}, [][]byte{[]byte("unused")})
+
+	_, _, err := newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected 1 component audit infos but received 0")
+}
+
+func TestPolicyEnrollmentIDNoComponents(t *testing.T) {
+	// malformed: a policy identity with no components at all
+	inner, err := (&PolicyIdentity{Policy: "$0"}).Serialize()
+	require.NoError(t, err)
+	policyID, err := identity.WrapWithType(Policy, inner)
+	require.NoError(t, err)
+
+	_, _, err = newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no components")
+}
+
+func TestPolicyEnrollmentIDZeroValueDeserializer(t *testing.T) {
+	// zero-value deserializer (no inner): legacy behavior, empty enrollment ID
+	m0, ai0 := newX509Member(t, "cert-zero", "wallet-42")
+	policyID, wrapped := newPolicyIdentity(t, "$0", [][]byte{m0}, [][]byte{ai0})
+
+	d := deserializer.NewEIDRHDeserializer()
+	d.AddDeserializer(Policy, &AuditInfoDeserializer{})
+
+	eid, rh, err := d.GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.NoError(t, err)
+	assert.Empty(t, eid)
+	assert.Empty(t, rh)
+}
+
+func TestPolicyAuditInfoGarbageStillErrors(t *testing.T) {
+	m0, _ := newX509Member(t, "cert-zero", "wallet-42")
+	inner, err := (&PolicyIdentity{Policy: "$0", Identities: [][]byte{m0}}).Serialize()
+	require.NoError(t, err)
+	policyID, err := identity.WrapWithType(Policy, inner)
+	require.NoError(t, err)
+
+	_, _, err = newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, []byte("not-json"))
+	require.Error(t, err)
+}
+
+func TestPolicyEnrollmentIDCrossEIDThenMalformedMember(t *testing.T) {
+	// members legitimately span enrollments, but a later member is malformed:
+	// the corruption must surface as an error, not be masked by the
+	// cross-enrollment "" result
+	unresolvable, err := identity.WrapWithType(identity.Type(99), []byte("cert-two"))
+	require.NoError(t, err)
+	unresolvableInfo, err := (&x509.AuditInfo{EID: "wallet-44"}).Bytes()
+	require.NoError(t, err)
+
+	m0, ai0 := newX509Member(t, "cert-zero", "wallet-42")
+	m1, ai1 := newX509Member(t, "cert-one", "wallet-43")
+	policyID, wrapped := newPolicyIdentity(t, "$0 OR $1 OR $2",
+		[][]byte{m0, m1, unresolvable}, [][]byte{ai0, ai1, unresolvableInfo})
+
+	_, _, err = newEIDRHDeserializer().GetEIDAndRH(t.Context(), policyID, wrapped)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to deserialize audit info of component")
+}

--- a/token/services/identity/boolpolicy/deserializer.go
+++ b/token/services/identity/boolpolicy/deserializer.go
@@ -183,8 +183,8 @@ func (a *AuditInfoDeserializer) DeserializeAuditInfo(ctx context.Context, id dri
 
 // commonEnrollmentID returns the enrollment ID shared by all components:
 // "" when a component has none (e.g. a nested composite), its audit info is
-// missing, or they disagree; an error on unresolvable audit info or a
-// component count mismatch.
+// missing, or they disagree; an error on an invalid component identity,
+// unresolvable audit info or a component count mismatch.
 func (a *AuditInfoDeserializer) commonEnrollmentID(ctx context.Context, id driver.Identity, ei *AuditInfo) (string, error) {
 	if a.inner == nil {
 		return "", nil
@@ -192,6 +192,9 @@ func (a *AuditInfoDeserializer) commonEnrollmentID(ctx context.Context, id drive
 	pi := PolicyIdentity{}
 	if err := pi.Deserialize(id); err != nil {
 		return "", errors.Wrapf(err, "failed to deserialize policy identity")
+	}
+	if err := validateComponentIdentities(pi.Identities); err != nil {
+		return "", errors.Wrap(err, "invalid policy identity")
 	}
 	if len(pi.Identities) != len(ei.IdentityAuditInfos) {
 		return "", errors.Errorf("expected %d component audit infos but received %d",
@@ -212,6 +215,11 @@ func (a *AuditInfoDeserializer) commonEnrollmentID(ctx context.Context, id drive
 		memberAuditInfo, err := a.inner.DeserializeAuditInfo(ctx, pi.Identities[k], info.AuditInfo)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to deserialize audit info of component [%d]", k)
+		}
+		if memberAuditInfo == nil {
+			// an inner deserializer may report neither audit info nor error:
+			// treat it like missing audit info rather than panicking
+			continue
 		}
 		eids[k] = memberAuditInfo.EnrollmentID()
 	}

--- a/token/services/identity/boolpolicy/deserializer.go
+++ b/token/services/identity/boolpolicy/deserializer.go
@@ -182,8 +182,9 @@ func (a *AuditInfoDeserializer) DeserializeAuditInfo(ctx context.Context, id dri
 }
 
 // commonEnrollmentID returns the enrollment ID shared by all components:
-// "" when a component has none (e.g. a nested composite) or they disagree,
-// an error on unresolvable audit info or a component count mismatch.
+// "" when a component has none (e.g. a nested composite), its audit info is
+// missing, or they disagree; an error on unresolvable audit info or a
+// component count mismatch.
 func (a *AuditInfoDeserializer) commonEnrollmentID(ctx context.Context, id driver.Identity, ei *AuditInfo) (string, error) {
 	if a.inner == nil {
 		return "", nil
@@ -203,6 +204,11 @@ func (a *AuditInfoDeserializer) commonEnrollmentID(ctx context.Context, id drive
 	// later component is not masked by an earlier "no common EID" outcome
 	eids := make([]string, len(ei.IdentityAuditInfos))
 	for k, info := range ei.IdentityAuditInfos {
+		if len(info.AuditInfo) == 0 {
+			// missing audit info is legal (e.g. an identity not registered
+			// locally): the component contributes no enrollment ID
+			continue
+		}
 		memberAuditInfo, err := a.inner.DeserializeAuditInfo(ctx, pi.Identities[k], info.AuditInfo)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to deserialize audit info of component [%d]", k)

--- a/token/services/identity/boolpolicy/deserializer.go
+++ b/token/services/identity/boolpolicy/deserializer.go
@@ -154,13 +154,68 @@ func (d *TypedIdentityDeserializer) Recipients(id driver.Identity, typ identity.
 
 // AuditInfoDeserializer deserialises raw audit info bytes into the AuditInfo
 // struct for the enrollment-ID / revocation-handle path.
-type AuditInfoDeserializer struct{}
+// It derives the policy identity's enrollment ID from its components.
+type AuditInfoDeserializer struct {
+	inner driver2.AuditInfoDeserializer
+}
 
-func (a *AuditInfoDeserializer) DeserializeAuditInfo(_ context.Context, _ driver.Identity, raw []byte) (driver2.AuditInfo, error) {
+// NewAuditInfoDeserializer constructs an AuditInfoDeserializer resolving
+// per-component audit infos through inner, typically the parent multiplex
+// deserializer.
+func NewAuditInfoDeserializer(inner driver2.AuditInfoDeserializer) *AuditInfoDeserializer {
+	return &AuditInfoDeserializer{inner: inner}
+}
+
+// DeserializeAuditInfo decodes raw policy audit info and derives its enrollment ID.
+func (a *AuditInfoDeserializer) DeserializeAuditInfo(ctx context.Context, id driver.Identity, raw []byte) (driver2.AuditInfo, error) {
 	ei := &AuditInfo{}
 	if err := json.Unmarshal(raw, ei); err != nil {
 		return nil, err
 	}
+	eid, err := a.commonEnrollmentID(ctx, id, ei)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed deriving policy enrollment ID")
+	}
+	ei.eid = eid
 
 	return ei, nil
+}
+
+// commonEnrollmentID returns the enrollment ID shared by all components:
+// "" when a component has none (e.g. a nested composite) or they disagree,
+// an error on unresolvable audit info or a component count mismatch.
+func (a *AuditInfoDeserializer) commonEnrollmentID(ctx context.Context, id driver.Identity, ei *AuditInfo) (string, error) {
+	if a.inner == nil {
+		return "", nil
+	}
+	pi := PolicyIdentity{}
+	if err := pi.Deserialize(id); err != nil {
+		return "", errors.Wrapf(err, "failed to deserialize policy identity")
+	}
+	if len(pi.Identities) != len(ei.IdentityAuditInfos) {
+		return "", errors.Errorf("expected %d component audit infos but received %d",
+			len(pi.Identities), len(ei.IdentityAuditInfos))
+	}
+	if len(pi.Identities) == 0 {
+		return "", errors.New("policy identity has no components")
+	}
+	// resolve every component before declaring a result so corruption in a
+	// later component is not masked by an earlier "no common EID" outcome
+	eids := make([]string, len(ei.IdentityAuditInfos))
+	for k, info := range ei.IdentityAuditInfos {
+		memberAuditInfo, err := a.inner.DeserializeAuditInfo(ctx, pi.Identities[k], info.AuditInfo)
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to deserialize audit info of component [%d]", k)
+		}
+		eids[k] = memberAuditInfo.EnrollmentID()
+	}
+	for _, memberEID := range eids {
+		if memberEID == "" || memberEID != eids[0] {
+			// no common EID: a member has none (e.g. a nested composite
+			// spanning enrollments) or members belong to different ones
+			return "", nil
+		}
+	}
+
+	return eids[0], nil
 }

--- a/token/services/identity/boolpolicy/identity.go
+++ b/token/services/identity/boolpolicy/identity.go
@@ -95,11 +95,21 @@ type IdentityAuditInfo struct {
 // It is a sequence of per-component audit infos in the same order as Identities.
 type AuditInfo struct {
 	IdentityAuditInfos []IdentityAuditInfo
+	// eid is the enrollment ID shared by all component identities;
+	// empty when they span enrollments.
+	eid string
 }
 
-func (a *AuditInfo) EnrollmentID() string     { return "" }
+// EnrollmentID returns the enrollment ID shared by all component identities,
+// or "" when there is none.
+func (a *AuditInfo) EnrollmentID() string { return a.eid }
+
+// RevocationHandle returns "": a policy identity has no revocation handle of
+// its own.
 func (a *AuditInfo) RevocationHandle() string { return "" }
-func (a *AuditInfo) Bytes() ([]byte, error)   { return json.Marshal(a) }
+
+// Bytes returns the JSON encoding of the AuditInfo.
+func (a *AuditInfo) Bytes() ([]byte, error) { return json.Marshal(a) }
 
 // WrapAuditInfo packs per-component audit info bytes into a single blob.
 func WrapAuditInfo(recipients [][]byte) ([]byte, error) {


### PR DESCRIPTION
Fixes #2145

## What

Derive the enrollment ID of a boolpolicy identity from its member identities, mirroring the recursive `htlc.NewAuditDeserializer` pattern:

- `boolpolicy.NewAuditInfoDeserializer` now takes the parent multiplex deserializer and resolves each component's audit info through it; the policy identity reports the enrollment ID shared by all components. The fabtoken and zkatdlog drivers pass the multiplexer at registration.
- Components with no enrollment ID of their own (e.g. a nested composite spanning enrollments) or disagreeing components yield the legacy empty value — composites resolve recursively, so a member may itself be a policy or multisig identity.
- A component whose audit info is missing is legal: `GetAuditInfo` returns nil for an identity that is not registered locally and `WrapAuditInfo` preserves the empty entry, so such a component contributes no enrollment ID rather than failing the audit path. This exemption is applied before subtype resolution, so a component of an unknown identity type carrying no audit info also yields no enrollment ID rather than an error.
- Malformed audit info — a non-empty component audit info that cannot be resolved, or a component count mismatch — is an error instead of a silent empty value, and every component is resolved before the result is declared so corruption in a later component is never masked by an earlier "no common EID" outcome.
- The wire-supplied component identities are validated at this deserialization boundary, as `GetAuditInfoMatcher` and `DeserializeVerifier` already do. Nothing else on the audit path reaches that validation: `Request.IsValid` only checks action structure and metadata consistency, and owner verifiers are deserialized solely by the driver validator at commit.
- A component whose inner deserializer returns neither audit info nor an error contributes no enrollment ID instead of panicking.

## Why

`AuditInfo.EnrollmentID()` returned `""` for every policy identity, and the two sides of a transaction are affected differently.

The input side carries the composite identity itself — both drivers put a single sender in `TransferInputMetadata` — so a policy-owned input reached the auditor with no enrollment attribution at all, and `completeInputsWithEmptyEID` then reassigned it to whichever enrollment ID the output stream reports first. That is the gap this PR closes.

The output side is separate: output rows are expanded per component and already resolve each member's own enrollment ID, so they are attributed correctly but counted once per member. That duplicate amount accounting is fixed by #2148. Only the two together bring a policy wallet's audited movements back to the true net; see #2145 for a worked example.

In our test environments the auditor's audit balances for policy wallets were corrupted by this pair of defects.

## Testing

- Unit tests cover: common-enrollment derivation, single member, legal cross-enrollment components, nested policies (both the common-EID and cross-enrollment inner case), empty member enrollment IDs, missing component audit info (alone, alongside a resolvable component, followed by a malformed component, and on an unknown identity type), invalid component identities (duplicate and empty), a nil audit info returned by the inner deserializer, the malformed cases (unresolvable component, count mismatch including an empty audit-info blob against a non-empty policy, a policy identity with no components, garbage audit info), the masked-later-corruption case, and the zero-value deserializer.
- `FuzzDeserializeAuditInfoNoPanic` fuzzes the recursive deserialization path (seeds: valid single/two-member policies in both identity encodings, empty, truncated, empty audit-info blob, count mismatch, unknown member type, 5-deep nesting; inputs capped at 64 KiB like the neighbouring identity targets), wired into `.github/workflows/nightly-fuzz.yml`; 20s local run clean at ~50k execs/sec.
