### PR TITLE
test(fungible): await co-owner commit in CheckCoOwnedBalance

### DIFF
--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -379,20 +379,26 @@ func CheckCoOwnedBalance(network *integration.Infrastructure, ref *token3.NodeRe
 	CheckCoOwnedBalanceForTMSID(network, ref, wallet, typ, expected, nil)
 }
 
+// CheckCoOwnedBalanceForTMSID asserts that ref reports expected as the balance of the
+// tokens it co-owns. The check retries: the co-owners of a multisig transaction observe
+// its commit independently of the node that assembled and ordered it, so a one-shot query
+// right after the sender's view returns races with the co-owner's own commit.
 func CheckCoOwnedBalanceForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.Type, expected uint64, tmsID *token2.TMSID) {
-	res, err := network.Client(ref.ReplicaName()).CallView("CoOwnedBalance", common.JSONMarshall(&views.CoOwnedBalanceQuery{
-		Wallet: wallet,
-		Type:   typ,
-		TMSID:  tmsID,
-	}))
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	b := &views.Balance{}
-	common.JSONUnmarshal(res.([]byte), b)
-	gomega.Expect(b.Type).To(gomega.BeEquivalentTo(typ))
-	q, err := token.ToQuantity(b.Quantity, 64)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	expectedQ := token.NewQuantityFromUInt64(expected)
-	gomega.Expect(expectedQ.Cmp(q)).To(gomega.BeEquivalentTo(0), "[%s]!=[%s]", expected, q)
+	gomega.Eventually(func(g gomega.Gomega, network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.Type, expected uint64, tmsID *token2.TMSID) {
+		res, err := network.Client(ref.ReplicaName()).CallView("CoOwnedBalance", common.JSONMarshall(&views.CoOwnedBalanceQuery{
+			Wallet: wallet,
+			Type:   typ,
+			TMSID:  tmsID,
+		}))
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		b := &views.Balance{}
+		common.JSONUnmarshal(res.([]byte), b)
+		g.Expect(b.Type).To(gomega.BeEquivalentTo(typ))
+		q, err := token.ToQuantity(b.Quantity, 64)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		expectedQ := token.NewQuantityFromUInt64(expected)
+		g.Expect(expectedQ.Cmp(q)).To(gomega.BeEquivalentTo(0), "[%s]!=[%s]", expected, q)
+	}).WithArguments(network, ref, wallet, typ, expected, tmsID).WithTimeout(eventualCheckTimeout).WithPolling(eventualCheckPolling).Should(gomega.Succeed())
 }
 
 func CheckHolding(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.Type, expected int64, auditor *token3.NodeReference) {


### PR DESCRIPTION
TestMultiSig (dlog-fabric-t12) failed with

  [50]!=[&{0}] ... CheckCoOwnedBalanceForTMSID support.go:354

CheckCoOwnedBalanceForTMSID queried the co-owner once, with no retry, unlike CheckBalanceForTMSID and CheckHoldingForTMSID which wrap the same assertion in gomega.Eventually. The sender's MultiSigLockView returns as soon as its own NewOrderingAndFinalityView sees the commit; bob and charlie observe the same block through their own delivery pipelines and finish their AcceptCashView independently. In the failing run the block committed on the peers at 13:03:19.197, the sender returned, and the one-shot query for bob's co-owned balance ran at 13:03:19.442 before bob had applied the block, so it read 0 instead of 50.

Wrap the check in gomega.Eventually with the shared eventualCheckTimeout / eventualCheckPolling, matching the other balance checks in this file.