### PR TITLE
test: stop two timing-dependent tests from flaking

### DIFF
--- a/token/services/selector/sherdlock/manager_test.go
+++ b/token/services/selector/sherdlock/manager_test.go
@@ -51,7 +51,12 @@ func TestSufficientTokensBigDenominationsOneReplica(t *testing.T) {
 }
 
 func TestSufficientTokensBigDenominationsManyReplicas(t *testing.T) {
-	replicas, terminate := startManagers(t, 3, 2*time.Second, 10)
+	// The retry budget has to absorb contention, not decide the result. Three replicas compete for
+	// the same two tokens here, so a replica can legitimately be beaten to a token several times
+	// before it wins one. The single replica variant above already needs 20 retries with no
+	// competition at all, so 10 across three replicas was far too tight and made the outcome
+	// depend on scheduling. See #2121.
+	replicas, terminate := startManagers(t, 3, 2*time.Second, 60)
 	defer terminate()
 	testutils.TestSufficientTokensBigDenominationsManyReplicas(t, replicas)
 }

--- a/token/services/ttx/random_test.go
+++ b/token/services/ttx/random_test.go
@@ -18,6 +18,10 @@ import (
 
 // TestGetRandomBytes_Success verifies that GetRandomBytes returns the correct length
 // of random bytes and that the buffer is fully filled.
+// allZeroCheckMinLen is the smallest buffer for which an all-zero draw is implausible enough
+// to assert on: 2^-64.
+const allZeroCheckMinLen = 8
+
 func TestGetRandomBytes_Success(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -39,8 +43,11 @@ func TestGetRandomBytes_Success(t *testing.T) {
 			require.NoError(t, err)
 			assert.Len(t, result, tt.length, "returned buffer should have requested length")
 
-			// For non-zero lengths, verify buffer is not all zeros (extremely unlikely with crypto/rand)
-			if tt.length > 0 {
+			// Only meaningful once the buffer is wide enough that all-zeros is not a plausible
+			// draw. At one byte it just means the byte is 0, which happens 1 run in 256, so
+			// asserting it made this test flaky. Randomness itself is covered by
+			// TestGetRandomBytes_Uniqueness.
+			if tt.length >= allZeroCheckMinLen {
 				allZeros := true
 				for _, b := range result {
 					if b != 0 {

--- a/token/services/utils/retry_internal_test.go
+++ b/token/services/utils/retry_internal_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// internalTestLogger mirrors the helper in the external test package, which this file cannot
+// reach from inside package utils.
+func internalTestLogger() logging.Logger {
+	return logging.DriverLogger("test", "n1", "c1", "ns1")
+}
+
+// nextDelay is the whole of the backoff policy, so it can be checked directly rather than by
+// measuring how long RunWithContext actually sleeps. Asserting on measured sleeps made this
+// flaky: at a 10ms initial delay, ordinary scheduler jitter on a loaded CI runner is a large
+// fraction of the interval, and it cost around 131s per run to walk the backoff to the cap.
+
+// With the default constructor the jitter factor is zero, so every delay is exact.
+func TestNextDelay_ExponentialUntilCapped(t *testing.T) {
+	r := NewRetryRunner(internalTestLogger(), 15, 10*time.Millisecond, true)
+
+	// 10ms doubling: the 13th attempt (index 12) is the first that would exceed the 30s cap.
+	for attempt := range 12 {
+		want := 10 * time.Millisecond << attempt
+		require.Less(t, want, defaultMaxDelay, "attempt %d should still be under the cap", attempt)
+		assert.Equal(t, want, r.nextDelay(attempt), "attempt %d", attempt)
+	}
+
+	for _, attempt := range []int{12, 13, 20, 100} {
+		assert.Equal(t, defaultMaxDelay, r.nextDelay(attempt),
+			"attempt %d must be capped at %s", attempt, defaultMaxDelay)
+	}
+}
+
+// Without exponential backoff every attempt waits the initial delay.
+func TestNextDelay_ConstantWhenBackoffDisabled(t *testing.T) {
+	r := NewRetryRunner(internalTestLogger(), 5, 25*time.Millisecond, false)
+
+	for _, attempt := range []int{0, 1, 7, 50} {
+		assert.Equal(t, 25*time.Millisecond, r.nextDelay(attempt), "attempt %d", attempt)
+	}
+}
+
+// A custom cap is honoured, and growth stops there rather than at the default.
+func TestNextDelay_RespectsCustomMaxDelay(t *testing.T) {
+	r := NewRetryRunnerWithJitter(internalTestLogger(), 10, 100*time.Millisecond, time.Second, 2.0, 0.0)
+
+	assert.Equal(t, 100*time.Millisecond, r.nextDelay(0))
+	assert.Equal(t, 200*time.Millisecond, r.nextDelay(1))
+	assert.Equal(t, 400*time.Millisecond, r.nextDelay(2))
+	assert.Equal(t, 800*time.Millisecond, r.nextDelay(3))
+	// 1.6s would exceed the 1s cap
+	assert.Equal(t, time.Second, r.nextDelay(4))
+	assert.Equal(t, time.Second, r.nextDelay(9))
+}
+
+// Jitter is random, so the delay is only bounded, not exact. It must stay inside the documented
+// band and must never push a capped delay above the cap by more than the jitter allows.
+func TestNextDelay_JitterStaysWithinBand(t *testing.T) {
+	const (
+		initial = 100 * time.Millisecond
+		maxD    = time.Second
+		jitter  = 0.5
+	)
+	r := NewRetryRunnerWithJitter(internalTestLogger(), 10, initial, maxD, 2.0, jitter)
+
+	for attempt := range 8 {
+		base := float64(initial) * float64(int(1)<<attempt)
+		if base > float64(maxD) {
+			base = float64(maxD)
+		}
+		lo := time.Duration(base * (1 - jitter/2))
+		hi := time.Duration(base * (1 + jitter/2))
+
+		for range 200 {
+			got := r.nextDelay(attempt)
+			assert.GreaterOrEqual(t, got, lo, "attempt %d below jitter band", attempt)
+			assert.LessOrEqual(t, got, hi, "attempt %d above jitter band", attempt)
+		}
+	}
+}
+
+// The constructor clamps jitterFactor to 1.0, and nextDelay applies (1 +/- jf/2), so the floor
+// through the public API is half the base delay. The negative guard is therefore unreachable that
+// way, which is worth pinning so nobody assumes otherwise.
+func TestNextDelay_ConstructorClampsJitter(t *testing.T) {
+	for _, requested := range []float64{1.0, 2.0, 3.0, 100.0} {
+		r := NewRetryRunnerWithJitter(internalTestLogger(), 10, 10*time.Millisecond, time.Second, 2.0, requested)
+		assert.LessOrEqual(t, r.jitterFactor, 1.0, "jitterFactor %v should have been clamped", requested)
+
+		for range 1000 {
+			assert.Positive(t, r.nextDelay(3))
+		}
+	}
+}
+
+// The negative guard in nextDelay only bites for a jitter factor above 2, which the constructor
+// will not produce. Building the struct directly is the only way to reach it, so do that rather
+// than assert a branch that cannot fire: at jf=3.0 roughly one draw in six would otherwise go
+// negative, and each of those must come back as initialDelay instead.
+func TestNextDelay_FallsBackWhenJitterWouldGoNegative(t *testing.T) {
+	r := &retryRunner{
+		initialDelay:      10 * time.Millisecond,
+		maxDelay:          time.Second,
+		expBackoff:        true,
+		backoffMultiplier: 2.0,
+		jitterFactor:      3.0,
+		maxTimes:          10,
+		logger:            internalTestLogger(),
+	}
+
+	const draws = 20000
+	fallbacks := 0
+	for range draws {
+		d := r.nextDelay(3)
+		require.Positive(t, d, "nextDelay must never return a non-positive duration")
+		if d == r.initialDelay {
+			fallbacks++
+		}
+	}
+
+	// 1/6 of draws are expected to land in the guard. Assert only that it fired often enough to
+	// have genuinely exercised it, not the exact rate.
+	assert.Greater(t, fallbacks, draws/12,
+		"expected the negative guard to fire on roughly a sixth of draws, got %d/%d", fallbacks, draws)
+}

--- a/token/services/utils/retry_test.go
+++ b/token/services/utils/retry_test.go
@@ -286,54 +286,6 @@ func TestRunWithErrors_ExponentialBackoff(t *testing.T) {
 	}
 }
 
-// TestNextDelay_MaxDelayCap verifies that exponential backoff is capped at maxDelay (30s default).
-// This test uses a fast-running approach by checking delays grow exponentially until they hit the cap.
-func TestNextDelay_MaxDelayCap(t *testing.T) {
-	// Use 10ms initial delay with exponential backoff
-	// Delays will be: 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.28s, 2.56s, 5.12s, 10.24s, 20.48s, 30s (capped), 30s, 30s...
-	runner := utils.NewRetryRunner(testLogger(), 15, 10*time.Millisecond, true)
-
-	var delays []time.Duration
-	prev := time.Now()
-
-	_ = runner.RunWithContext(t.Context(), func() error {
-		now := time.Now()
-		delays = append(delays, now.Sub(prev))
-		prev = now
-
-		return errors.New("always fail")
-	})
-
-	// Skip first delay (no sleep before first call)
-	delays = delays[1:]
-
-	// Verify exponential growth until cap
-	for i := range len(delays) - 1 {
-		if delays[i] < 20*time.Second {
-			// Before cap: should roughly double.
-			// Tolerance (1.0) allows for ratios between 1.0 and 3.0 to account for CI scheduling jitter.
-			ratio := float64(delays[i+1]) / float64(delays[i])
-			assert.InDelta(t, 2.0, ratio, 1.0,
-				"delay %d (%v) should roughly double to delay %d (%v)", i, delays[i], i+1, delays[i+1])
-		} else {
-			// After cap: should stay at ~30s (with tolerance for scheduling)
-			assert.GreaterOrEqual(t, delays[i], 20*time.Second,
-				"delay %d should be capped near 30s, got %v", i, delays[i])
-			assert.LessOrEqual(t, delays[i], 35*time.Second,
-				"delay %d should not exceed 30s cap by much, got %v", i, delays[i])
-		}
-	}
-
-	// Verify the last few delays are all capped at 30s (with tolerance)
-	lastDelays := delays[len(delays)-3:]
-	for i, d := range lastDelays {
-		assert.GreaterOrEqual(t, d, 20*time.Second,
-			"final delay %d should be capped near 30s, got %v", i, d)
-		assert.LessOrEqual(t, d, 35*time.Second,
-			"final delay %d should not exceed 30s cap by much, got %v", i, d)
-	}
-}
-
 // TestRunWithContext_MaxRetriesExhaustedNoErrors verifies the edge case where
 // maxTimes is exhausted but the runner never returned an error (always returned nil).
 // This should return ErrMaxRetriesExceeded.


### PR DESCRIPTION
Fixes #2121.

### `TestNextDelay_MaxDelayCap`

It measured wall clock gaps between retries and asserted each one roughly doubled. The first gaps
are 10ms and 20ms, where scheduler jitter on a loaded runner is a large fraction of the interval, so
a ~34ms late wake up was enough to fail it:

```
delay 0 (10.185452ms) should roughly double to delay 1 (44.320386ms)   ratio 4.35
```

`nextDelay` is a pure function though, so the policy can be asserted directly rather than inferred
from how long the runner actually slept. The new `retry_internal_test.go` covers exact exponential
growth, the 30s cap, the no-backoff case, the jitter band and the non-negative guard. With
`jitterFactor` at 0 the values are exact, so there is nothing left to be flaky about.

It also runs in **0.086s** against 131s for the test it replaces. Worth being clear that this does
not make the package fast: `token/services/utils` still takes around 378s, dominated by other
sleep-based tests I have not touched here.

### `TestSufficientTokensBigDenominationsManyReplicas`

It asserted `assert.Empty(t, errs)`, so it required that no replica ever exhausts its retry budget.
That is a scheduling outcome, not an invariant: three replicas compete for the same two tokens, so a
replica can legitimately lose several races before it wins one.

The budgets look like an oversight rather than a deliberate choice:

| test | replicas | retries |
| --- | --- | --- |
| `...BigDenominationsOneReplica` | 1 | 20 |
| `...BigDenominationsManyReplicas` | 3 | 10 |

Three times the contention on half the budget. Raised to 60 so contention cannot decide the result.
The assertion is unchanged, so the test still fails if selection genuinely cannot be satisfied.

Ran the selector test with `-count=3 -race` and the new retry tests repeatedly, all green.

### `TestGetRandomBytes_Success/single_byte`

Added after the fact, it turned up in the CI on #1982. The table includes a one byte case and every
non-zero length asserts the buffer is not all zeros. The comment says that is "extremely unlikely
with crypto/rand", which holds at 16 bytes and up, but at one byte all-zeros just means the byte is
0, so it fails about 1 run in 256.

Now only asserted once the buffer is wide enough for an all-zero draw to be implausible.
`TestGetRandomBytes_Uniqueness` already covers whether the output is actually random.
