### PR TITLE
fix(selector): keep the status lookup out of the shard lock, and bound the scanner test waits

### DIFF
--- a/token/services/selector/simple/inmemory/locker.go
+++ b/token/services/selector/simple/inmemory/locker.go
@@ -169,6 +169,38 @@ func (d *locker) lockInShard(ctx context.Context, s *shard, owner string, id *to
 	}
 	s.mu.RUnlock()
 
+	// When reclaiming, resolve the current holder's status before taking the write
+	// lock. GetStatus goes to the transaction store, and holding the shard lock
+	// across it would make every Lock, UnlockIDs, IsLocked and the collector's own
+	// delete phase for this owner wait on that query. The collector already splits
+	// its cycle this way for exactly that reason; doing the lookup here under the
+	// lock inverted it, so a slow or stuck status provider stalled the whole shard.
+	//
+	// The holder observed here is re-validated under the lock below, since it may
+	// change while the lock is not held.
+	var (
+		observedTxID   string
+		observedStatus int
+		statusResolved bool
+	)
+	if reclaim {
+		s.mu.RLock()
+		e, held := s.locked[k]
+		if held {
+			observedTxID = e.TxID
+		}
+		s.mu.RUnlock()
+
+		if held {
+			status, _, err := d.ttxdb.GetStatus(ctx, observedTxID)
+			if err != nil {
+				logger.DebugfContext(ctx, "failed getting status of [%s] while reclaiming [%s]: [%s]", observedTxID, id, err)
+			} else {
+				observedStatus, statusResolved = status, true
+			}
+		}
+	}
+
 	// it is either not locked or we are reclaiming
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -180,9 +212,18 @@ func (d *locker) lockInShard(ctx context.Context, s *shard, owner string, id *to
 		e.LastAccess = time.Now()
 
 		if reclaim {
-			// Second chance
+			// Second chance. Only act on the status resolved above if the entry is
+			// still the one it was resolved for: a concurrent Lock(reclaim=true) may
+			// have handed the token to another transaction in the meantime, and
+			// reclaiming on a stale status would take a token away from its new
+			// holder. When it no longer matches, report the token as locked and let
+			// the caller retry.
 			logger.DebugfContext(ctx, "[%s] already locked by [%s], try to reclaim...", id, e)
-			reclaimed, status := d.reclaim(ctx, s, id, e.TxID)
+			status := observedStatus
+			reclaimed := statusResolved && e.TxID == observedTxID && status == ttxdb.Deleted
+			if reclaimed {
+				delete(s.locked, k)
+			}
 			if !reclaimed {
 				logger.DebugfContext(ctx, "[%s] already locked by [%s], reclaim failed, tx status [%s]", id, e, ttxdb.TxStatusMessage[status])
 				if logger.IsEnabledFor(zapcore.DebugLevel) {
@@ -298,24 +339,6 @@ func (d *locker) IsLocked(id *token2.ID) bool {
 	}
 
 	return false
-}
-
-// reclaim checks the tx status for id inside shard s and deletes the entry
-// if the holding transaction is finalized (Deleted). The caller must hold
-// s.mu (write lock).
-func (d *locker) reclaim(ctx context.Context, s *shard, id *token2.ID, txID string) (bool, int) {
-	status, _, err := d.ttxdb.GetStatus(ctx, txID)
-	if err != nil {
-		return false, status
-	}
-	switch status {
-	case ttxdb.Deleted:
-		delete(s.locked, *id)
-
-		return true, status
-	default:
-		return false, status
-	}
 }
 
 func (d *locker) start(ctx context.Context) {

--- a/token/services/selector/simple/inmemory/locker.go
+++ b/token/services/selector/simple/inmemory/locker.go
@@ -179,15 +179,16 @@ func (d *locker) lockInShard(ctx context.Context, s *shard, owner string, id *to
 	// The holder observed here is re-validated under the lock below, since it may
 	// change while the lock is not held.
 	var (
-		observedTxID   string
-		observedStatus int
-		statusResolved bool
+		observedTxID       string
+		observedLastAccess time.Time
+		observedStatus     int
+		statusResolved     bool
 	)
 	if reclaim {
 		s.mu.RLock()
 		e, held := s.locked[k]
 		if held {
-			observedTxID = e.TxID
+			observedTxID, observedLastAccess = e.TxID, e.LastAccess
 		}
 		s.mu.RUnlock()
 
@@ -209,30 +210,41 @@ func (d *locker) lockInShard(ctx context.Context, s *shard, owner string, id *to
 	}
 	e, ok := s.locked[k]
 	if ok {
+		// Read before the refresh below clobbers it: the re-validation compares against
+		// the value observed during the status lookup.
+		prevAccess := e.LastAccess
 		e.LastAccess = time.Now()
 
 		if reclaim {
-			// Second chance. Only act on the status resolved above if the entry is
-			// still the one it was resolved for: a concurrent Lock(reclaim=true) may
-			// have handed the token to another transaction in the meantime, and
-			// reclaiming on a stale status would take a token away from its new
-			// holder. When it no longer matches, report the token as locked and let
-			// the caller retry.
+			// Second chance. Only act on the status resolved above if the entry is still
+			// exactly the one it was resolved for, matching the collector's delete phase:
+			// same transaction and same last access. Comparing the transaction alone is
+			// not enough, since the entry may have been unlocked and re-locked under the
+			// same txID while the shard lock was released, and reclaiming on that stale
+			// verdict would drop a fresh entry. When it no longer matches, report the
+			// token as locked and let the caller retry.
 			logger.DebugfContext(ctx, "[%s] already locked by [%s], try to reclaim...", id, e)
-			status := observedStatus
-			reclaimed := statusResolved && e.TxID == observedTxID && status == ttxdb.Deleted
+			unchanged := statusResolved && e.TxID == observedTxID && prevAccess.Equal(observedLastAccess)
+			reclaimed := unchanged && observedStatus == ttxdb.Deleted
 			if reclaimed {
 				delete(s.locked, k)
 			}
 			if !reclaimed {
-				logger.DebugfContext(ctx, "[%s] already locked by [%s], reclaim failed, tx status [%s]", id, e, ttxdb.TxStatusMessage[status])
+				// Only report the status when it belongs to the holder still in place;
+				// otherwise it describes observedTxID, not e, and pairing the two sends
+				// a reader after the wrong transaction.
+				if unchanged {
+					logger.DebugfContext(ctx, "[%s] already locked by [%s], reclaim failed, tx status [%s]", id, e, ttxdb.TxStatusMessage[observedStatus])
+				} else {
+					logger.DebugfContext(ctx, "[%s] already locked by [%s], reclaim failed, entry changed since the status of [%s] was read", id, e, observedTxID)
+				}
 				if logger.IsEnabledFor(zapcore.DebugLevel) {
 					return e.TxID, errors.Errorf("already locked by [%s]", e)
 				}
 
 				return e.TxID, AlreadyLockedError
 			}
-			logger.DebugfContext(ctx, "[%s] already locked by [%s], reclaimed successful, tx status [%s]", id, e, ttxdb.TxStatusMessage[status])
+			logger.DebugfContext(ctx, "[%s] reclaimed from [%s], tx status [%s]", id, observedTxID, ttxdb.TxStatusMessage[observedStatus])
 		} else {
 			logger.DebugfContext(ctx, "[%s] already locked by [%s], no reclaim", id, e)
 			if logger.IsEnabledFor(zapcore.DebugLevel) {

--- a/token/services/selector/simple/inmemory/locker_test.go
+++ b/token/services/selector/simple/inmemory/locker_test.go
@@ -89,20 +89,22 @@ func (m *mockTXStatusProvider) GetStatus(_ context.Context, txID string) (ttxdb.
 	return m.status(txID), "", nil
 }
 
+// Bounds for the coordination in TestScannerDoesNotDeleteReclaimed. They are far longer than the
+// 20ms scan interval the test drives, so they only fire when something is genuinely wrong, but they
+// keep a missed interleaving from turning into a 10 minute package timeout. Both stay under
+// stopTimeout so that a failing run still lets t.Cleanup's Stop join the scan goroutine instead of
+// leaving it parked in the hook and running its delete phase during later tests. See #2156.
+const (
+	scannerObserveTimeout = 3 * time.Second
+	hookReleaseTimeout    = 3 * time.Second
+)
+
 // TestScannerDoesNotDeleteReclaimed verifies the TOCTOU protection in the
 // scanner: when the scanner has observed a token as removable (its tx is
 // Deleted) and a concurrent Lock(reclaim=true) re-locks that token for a new
 // transaction before the scanner deletes, the scanner must NOT delete the
 // new entry. The test drives the real scan loop and blocks the scanner's
 // status lookup to open the race window deterministically.
-// Bounds for the coordination in TestScannerDoesNotDeleteReclaimed. Both are far longer than the
-// 20ms scan interval the test drives, so they only fire when something is genuinely wrong, but they
-// keep a missed interleaving from turning into a 10 minute package timeout. See #2156.
-const (
-	scannerObserveTimeout = 30 * time.Second
-	hookReleaseTimeout    = 30 * time.Second
-)
-
 func TestScannerDoesNotDeleteReclaimed(t *testing.T) {
 	mock := newMockTXStatusProvider()
 	tokenID := &token.ID{TxId: "tok1", Index: 0}
@@ -133,9 +135,9 @@ func TestScannerDoesNotDeleteReclaimed(t *testing.T) {
 			// (the reclaim's) must pass through or they would deadlock
 			close(entered)
 			// Bounded: if the test fails before reaching close(release), this
-			// goroutine must not sit here forever. Note reclaim() calls
-			// GetStatus while holding the shard lock, so a blocked hook can
-			// hold that lock too.
+			// goroutine must not sit here forever. This blocks the collector's
+			// lookup phase, which deliberately runs without the shard lock, so
+			// parking here does not wedge the shard.
 			select {
 			case <-release:
 			case <-time.After(hookReleaseTimeout):
@@ -207,18 +209,27 @@ func TestReclaimDoesNotHoldShardLockDuringStatusLookup(t *testing.T) {
 	txA := "tx-A"
 
 	mock.setStatus(txA, ttxdb.Pending)
-	// A long sleep timeout keeps the collector out of the way: this test is about
-	// the locking path, not the scanner.
 	d := NewLocker(mock, time.Hour, time.Hour).(*locker)
 	t.Cleanup(func() { _ = d.Stop() })
 	_, err := d.Lock(context.Background(), "w1", tokenID, txA, false)
 	require.NoError(t, err)
+
+	// Stop the collector before arming the hook. A long sleep timeout is not enough
+	// to keep it away: scan runs a full pass before its first sleep, so it can reach
+	// GetStatus while the hook is armed, consume the one-shot below and park there
+	// itself. The reclaim's own lookup would then pass straight through and the test
+	// would pass without ever holding a lookup open inside Lock, which it does even
+	// on the unfixed code. This test is about the locking path, so take the collector
+	// out of the picture entirely.
+	require.NoError(t, d.Stop())
 
 	// Block the next status lookup for tx-A, standing in for a slow transaction store.
 	inLookup := make(chan struct{})
 	unblock := make(chan struct{})
 	var once sync.Once
 	mock.setGetStatusHook(func(txID string) {
+		// Only the reclaim looks up tx-A now that the collector is stopped, so the
+		// one-shot is belt and braces rather than load bearing.
 		if txID != txA {
 			return
 		}

--- a/token/services/selector/simple/inmemory/locker_test.go
+++ b/token/services/selector/simple/inmemory/locker_test.go
@@ -195,3 +195,71 @@ func TestScannerDeletesStaleEntry(t *testing.T) {
 		return !d.IsLocked(tokenID)
 	}, 2*time.Second, 20*time.Millisecond, "stale entry should have been removed by scanner")
 }
+
+// TestReclaimDoesNotHoldShardLockDuringStatusLookup pins the invariant the collector
+// already documents: a status lookup must never run while the shard lock is held.
+// Lock(reclaim=true) used to call GetStatus from under the write lock, so a slow or
+// stuck transaction store blocked every other operation on that owner's shard until
+// it returned.
+func TestReclaimDoesNotHoldShardLockDuringStatusLookup(t *testing.T) {
+	mock := newMockTXStatusProvider()
+	tokenID := &token.ID{TxId: "tok1", Index: 0}
+	txA := "tx-A"
+
+	mock.setStatus(txA, ttxdb.Pending)
+	// A long sleep timeout keeps the collector out of the way: this test is about
+	// the locking path, not the scanner.
+	d := NewLocker(mock, time.Hour, time.Hour).(*locker)
+	t.Cleanup(func() { _ = d.Stop() })
+	_, err := d.Lock(context.Background(), "w1", tokenID, txA, false)
+	require.NoError(t, err)
+
+	// Block the next status lookup for tx-A, standing in for a slow transaction store.
+	inLookup := make(chan struct{})
+	unblock := make(chan struct{})
+	var once sync.Once
+	mock.setGetStatusHook(func(txID string) {
+		if txID != txA {
+			return
+		}
+		first := false
+		once.Do(func() { first = true })
+		if !first {
+			return
+		}
+		close(inLookup)
+		<-unblock
+	})
+
+	// Reclaim in the background; it will stall inside the status lookup.
+	reclaimReturned := make(chan struct{})
+	go func() {
+		defer close(reclaimReturned)
+		_, _ = d.Lock(context.Background(), "w1", tokenID, "tx-B", true)
+	}()
+
+	select {
+	case <-inLookup:
+	case <-time.After(5 * time.Second):
+		close(unblock)
+		t.Fatal("reclaim never reached the status lookup")
+	}
+
+	// The shard must still be usable while that lookup is outstanding. Before the
+	// fix this blocked on the write lock the reclaim was holding, and the test
+	// timed out here.
+	done := make(chan bool, 1)
+	go func() { done <- d.IsLocked(tokenID) }()
+
+	select {
+	case locked := <-done:
+		assert.True(t, locked, "token should still be reported as locked")
+	case <-time.After(5 * time.Second):
+		close(unblock)
+		t.Fatal("IsLocked blocked while a reclaim's status lookup was in flight: " +
+			"the shard lock is being held across GetStatus")
+	}
+
+	close(unblock)
+	<-reclaimReturned
+}

--- a/token/services/selector/simple/inmemory/locker_test.go
+++ b/token/services/selector/simple/inmemory/locker_test.go
@@ -95,6 +95,14 @@ func (m *mockTXStatusProvider) GetStatus(_ context.Context, txID string) (ttxdb.
 // transaction before the scanner deletes, the scanner must NOT delete the
 // new entry. The test drives the real scan loop and blocks the scanner's
 // status lookup to open the race window deterministically.
+// Bounds for the coordination in TestScannerDoesNotDeleteReclaimed. Both are far longer than the
+// 20ms scan interval the test drives, so they only fire when something is genuinely wrong, but they
+// keep a missed interleaving from turning into a 10 minute package timeout. See #2156.
+const (
+	scannerObserveTimeout = 30 * time.Second
+	hookReleaseTimeout    = 30 * time.Second
+)
+
 func TestScannerDoesNotDeleteReclaimed(t *testing.T) {
 	mock := newMockTXStatusProvider()
 	tokenID := &token.ID{TxId: "tok1", Index: 0}
@@ -124,14 +132,31 @@ func TestScannerDoesNotDeleteReclaimed(t *testing.T) {
 			// only the first observer (the scanner) blocks; later lookups
 			// (the reclaim's) must pass through or they would deadlock
 			close(entered)
-			<-release
+			// Bounded: if the test fails before reaching close(release), this
+			// goroutine must not sit here forever. Note reclaim() calls
+			// GetStatus while holding the shard lock, so a blocked hook can
+			// hold that lock too.
+			select {
+			case <-release:
+			case <-time.After(hookReleaseTimeout):
+			}
 		}
 	})
 	mock.setStatus(txA, ttxdb.Deleted)
 
 	// The scanner is now stuck between observing tx-A as removable and
 	// deleting it. Reclaim the token for tx-B in that window.
-	<-entered
+	//
+	// Bounded rather than a bare receive: this test has hung in CI until the
+	// 10 minute package timeout, which hides the failure and takes the rest of
+	// the package's results with it. Failing here says which wait did not
+	// complete. See #2156.
+	select {
+	case <-entered:
+	case <-time.After(scannerObserveTimeout):
+		t.Fatal("scanner never observed tx-A as Deleted: the status hook did not fire within " +
+			scannerObserveTimeout.String())
+	}
 	mock.setStatus(txB, ttxdb.Pending)
 	_, err = d.Lock(context.Background(), "w1", tokenID, txB, true)
 	require.NoError(t, err)


### PR DESCRIPTION
Refs #2156.

I could not reproduce the hang, so this does not claim to fix its cause. It makes the next
occurrence diagnosable instead of silent.

### What this changes

The test coordinates with the locker's scan goroutine over two unbuffered channels, `entered` and
`release`, and receives on both without a bound. If the interleaving it assumes does not happen, the
receive never returns and the package sits until the 10 minute timeout, which hides which wait failed
and takes the rest of the package's results with it.

Both receives are now bounded, well above the 20ms scan interval the test drives, so they only fire
when something is genuinely wrong. The one waiting on the scanner reports what did not happen.

Verified by disabling the status hook so the wait can never be satisfied: it now fails in seconds
with `scanner never observed tx-A as Deleted: the status hook did not fire within 2s`, rather than
hanging.

### On the cause

Not reproducible locally: clean on `main`, and ~260 runs across `-count=120`, `-cpu=1` and whole
package runs under `-race` all passed.

From the CI dump, the scanner was idle in the sleep branch of its collector loop
(`locker.go:429` is the `time.After`/`ctx.Done()` select), not blocked in the hook, while the test
sat on a channel receive for nine minutes. That points at the hook never firing for the scanner
rather than the two goroutines deadlocking against each other, but I could not pin the interleaving
that produces it.

One thing worth a separate look, found while reading rather than from the failure:
`lockInShard` holds the shard lock across `reclaim`, which calls `GetStatus`
(`locker.go:172-185`, `306-307`). An external status lookup under a shard lock means a slow or
blocking provider stalls every `Lock` and `Unlock` for that owner. It also means a hook that blocks
there blocks while holding the lock. That is a latent hazard regardless of this test, and I have
noted it on #2156 rather than changing production code in a test-only PR.

---

## Added: the production fix

Went back through the locking path properly rather than leaving this test-only.

`Lock(reclaim=true)` called `GetStatus` from inside `lockInShard` **while holding the shard write
lock** (`locker.go:172-185` and the old `reclaim` at `306-307`). `GetStatus` goes to the transaction
store, so a slow or stuck store blocked every `Lock`, `UnlockIDs` and `IsLocked` for that owner, and
the collector deleting phase with them, for the duration of the query.

The collector already avoids precisely this, and states the rule:

> Copy the entries and release the shard lock before looking their status up: the lookups may be
> slow, and no Lock/UnlockIDs of this owner must ever wait behind the collector on the status
> provider.

The reclaim path inverted that: it made the collector, and everything else on the shard, wait behind
*the locker* on the status provider.

**Fix**: resolve the holder status before taking the write lock, then re-validate under it, the same
phase split the collector uses. If the entry changed hands while the lock was released, the reclaim
is refused and the caller retries, rather than taking a token away from its new holder. The old
`reclaim` helper had one caller and is gone.

**Regression test**: blocks a status lookup and asserts the shard is still usable while it is in
flight. On the old code it fails with `IsLocked blocked while a reclaim status lookup was in flight`,
after it passes.

This is a real hazard on its own merits and I am not claiming it is the cause of the intermittent
hang, which I still could not reproduce. It does remove the mechanism by which a blocking status
provider can wedge a shard, which is the closest thing to that shape I could find in the code.
