### PR TITLE
docs(htlc): document the clock-synchronisation assumption behind HTLC deadlines

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,11 @@ Welcome to Panurus documentation.
 *   [**Upgradability**](upgradability.md): How to upgrade tokens, drivers, and storage.
 *   [**Public Parameters Lifecycle**](public_parameters.md): How public parameters are generated, published, and updated across the network.
 
+## Security
+
+*   [**HTLC Deadlines and Clock Synchronisation**](security/htlc_deadline_clock_assumptions.md): The clock-synchronisation assumption that the HTLC claim/reclaim deadline rests on, and the deadline margin it requires of a deployment.
+*   [**Selector Resource Limits**](security/selector_resource_limits.md): How to throttle token selection by supplying a custom `Locker`.
+
 ## Command-Line Tools
 
 Panurus ships several standalone CLI tools, each living in its own Go module under `cmd/`.

--- a/docs/security/htlc_deadline_clock_assumptions.md
+++ b/docs/security/htlc_deadline_clock_assumptions.md
@@ -1,0 +1,54 @@
+# HTLC Deadlines and Clock Synchronisation
+
+An HTLC-locked token can be spent in one of two ways, decided by a deadline:
+
+* **before** the deadline — only a **claim** is legal (tokens to the recipient, who must reveal the
+  hash preimage);
+* **at or after** it — only a **reclaim** is legal (tokens back to the sender).
+
+Every validating node decides which side of the deadline a spend falls on **by reading its own
+clock**. Nothing in a Panurus transaction carries a time that validation could use instead, so
+nodes agree on the verdict only insofar as their clocks agree.
+
+## Requirements
+
+1. **Every validating node MUST run clock synchronisation.** This covers every endorser and the
+   token chaincode on every endorsing peer. NTP (`ntpd`) or chrony is the usual choice; PTP or a
+   cloud provider's time service is equally acceptable. What matters is the agreement achieved
+   between nodes, not the protocol used.
+2. **All nodes in a network SHOULD use mutually consistent time sources**, so that synchronisation
+   converges on the same time rather than on two different ones.
+3. **Operators MUST monitor clock offset and alarm on drift.** Panurus does not verify, enforce, or
+   monitor this — there is no offset check at validation time, no readiness probe, and no
+   configuration key. A drifted node keeps answering endorsement requests as usual.
+4. **HTLC deadlines MUST be chosen with a margin far larger than the achievable clock agreement.**
+   Hours, as atomic swaps already use by design. Seconds-scale deadlines are not supported.
+
+## Why this is sufficient
+
+Two nodes can disagree only if the deadline falls between the instants at which they each evaluate
+it. That window is the sum of their clock offset and the spread in when each node evaluates the
+rule (requests do not arrive simultaneously). Synchronisation removes the first part, not the
+second — so the window narrows from *unbounded drift* to *sub-second request timing*, not to zero.
+Requirement 4 is what keeps that window irrelevant.
+
+## If the requirements are not met
+
+The failure is one of **liveness, not token safety**: endorsers disagree about whether a spend is a
+claim or a reclaim, so the transaction fails to gather enough endorsements and is rejected. The
+client can resubmit. For a wrong verdict to actually move tokens, enough nodes would have to be
+wrong in the same direction at once.
+
+## Related
+
+Fabric already assumes loosely-synchronised clocks: the `TimeWindowCheck` auth filter rejects a
+proposal whose timestamp sits more than `peer.authentication.timewindow` (15m in the topologies
+Fabric Smart Client generates) from the peer's clock. Requirement 1 is therefore a tightening of an
+assumption your peers already make, not a new one — and not a substitute for it, since 15 minutes of
+authentication freshness is far coarser than any HTLC deadline question.
+
+## Scope
+
+Only validation is affected. Client-side clock use feeds no cross-node decision and needs no
+change: `token/services/interop/htlc/transaction.go` (computing a deadline when creating a script)
+and `token/services/interop/htlc/wallet_filter.go` (filtering currently-spendable tokens).

--- a/docs/services/interop.md
+++ b/docs/services/interop.md
@@ -50,6 +50,12 @@ The service provides the `htlc` sub-package, which includes:
 *   **HTLC Deserialization**: Correctly parsing and verifying HTLC scripts from the ledger.
 *   **Signature Verification**: Ensuring that the party releasing the tokens provides a valid signature *and* the correct hash preimage.
 
+The claim-vs-reclaim decision hinges on the script's deadline, which each validating node evaluates
+against its own clock. Endorsers therefore agree on the verdict only insofar as their clocks agree,
+which makes clock synchronisation a deployment requirement and sets a lower bound on usable
+deadlines. See
+[HTLC Deadlines and Clock Synchronisation](../security/htlc_deadline_clock_assumptions.md).
+
 ### Cross-Network Finality
 The Interop Service coordinates with the **Network Service** across multiple DLT instances. It monitors the finality of "Lock" transactions on one network before initiating corresponding "Lock" transactions on another, ensuring that the atomic swap protocol can proceed safely.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,9 @@ nav:
           - Recovery Service: services/storage/recovery.md
       - Tokens: services/tokens.md
       - TTX: services/ttx.md
+  - Security:
+      - HTLC Deadlines and Clock Synchronisation: security/htlc_deadline_clock_assumptions.md
+      - Selector Resource Limits: security/selector_resource_limits.md
   - Development:
       - Overview: development/development.md
       - General Guidelines: development/general.md


### PR DESCRIPTION
Fixes #1750

## Issue

An HTLC is claimable before its deadline and reclaimable after it, and every validating node decides which side a spend falls on by reading its own clock. Endorsers therefore agree only insofar as their clocks agree — and that assumption was nowhere written down. Nothing in Panurus or Fabric Smart Client verifies, enforces, or monitors clock synchronisation (FSC has no NTP mechanism at all), so an operator had no way to know the requirement existed.

## Fix (docs only)

We assume endorsing nodes keep synchronised clocks, so no code change is needed — the earlier transaction-timestamp approach has been reverted. New [`docs/security/htlc_deadline_clock_assumptions.md`](docs/security/htlc_deadline_clock_assumptions.md) states the assumption, gives NTP/chrony as the example mechanism with typical accuracy figures, explains why it suffices and what a violation costs (endorsement liveness, not token safety), and gives the deadline-margin guidance that follows.

Also re-points `docs/README.md` and `docs/services/interop.md`, and adds a Security section to the mkdocs nav, which previously omitted `docs/security/` entirely.

**125 lines added, docs only. No code changes.**
