### PR TITLE
fix(identity): bound nesting depth and fan-out when deserializing composite identities

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -99,6 +99,9 @@ jobs:
           - name: fabricx-endorser-for-threshold-rule
             pkg: ./token/services/network/fabricx/endorsement
             func: FuzzEndorserForThresholdRuleNoPanic
+          - name: fabtoken-owner-verifier
+            pkg: ./token/core/fabtoken/v1/driver
+            func: FuzzOwnerVerifierNoPanic
 
     steps:
       - name: Checkout code

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,6 +129,8 @@ token:
       maxMetadataKeyBytes: 256
       maxMetadataValueBytes: 4096
       maxProofBytes: 131072
+      maxIdentityDepth: 5
+      maxIdentityComponents: 16
 
   # optional global SQL table name overrides (applied to all TMS instances).
   # The value replaces the short code; the FSC-generated prefix and params still wrap it.
@@ -512,6 +514,8 @@ token:
       maxMetadataKeyBytes: 256
       maxMetadataValueBytes: 4096
       maxProofBytes: 131072
+      maxIdentityDepth: 5
+      maxIdentityComponents: 16
 ```
 
 Default values:
@@ -527,6 +531,10 @@ Default values:
 - maxMetadataKeyBytes: 256
 - maxMetadataValueBytes: 4096 (4 KiB)
 - maxProofBytes: 131072 (128 KiB) — ignored by drivers without a zero-knowledge proof (fabtoken)
+- maxIdentityDepth: 5 — how deeply composite owner identities (multisig, policy, HTLC script) may
+  nest inside one another. Real deployments nest 2–3 levels, e.g. a policy over a multisig over x509
+- maxIdentityComponents: 16 — how many component identities a single composite identity may carry.
+  Bounds fan-out, which maxIdentityDepth does not
 
 Every field is optional; any field omitted (or the whole `token.validation.limits` key omitted)
 resolves to its default. Read via the config service, so this key applies only to the FSC/DI

--- a/docs/drivers/validation-resource-limits.md
+++ b/docs/drivers/validation-resource-limits.md
@@ -10,11 +10,11 @@ The token request validators (`token/core/common`, and the fabtoken/zkatdlog dri
 of it) accept raw, attacker-controlled bytes over the network. Aside from the signing anchor
 (`driver.MaxAnchorSize`), nothing else bounds the size of the raw request, the number of actions or
 signatures, the size of an individual action or signature, the number of inputs/outputs/metadata
-entries in an action, or the length of a zero-knowledge proof — unless these limits are enforced.
-Without them, an attacker could force unbounded allocations
-(`make([]..., len(attackerControlledCount))`) and expensive cryptographic work (proof
-deserialization, ZK verification) purely by shaping the wire bytes, without needing any valid
-signature.
+entries in an action, the length of a zero-knowledge proof, or how deeply a composite owner identity
+nests — unless these limits are enforced. Without them, an attacker could force unbounded allocations
+(`make([]..., len(attackerControlledCount))`), unbounded recursion (a composite identity nested
+inside itself), and expensive cryptographic work (proof deserialization, ZK verification) purely by
+shaping the wire bytes, without needing any valid signature.
 
 ## Configuration mechanism
 
@@ -37,6 +37,8 @@ Two sources resolve a `driver.ResourceLimits` value at composition-root time, bo
       limits:
         maxActions: 128
         maxProofBytes: 65536
+        maxIdentityDepth: 5
+        maxIdentityComponents: 16
   ```
 
   Every field is optional; an entirely absent `token.validation.limits` key resolves to
@@ -156,6 +158,81 @@ Auditor-side deserializers (`.../audit/auditor.go` in both drivers) are not the
 consensus-endorsement boundary and are unaffected by this configuration mechanism — they always
 run with `DefaultResourceLimits()`.
 
+### 3. Composite identity nesting
+
+A token's owner is an identity, and three identity types are *composite* — their components are
+themselves identities:
+
+| Type | Registered as | Components |
+| --- | --- | --- |
+| `multisig` (`token/services/identity/multisig`) | `driver.MultiSigIdentityType` | N component identities, all of which must sign |
+| `boolpolicy` (`token/services/identity/boolpolicy`) | `driver.PolicyIdentityType` | N component identities, combined by a boolean expression |
+| `htlc` (`token/services/identity/interop/htlc`) | `htlc.ScriptType` | the script's sender and recipient |
+
+Each driver's `NewDeserializer` (`token/core/fabtoken/v1/driver/deserializer.go`,
+`token/core/zkatdlog/nogh/v1/driver/deserializer.go`) registers the verifier multiplex as the
+*component* deserializer for all three, including for itself:
+
+```go
+des := deserializer.NewTypedVerifierDeserializerMultiplex()
+...
+des.AddTypedVerifierDeserializer(htlc2.ScriptType, htlc.NewTypedIdentityDeserializer(des))
+des.AddTypedVerifierDeserializer(multisig.Multisig, multisig.NewTypedIdentityDeserializer(des, des))
+des.AddTypedVerifierDeserializer(boolpolicy.Policy, boolpolicy.NewTypedIdentityDeserializer(des, des))
+```
+
+That self-registration is what makes composite identities compose — a policy over a multisig over an
+x509 identity resolves correctly — and it is also what makes the recursion unbounded without an
+explicit budget. `GetOwnerVerifier` is called once per input token from the transfer validator, so an
+attacker-shaped owner identity drives that recursion **before any signature is verified**.
+
+Two bounds close it:
+
+| Field | Default | Bounds |
+| --- | --- | --- |
+| `MaxIdentityDepth` | 5 | How deeply composite identities may nest inside one another |
+| `MaxIdentityComponents` | 16 | How many components a single composite identity may carry |
+
+Both are needed. Depth alone does not bound fan-out (one level with thousands of components is a
+single recursive step doing unbounded work), and fan-out alone does not bound depth. Real deployments
+nest 2–3 levels — a policy over a multisig over x509 — comfortably inside the default.
+
+The depth budget is carried in `context.Context` (`token/driver/identity_nesting.go`), which is
+already the first parameter of every method in the recursion. `driver.EnterCompositeIdentity(ctx)`
+accounts for one level and returns the context to pass to the components; it returns an error
+wrapping `driver.ErrIdentityNestingTooDeep` past the limit. Exceeding `MaxIdentityComponents` returns
+`driver.ErrTooManyIdentityComponents`. Because the count rides in the context, it is **per-path**:
+sibling components each descend from their parent's depth rather than sharing a running total, which
+is the correct semantics for a depth bound and the reason the fan-out bound is required alongside it.
+
+There are four independent recursion chains, each of which accounts for its own depth — the matcher
+paths recurse separately from the deserialization that produced them, so a budget spent during
+construction must not be inherited at match time:
+
+| Chain | Entry point |
+| --- | --- |
+| Verifier deserialization | `TypedIdentityDeserializer.DeserializeVerifier` in all three packages |
+| Matcher construction | `TypedIdentityDeserializer.GetAuditInfoMatcher` (`multisig`, `boolpolicy`) |
+| Matcher evaluation | `InfoMatcher.Match` (`multisig`, `boolpolicy`), `AuditInfoMatcher.Match` (`htlc`) |
+| Audit-info collection | `TypedIdentityDeserializer.GetAuditInfo` in all three packages |
+
+Validators seed the configured limits into the context at each public entry point
+(`(*Validator).withIdentityNestingLimits`, `token/core/common/limits.go`). Composite identity
+deserialization is also reachable from paths that carry no `ResourceLimits` — a wallet resolving a
+recipient, an auditor inspecting a request, tests — and those **still get the defaults** rather than
+running unbounded, so a seeding site added later and forgotten weakens the bound to the default
+instead of disabling it.
+
+The fan-out bound is applied on every chain above that walks a component list — verifier
+deserialization, matcher construction and audit-info collection — through the same
+`validateComponentIdentities` choke point, which also rejects an empty or duplicated component. The
+matcher-evaluation chain needs no separate check: its component count is fixed by the matcher tree
+built during construction, which was already bounded.
+
+The fan-out bound is also applied on the honest-caller path, in `multisig.WrapIdentities` and
+`boolpolicy.WrapPolicyIdentity`, so an identity constructed in-process cannot exceed what a validator
+will later accept.
+
 ## Choosing and changing these values
 
 The default values are conservative but comfortably above real usage observed across the unit,
@@ -186,9 +263,20 @@ of the defaults. If a deployment needs a different limit:
   oversized proof is rejected in well under 50ms — i.e. before any verifier is constructed. This is
   a timing property, verified as a plain (non-fuzzed) unit test so it isn't subject to fuzz-worker
   CPU contention.
+- **Identity-nesting tests**: `nesting_test.go` in `multisig` and `boolpolicy` covers each of the
+  four recursion chains at `limit` and `limit+1`, that the depth counter is per-path rather than
+  global, and that an unseeded context is still bounded by the defaults.
+  `deserializer_nesting_test.go` (`token/core/fabtoken/v1/driver`) proves the same against the real
+  assembled multiplex, including composite types alternating with each other so that no type gets a
+  fresh budget, and asserts a realistic three-level identity is *not* rejected as over-nested.
 - **Fuzzing**: `common.FuzzRequestResourceLimits`, `zkatdlog validator.FuzzActionResourceLimits`,
   and `fabtoken validator.FuzzActionResourceLimits` fuzz requests/actions shaped directly by their
   resource dimensions (counts and byte lengths) against `DefaultResourceLimits()`, asserting no
-  panic and the expected typed error at every boundary. Each target has a persisted seed corpus
-  under its package's `testdata/fuzz/<TargetName>/` covering every default's boundary, and runs
-  nightly via [`.github/workflows/nightly-fuzz.yml`](../../.github/workflows/nightly-fuzz.yml).
+  panic and the expected typed error at every boundary. `fabtoken driver.FuzzOwnerVerifierNoPanic`
+  additionally fuzzes the owner-identity deserialization path itself — the one reached from the
+  transfer validator once per input token — seeded with identities nested from 1 to 600 levels deep.
+  The three resource-dimension targets each have a persisted seed corpus under their package's
+  `testdata/fuzz/<TargetName>/` covering every default's boundary; `FuzzOwnerVerifierNoPanic` seeds
+  from code only, since its interesting shapes are generated (nesting depth) rather than enumerated.
+  All of them run nightly via
+  [`.github/workflows/nightly-fuzz.yml`](../../.github/workflows/nightly-fuzz.yml).

--- a/token/core/common/limits.go
+++ b/token/core/common/limits.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package common
 
 import (
+	"context"
+
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
@@ -32,6 +34,19 @@ var (
 	// ErrActionTooLarge is returned when an action's raw bytes exceed Limits.MaxActionBytes.
 	ErrActionTooLarge = errors.New("action exceeds maximum allowed size")
 )
+
+// withIdentityNestingLimits returns a context carrying this validator's bounds on composite
+// identity nesting, so that the deserializers that turn an untrusted owner identity into a
+// verifier enforce the configured limits rather than the package defaults.
+//
+// It is called at each public entry point of the validator rather than deeper down because the
+// owner identity is reached from several of them - transfer input verification, auditing, the
+// matcher path - and seeding once at the top covers all of them. Deserialization reached from a
+// context that was never seeded still gets the defaults, so a missed entry point weakens the bound
+// to the default rather than removing it (see driver.EnterCompositeIdentity).
+func (v *Validator[P, T, TA, IA, DS]) withIdentityNestingLimits(ctx context.Context) context.Context {
+	return driver.WithIdentityNestingLimits(ctx, v.Limits.MaxIdentityDepth, v.Limits.MaxIdentityComponents)
+}
 
 // CheckRawRequestSize rejects raw token request bytes that exceed v.Limits.MaxRequestBytes.
 // It must be called before unmarshalling so oversized payloads are rejected before any

--- a/token/core/common/validator.go
+++ b/token/core/common/validator.go
@@ -134,6 +134,7 @@ func (v *Validator[P, T, TA, IA, DS]) VerifyTokenRequestFromRaw(ctx context.Cont
 	if len(raw) == 0 {
 		return nil, nil, errors.New("empty token request")
 	}
+	ctx = v.withIdentityNestingLimits(ctx)
 	if err := v.CheckRawRequestSize(raw); err != nil {
 		return nil, nil, err
 	}
@@ -232,6 +233,7 @@ func (v *Validator[P, T, TA, IA, DS]) VerifyTokenRequest(
 	if utils.IsNil(v.ActionDeserializer) {
 		return nil, nil, ErrNilActionDeserializer
 	}
+	ctx = v.withIdentityNestingLimits(ctx)
 	if err := v.VerifyAuditing(ctx, anchor, tr, ledger, signatureProvider, attributes); err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to verify auditor signatures [%s]", anchor)
 	}

--- a/token/core/fabtoken/v1/driver/deserializer_nesting_test.go
+++ b/token/core/fabtoken/v1/driver/deserializer_nesting_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/json"
+	tdriver "github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/boolpolicy"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/multisig"
+	htlc2 "github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the real production wiring in NewDeserializer, where the verifier multiplex
+// is registered as its own component deserializer for multisig, boolpolicy and htlc. That
+// self-registration is what makes the recursion unbounded in principle, so the bound has to be
+// proven against the assembled multiplex and not only against the individual deserializers.
+
+func wrapMultisig(t *testing.T, ids ...token.Identity) token.Identity {
+	t.Helper()
+	inner, err := (&multisig.MultiIdentity{Identities: ids}).Bytes()
+	require.NoError(t, err)
+	envelope, err := (&identity.TypedIdentity{Type: multisig.Multisig, Identity: inner}).Bytes()
+	require.NoError(t, err)
+
+	return envelope
+}
+
+func wrapPolicy(t *testing.T, ids ...token.Identity) token.Identity {
+	t.Helper()
+	raw := make([][]byte, len(ids))
+	for k := range ids {
+		raw[k] = ids[k]
+	}
+	inner, err := (&boolpolicy.PolicyIdentity{Policy: "$0", Identities: raw}).Bytes()
+	require.NoError(t, err)
+	envelope, err := (&identity.TypedIdentity{Type: boolpolicy.Policy, Identity: inner}).Bytes()
+	require.NoError(t, err)
+
+	return envelope
+}
+
+func wrapHTLC(t *testing.T, sender, recipient token.Identity) token.Identity {
+	t.Helper()
+	inner, err := json.Marshal(&htlc2.Script{Sender: sender, Recipient: recipient})
+	require.NoError(t, err)
+	envelope, err := (&identity.TypedIdentity{Type: htlc2.ScriptType, Identity: inner}).Bytes()
+	require.NoError(t, err)
+
+	return envelope
+}
+
+// A single-component multisig identity nested far past any plausible limit must be rejected rather
+// than walked. This is the shape from the report: the cheapest bytes per level, so the deepest
+// recursion for a given identity size.
+func TestGetOwnerVerifier_RejectsDeeplyNestedMultisig(t *testing.T) {
+	des := NewDeserializer()
+
+	id := token.Identity("leaf")
+	for range 512 {
+		id = wrapMultisig(t, id)
+	}
+
+	_, err := des.GetOwnerVerifier(context.Background(), id)
+	require.ErrorIs(t, err, tdriver.ErrIdentityNestingTooDeep)
+}
+
+// Alternating the composite types must not let an attacker spend a fresh budget at each type: the
+// depth is counted per descent, not per type.
+//
+// The nesting here is shallower than in the multisig-only case on purpose: an htlc level carries its
+// children as JSON, which base64-encodes them, so each htlc level inflates the identity by about a
+// third and the size grows exponentially in the number of them. 24 levels is already far past any
+// configurable bound.
+func TestGetOwnerVerifier_RejectsDeeplyNestedMixedTypes(t *testing.T) {
+	des := NewDeserializer()
+
+	id := token.Identity("leaf")
+	for i := range 24 {
+		switch i % 3 {
+		case 0:
+			id = wrapMultisig(t, id)
+		case 1:
+			id = wrapPolicy(t, id)
+		default:
+			id = wrapHTLC(t, id, token.Identity("recipient-"+strconv.Itoa(i)))
+		}
+	}
+
+	_, err := des.GetOwnerVerifier(context.Background(), id)
+	require.ErrorIs(t, err, tdriver.ErrIdentityNestingTooDeep)
+}
+
+// A composite identity that fans out far more widely than the limit must be rejected before any
+// component is deserialized, since depth alone does not bound fan-out.
+func TestGetOwnerVerifier_RejectsWideFanOut(t *testing.T) {
+	des := NewDeserializer()
+
+	ids := make([]token.Identity, 4096)
+	for k := range ids {
+		ids[k] = token.Identity("identity-" + strconv.Itoa(k))
+	}
+
+	_, err := des.GetOwnerVerifier(context.Background(), wrapMultisig(t, ids...))
+	require.ErrorIs(t, err, tdriver.ErrTooManyIdentityComponents)
+
+	_, err = des.GetOwnerVerifier(context.Background(), wrapPolicy(t, ids...))
+	require.ErrorIs(t, err, tdriver.ErrTooManyIdentityComponents)
+}
+
+// Nesting within the limit must fail for a reason other than the bound: an x509 leaf is not
+// available here, so the descent is expected to reach the leaf and fail there. What matters is that
+// it is *not* rejected as over-nested, which is what proves the bound does not fire on real shapes.
+func TestGetOwnerVerifier_AllowsRealisticNesting(t *testing.T) {
+	des := NewDeserializer()
+
+	// policy over multisig over a leaf identity - three levels, the deepest shape described as
+	// realistic in the report
+	id := wrapPolicy(t, wrapMultisig(t, token.Identity("leaf")))
+
+	_, err := des.GetOwnerVerifier(context.Background(), id)
+	require.Error(t, err, "the leaf identity is not a valid x509 identity, so the descent still fails")
+	require.NotErrorIs(t, err, tdriver.ErrIdentityNestingTooDeep,
+		"a three-level identity must not be rejected as over-nested")
+	require.NotErrorIs(t, err, tdriver.ErrTooManyIdentityComponents)
+}
+
+// The bound also has to hold on the matcher path, which recurses independently of verifier
+// deserialization. The audit info has to be nested in step with the identity, otherwise the descent
+// stops early on a component-count mismatch and never reaches the depth being tested.
+//
+// The nesting is shallower than in the verifier case because each level base64-encodes the level
+// below it in JSON, so the size grows exponentially. 24 levels is far past any configurable bound.
+func TestMatchIdentity_RejectsDeeplyNestedIdentity(t *testing.T) {
+	des := NewDeserializer()
+
+	id := token.Identity("leaf")
+	auditInfo := []byte("leaf-audit-info")
+	for range 24 {
+		id = wrapMultisig(t, id)
+		nested, err := json.Marshal(&multisig.AuditInfo{
+			IdentityAuditInfos: []multisig.IdentityAuditInfo{{AuditInfo: auditInfo}},
+		})
+		require.NoError(t, err)
+		auditInfo = nested
+	}
+
+	err := des.MatchIdentity(context.Background(), id, auditInfo)
+	require.ErrorIs(t, err, tdriver.ErrIdentityNestingTooDeep)
+}
+
+// FuzzOwnerVerifierNoPanic drives the owner-identity deserialization path, the one reached from the
+// transfer validator once per input token before any signature is checked, with arbitrary bytes. It
+// must always return - never panic, and never recurse without bound.
+func FuzzOwnerVerifierNoPanic(f *testing.F) {
+	nest := func(depth int) []byte {
+		id := []byte("leaf")
+		for range depth {
+			inner, err := (&multisig.MultiIdentity{Identities: []token.Identity{id}}).Bytes()
+			if err != nil {
+				return id
+			}
+			envelope, err := (&identity.TypedIdentity{Type: multisig.Multisig, Identity: inner}).Bytes()
+			if err != nil {
+				return id
+			}
+			id = envelope
+		}
+
+		return id
+	}
+
+	f.Add([]byte{})
+	f.Add([]byte("not an identity"))
+	f.Add(nest(1))
+	f.Add(nest(3))
+	// the shape from the report: nesting far past any plausible bound
+	f.Add(nest(64))
+	f.Add(nest(600))
+	// a truncated deep identity, so the fuzzer starts from partially valid DER as well
+	if deep := nest(64); len(deep) > 8 {
+		f.Add(deep[:len(deep)/2])
+	}
+
+	des := NewDeserializer()
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		// the contract is only that this returns; a verifier or an error are both fine
+		_, _ = des.GetOwnerVerifier(context.Background(), raw)
+		_ = des.MatchIdentity(context.Background(), raw, []byte(`{"IdentityAuditInfos":[{}]}`))
+		_, _ = des.Recipients(raw)
+	})
+}

--- a/token/driver/identity_nesting.go
+++ b/token/driver/identity_nesting.go
@@ -1,0 +1,107 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import (
+	"context"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// ErrIdentityNestingTooDeep is returned when a composite identity nests more deeply than
+// ResourceLimits.MaxIdentityDepth allows. Callers that need to distinguish a malformed identity
+// from an over-nested one can test for it with errors.Is.
+var ErrIdentityNestingTooDeep = errors.New("composite identity nesting is too deep")
+
+// ErrTooManyIdentityComponents is returned when a composite identity carries more component
+// identities than ResourceLimits.MaxIdentityComponents allows.
+var ErrTooManyIdentityComponents = errors.New("composite identity has too many components")
+
+// identityNestingKey is the private context key under which the identity-nesting budget is
+// carried. It is a distinct unexported type so that no other package can collide with it.
+type identityNestingKey struct{}
+
+// identityNesting is the budget for one descent through a composite identity: the limits in
+// force, plus how many levels the current path has already consumed.
+type identityNesting struct {
+	depth         int
+	maxDepth      int
+	maxComponents int
+}
+
+// WithIdentityNestingLimits returns a copy of ctx carrying the bounds that
+// EnterCompositeIdentity and MaxIdentityComponentsFrom enforce while deserializing composite
+// identities. Non-positive values are replaced by the corresponding defaults, so a partially
+// specified ResourceLimits can never silently disable a bound.
+//
+// Validators should seed this from the ResourceLimits they were built with, so that the bound a
+// peer applies to an untrusted owner identity is the configured one. Any descent whose context
+// was never seeded still gets the defaults - see EnterCompositeIdentity.
+func WithIdentityNestingLimits(ctx context.Context, maxDepth, maxComponents int) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	d := DefaultResourceLimits()
+	if maxDepth <= 0 {
+		maxDepth = d.MaxIdentityDepth
+	}
+	if maxComponents <= 0 {
+		maxComponents = d.MaxIdentityComponents
+	}
+
+	return context.WithValue(ctx, identityNestingKey{}, identityNesting{
+		maxDepth:      maxDepth,
+		maxComponents: maxComponents,
+	})
+}
+
+// nestingFrom returns the nesting budget carried by ctx, falling back to a fresh budget built
+// from the default limits when ctx carries none.
+//
+// Defaulting rather than treating an unseeded context as unbounded is deliberate. Composite
+// identity deserialization is reachable from paths that have no ResourceLimits to seed - wallets
+// resolving a recipient, an auditor inspecting a request, tests - and the failure mode of a
+// seeding site that is added later and forgotten should be a bound that still holds, not one that
+// is silently switched off. Legitimate identities nest 2-3 levels, well inside the defaults.
+func nestingFrom(ctx context.Context) identityNesting {
+	if ctx != nil {
+		if n, ok := ctx.Value(identityNestingKey{}).(identityNesting); ok {
+			return n
+		}
+	}
+	d := DefaultResourceLimits()
+
+	return identityNesting{maxDepth: d.MaxIdentityDepth, maxComponents: d.MaxIdentityComponents}
+}
+
+// EnterCompositeIdentity accounts for one level of composite-identity nesting and returns the
+// context to use for the components one level down. It returns an error wrapping
+// ErrIdentityNestingTooDeep once the path has consumed MaxIdentityDepth levels.
+//
+// Call it at the top of every step that recurses into a component identity, and pass the
+// *returned* context to the components - passing the original one down leaves the counter at zero
+// and the bound unenforced. Because the count rides in the context, it is per-path: sibling
+// components each start from their parent's depth rather than sharing a running total. That is the
+// right semantics for a depth bound, and it is why the fan-out bound below is needed too.
+func EnterCompositeIdentity(ctx context.Context) (context.Context, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	n := nestingFrom(ctx)
+	if n.depth >= n.maxDepth {
+		return nil, errors.Wrapf(ErrIdentityNestingTooDeep, "nesting exceeds the maximum depth of %d", n.maxDepth)
+	}
+	n.depth++
+
+	return context.WithValue(ctx, identityNestingKey{}, n), nil
+}
+
+// MaxIdentityComponentsFrom returns the maximum number of component identities a single composite
+// identity may carry under the limits in force for ctx.
+func MaxIdentityComponentsFrom(ctx context.Context) int {
+	return nestingFrom(ctx).maxComponents
+}

--- a/token/driver/identity_nesting_test.go
+++ b/token/driver/identity_nesting_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A context that was never seeded must still be bounded, by the defaults. Composite identity
+// deserialization is reachable from paths that have no ResourceLimits to seed, and the failure mode
+// of a seeding site that is added later and forgotten must be a bound that still holds.
+func TestEnterCompositeIdentity_UnseededContextUsesDefaults(t *testing.T) {
+	maxDepth := DefaultResourceLimits().MaxIdentityDepth
+	require.Positive(t, maxDepth)
+
+	ctx := context.Background()
+	for i := range maxDepth {
+		next, err := EnterCompositeIdentity(ctx)
+		require.NoError(t, err, "descent to depth %d should be allowed", i+1)
+		//nolint:fatcontext // deriving one context per level is the mechanism under test: each
+		// iteration stands in for one step down a nested composite identity, which is exactly how
+		// the deserializers descend.
+		ctx = next
+	}
+
+	_, err := EnterCompositeIdentity(ctx)
+	require.ErrorIs(t, err, ErrIdentityNestingTooDeep)
+}
+
+func TestEnterCompositeIdentity_NilContextUsesDefaults(t *testing.T) {
+	//nolint:staticcheck // exercising the nil-context guard deliberately
+	ctx, err := EnterCompositeIdentity(nil)
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+}
+
+func TestEnterCompositeIdentity_HonoursConfiguredDepth(t *testing.T) {
+	ctx := WithIdentityNestingLimits(context.Background(), 2, 4)
+
+	ctx, err := EnterCompositeIdentity(ctx)
+	require.NoError(t, err)
+	ctx, err = EnterCompositeIdentity(ctx)
+	require.NoError(t, err)
+
+	_, err = EnterCompositeIdentity(ctx)
+	require.ErrorIs(t, err, ErrIdentityNestingTooDeep)
+	assert.Contains(t, err.Error(), "maximum depth of 2")
+}
+
+// The depth counter rides in the context, so it is per-path: two sibling components each descend
+// from their parent's depth rather than sharing a running total. This is the property that makes
+// the separate fan-out bound necessary, so pin it explicitly.
+func TestEnterCompositeIdentity_DepthIsPerPathNotGlobal(t *testing.T) {
+	root := WithIdentityNestingLimits(context.Background(), 2, 4)
+
+	parent, err := EnterCompositeIdentity(root)
+	require.NoError(t, err)
+
+	// both siblings descend one level from the same parent, and both are allowed
+	firstChild, err := EnterCompositeIdentity(parent)
+	require.NoError(t, err)
+	secondChild, err := EnterCompositeIdentity(parent)
+	require.NoError(t, err)
+
+	// each has now consumed the full budget along its own path
+	_, err = EnterCompositeIdentity(firstChild)
+	require.ErrorIs(t, err, ErrIdentityNestingTooDeep)
+	_, err = EnterCompositeIdentity(secondChild)
+	require.ErrorIs(t, err, ErrIdentityNestingTooDeep)
+}
+
+// A non-positive limit must not be readable as "unlimited": zero would make the very first descent
+// fail, and a negative value would make every descent succeed.
+func TestWithIdentityNestingLimits_NonPositiveFallsBackToDefaults(t *testing.T) {
+	d := DefaultResourceLimits()
+
+	for _, tc := range []struct {
+		name                    string
+		maxDepth, maxComponents int
+	}{
+		{"zero", 0, 0},
+		{"negative", -1, -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := WithIdentityNestingLimits(context.Background(), tc.maxDepth, tc.maxComponents)
+
+			assert.Equal(t, d.MaxIdentityComponents, MaxIdentityComponentsFrom(ctx))
+
+			_, err := EnterCompositeIdentity(ctx)
+			require.NoError(t, err, "the first descent must be allowed")
+		})
+	}
+}
+
+func TestMaxIdentityComponentsFrom(t *testing.T) {
+	assert.Equal(t, DefaultResourceLimits().MaxIdentityComponents, MaxIdentityComponentsFrom(context.Background()))
+	//nolint:staticcheck // exercising the nil-context guard deliberately
+	assert.Equal(t, DefaultResourceLimits().MaxIdentityComponents, MaxIdentityComponentsFrom(nil))
+	assert.Equal(t, 7, MaxIdentityComponentsFrom(WithIdentityNestingLimits(context.Background(), 3, 7)))
+}
+
+// The component cap must survive a descent, so that a nested composite identity is held to the same
+// fan-out bound as the outermost one.
+func TestMaxIdentityComponentsFrom_SurvivesDescent(t *testing.T) {
+	ctx, err := EnterCompositeIdentity(WithIdentityNestingLimits(context.Background(), 4, 7))
+	require.NoError(t, err)
+	ctx, err = EnterCompositeIdentity(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 7, MaxIdentityComponentsFrom(ctx))
+}
+
+// Callers distinguish an over-nested identity from a malformed one with errors.Is, so the sentinel
+// has to survive the wrapping the deserializers add on the way out.
+func TestErrIdentityNestingTooDeep_SurvivesWrapping(t *testing.T) {
+	ctx := WithIdentityNestingLimits(context.Background(), 1, 4)
+	ctx, err := EnterCompositeIdentity(ctx)
+	require.NoError(t, err)
+
+	_, err = EnterCompositeIdentity(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, errors.Wrap(err, "cannot deserialize multisig identity"), ErrIdentityNestingTooDeep)
+}

--- a/token/driver/limits.go
+++ b/token/driver/limits.go
@@ -43,6 +43,18 @@ type ResourceLimits struct {
 	// proof is handed to the bulletproof/CSP verifier for deserialization. Drivers without a
 	// zero-knowledge proof (e.g. fabtoken) ignore this field.
 	MaxProofBytes int
+
+	// MaxIdentityDepth bounds how deeply composite identities (multisig, policy, HTLC script)
+	// may nest inside one another. A composite identity's components are themselves identities,
+	// and the deserializer that turns an owner identity into a verifier recurses into each one,
+	// so an identity nested to depth d costs O(d) recursive deserializations - each of which
+	// re-parses the whole subtree still below it. Real deployments nest 2-3 levels, e.g. a policy
+	// over a multisig over x509.
+	MaxIdentityDepth int
+	// MaxIdentityComponents bounds the number of component identities in a single composite
+	// identity. MaxIdentityDepth bounds how deep the recursion goes; this bounds how wide it
+	// fans out at each level.
+	MaxIdentityComponents int
 }
 
 // DefaultResourceLimits returns the resource limits enforced when no override is configured.
@@ -64,6 +76,9 @@ func DefaultResourceLimits() ResourceLimits {
 		MaxMetadataValueBytes: 4 << 10, // 4 KiB
 
 		MaxProofBytes: 128 << 10, // 128 KiB
+
+		MaxIdentityDepth:      5,
+		MaxIdentityComponents: 16,
 	}
 }
 
@@ -107,6 +122,12 @@ func (l ResourceLimits) WithDefaults() ResourceLimits {
 	}
 	if l.MaxProofBytes <= 0 {
 		l.MaxProofBytes = d.MaxProofBytes
+	}
+	if l.MaxIdentityDepth <= 0 {
+		l.MaxIdentityDepth = d.MaxIdentityDepth
+	}
+	if l.MaxIdentityComponents <= 0 {
+		l.MaxIdentityComponents = d.MaxIdentityComponents
 	}
 
 	return l

--- a/token/driver/limits_test.go
+++ b/token/driver/limits_test.go
@@ -40,6 +40,8 @@ func TestResourceLimits_WithDefaults_FullyOverridden(t *testing.T) {
 		MaxMetadataKeyBytes:   9,
 		MaxMetadataValueBytes: 10,
 		MaxProofBytes:         11,
+		MaxIdentityDepth:      12,
+		MaxIdentityComponents: 13,
 	}
 	assert.Equal(t, l, l.WithDefaults())
 }
@@ -60,6 +62,8 @@ func TestResourceLimits_WithDefaults_NegativeValuesFallBackToDefault(t *testing.
 		MaxMetadataKeyBytes:   -1,
 		MaxMetadataValueBytes: -1,
 		MaxProofBytes:         -1,
+		MaxIdentityDepth:      -1,
+		MaxIdentityComponents: -1,
 	}
 	assert.Equal(t, DefaultResourceLimits(), l.WithDefaults())
 }

--- a/token/services/config/limits.go
+++ b/token/services/config/limits.go
@@ -34,6 +34,9 @@ type resourceLimitsConfig struct {
 	MaxMetadataValueBytes int `yaml:"maxMetadataValueBytes,omitempty"`
 
 	MaxProofBytes int `yaml:"maxProofBytes,omitempty"`
+
+	MaxIdentityDepth      int `yaml:"maxIdentityDepth,omitempty"`
+	MaxIdentityComponents int `yaml:"maxIdentityComponents,omitempty"`
 }
 
 func (c resourceLimitsConfig) toResourceLimits() driver.ResourceLimits {
@@ -51,6 +54,9 @@ func (c resourceLimitsConfig) toResourceLimits() driver.ResourceLimits {
 		MaxMetadataValueBytes: c.MaxMetadataValueBytes,
 
 		MaxProofBytes: c.MaxProofBytes,
+
+		MaxIdentityDepth:      c.MaxIdentityDepth,
+		MaxIdentityComponents: c.MaxIdentityComponents,
 	}
 }
 

--- a/token/services/identity/boolpolicy/deserializer.go
+++ b/token/services/identity/boolpolicy/deserializer.go
@@ -53,6 +53,12 @@ func (d *TypedIdentityDeserializer) GetAuditInfo(ctx context.Context, id driver.
 	if typ != Policy {
 		return nil, errors.Errorf("invalid type, got [%s], expected [%s]", typ, Policy)
 	}
+	// account for this level of nesting before recursing into the components; p may resolve a
+	// component's audit info by re-entering this deserializer for a nested policy identity
+	ctx, err := driver.EnterCompositeIdentity(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot get audit info for policy identity")
+	}
 
 	// return already-stored audit info when present
 	auditInfoRaw, err := p.GetAuditInfo(ctx, id)
@@ -68,6 +74,12 @@ func (d *TypedIdentityDeserializer) GetAuditInfo(ctx context.Context, id driver.
 	if err = pi.Deserialize(rawIdentity); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal policy identity")
 	}
+	// the fan-out bound has to hold here too: this path resolves the audit info of every component
+	// in turn, which is one provider lookup each and, for a nested composite component, a further
+	// descent. The depth bound above does not cover a single level that fans out without limit.
+	if err = validateComponentIdentities(pi.Identities, driver.MaxIdentityComponentsFrom(ctx)); err != nil {
+		return nil, errors.Wrap(err, "invalid policy identity")
+	}
 	ai := &AuditInfo{IdentityAuditInfos: make([]IdentityAuditInfo, len(pi.Identities))}
 	for k, compID := range pi.Identities {
 		ai.IdentityAuditInfos[k].AuditInfo, err = p.GetAuditInfo(ctx, compID)
@@ -82,6 +94,12 @@ func (d *TypedIdentityDeserializer) GetAuditInfo(ctx context.Context, id driver.
 // GetAuditInfoMatcher returns an InfoMatcher that checks each component
 // identity against its own per-component audit info.
 func (d *TypedIdentityDeserializer) GetAuditInfoMatcher(ctx context.Context, owner driver.Identity, auditInfo []byte) (driver.Matcher, error) {
+	// account for this level of nesting before recursing into the components, whose matchers are
+	// resolved through the parent multiplex and may be composite identities in turn
+	ctx, err := driver.EnterCompositeIdentity(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot build a matcher for policy identity")
+	}
 	ei := &AuditInfo{}
 	if err := json.Unmarshal(auditInfo, ei); err != nil {
 		return nil, err
@@ -94,7 +112,7 @@ func (d *TypedIdentityDeserializer) GetAuditInfoMatcher(ctx context.Context, own
 	if err = pi.Deserialize(tid.Identity); err != nil {
 		return nil, err
 	}
-	if err = validateComponentIdentities(pi.Identities); err != nil {
+	if err = validateComponentIdentities(pi.Identities, driver.MaxIdentityComponentsFrom(ctx)); err != nil {
 		return nil, errors.Wrap(err, "invalid policy identity")
 	}
 	if len(pi.Identities) != len(ei.IdentityAuditInfos) {
@@ -115,11 +133,18 @@ func (d *TypedIdentityDeserializer) GetAuditInfoMatcher(ctx context.Context, own
 // DeserializeVerifier deserialises raw (the inner PolicyIdentity bytes, not the
 // full envelope) into a PolicyVerifier that evaluates the stored policy AST.
 func (d *TypedIdentityDeserializer) DeserializeVerifier(ctx context.Context, typ identity.Type, raw []byte) (driver.Verifier, error) {
+	// account for this level of nesting before recursing into the components: the component
+	// deserializer is the parent multiplex, so a component may be a policy identity in turn and
+	// this is the step an attacker-crafted identity drives, ahead of any signature check
+	ctx, err := driver.EnterCompositeIdentity(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot deserialize policy identity")
+	}
 	pi := &PolicyIdentity{}
 	if err := pi.Deserialize(raw); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal policy identity")
 	}
-	if err := validateComponentIdentities(pi.Identities); err != nil {
+	if err := validateComponentIdentities(pi.Identities, driver.MaxIdentityComponentsFrom(ctx)); err != nil {
 		return nil, errors.Wrap(err, "invalid policy identity")
 	}
 	node, err := Parse(pi.Policy)
@@ -189,11 +214,19 @@ func (a *AuditInfoDeserializer) commonEnrollmentID(ctx context.Context, id drive
 	if a.inner == nil {
 		return "", nil
 	}
+	// account for this level of nesting before resolving the components: inner is the parent
+	// multiplex, so a component's audit info may be a policy audit info in turn and re-enter here
+	ctx, err := driver.EnterCompositeIdentity(ctx)
+	if err != nil {
+		return "", errors.Wrap(err, "cannot derive the enrollment ID of a policy identity")
+	}
 	pi := PolicyIdentity{}
 	if err := pi.Deserialize(id); err != nil {
 		return "", errors.Wrapf(err, "failed to deserialize policy identity")
 	}
-	if err := validateComponentIdentities(pi.Identities); err != nil {
+	// the fan-out bound applies here too: every component's audit info is resolved through inner,
+	// which is one deserialization each and a further descent for a nested composite component
+	if err := validateComponentIdentities(pi.Identities, driver.MaxIdentityComponentsFrom(ctx)); err != nil {
 		return "", errors.Wrap(err, "invalid policy identity")
 	}
 	if len(pi.Identities) != len(ei.IdentityAuditInfos) {

--- a/token/services/identity/boolpolicy/identity.go
+++ b/token/services/identity/boolpolicy/identity.go
@@ -143,7 +143,18 @@ type InfoMatcher struct {
 	AuditInfoMatcher []tdriver.Matcher
 }
 
+// Match matches raw, the inner PolicyIdentity bytes of a policy identity, against the
+// per-component audit info this matcher was built from.
+//
+// It recurses into the component matchers, which for a nested composite identity are themselves
+// InfoMatchers. That recursion is independent of the one in
+// TypedIdentityDeserializer.GetAuditInfoMatcher that built this matcher, so it accounts for its own
+// depth against ctx rather than inheriting a budget already spent during construction.
 func (e *InfoMatcher) Match(ctx context.Context, raw []byte) error {
+	ctx, err := tdriver.EnterCompositeIdentity(ctx)
+	if err != nil {
+		return errors.Wrap(err, "cannot match policy identity")
+	}
 	pi := PolicyIdentity{}
 	if err := pi.Deserialize(raw); err != nil {
 		return err
@@ -161,15 +172,23 @@ func (e *InfoMatcher) Match(ctx context.Context, raw []byte) error {
 	return nil
 }
 
-// validateComponentIdentities rejects an empty/none component identity and
-// any duplicate among ids. This is the single choke point applied both when
-// constructing a policy identity via WrapPolicyIdentity and when accepting
-// one from raw (potentially attacker-controlled) wire bytes during
-// deserialization in deserializer.go — an attacker who crafts a
-// PolicyIdentity's DER bytes directly bypasses WrapPolicyIdentity entirely,
-// so validation must also happen at the deserialization boundary to
-// actually close the gap.
-func validateComponentIdentities(ids [][]byte) error {
+// validateComponentIdentities rejects an empty/none component identity, any
+// duplicate among ids, and more than maxComponents of them. This is the single
+// choke point applied both when constructing a policy identity via
+// WrapPolicyIdentity and when accepting one from raw (potentially
+// attacker-controlled) wire bytes during deserialization in deserializer.go —
+// an attacker who crafts a PolicyIdentity's DER bytes directly bypasses
+// WrapPolicyIdentity entirely, so validation must also happen at the
+// deserialization boundary to actually close the gap.
+//
+// The maxComponents bound is the fan-out half of the recursion budget: each
+// component is deserialized in turn, and a policy identity may nest, so the
+// depth bound enforced in deserializer.go does not by itself bound the total
+// amount of recursive work.
+func validateComponentIdentities(ids [][]byte, maxComponents int) error {
+	if len(ids) > maxComponents {
+		return errors.Wrapf(tdriver.ErrTooManyIdentityComponents, "got %d component identities, the maximum is %d", len(ids), maxComponents)
+	}
 	seen := make(map[string]struct{}, len(ids))
 	for k, raw := range ids {
 		id := token.Identity(raw)
@@ -199,7 +218,7 @@ func WrapPolicyIdentity(policy string, ids ...token.Identity) (token.Identity, e
 	for k, id := range ids {
 		raw2D[k] = id
 	}
-	if err := validateComponentIdentities(raw2D); err != nil {
+	if err := validateComponentIdentities(raw2D, tdriver.DefaultResourceLimits().MaxIdentityComponents); err != nil {
 		return nil, err
 	}
 	pi := &PolicyIdentity{Policy: policy, Identities: raw2D}

--- a/token/services/identity/boolpolicy/nesting_test.go
+++ b/token/services/identity/boolpolicy/nesting_test.go
@@ -1,0 +1,375 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package boolpolicy
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	tdriver "github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recursiveVerifierDES re-enters the deserializer under test for any component that is itself a
+// policy identity, reproducing the production wiring where the component deserializer is the parent
+// multiplex the policy deserializer is registered in.
+type recursiveVerifierDES struct {
+	d     *TypedIdentityDeserializer
+	calls int
+}
+
+func (r *recursiveVerifierDES) DeserializeVerifier(ctx context.Context, id token.Identity) (tdriver.Verifier, error) {
+	r.calls++
+	ti, err := identity.UnmarshalTypedIdentity(id)
+	if err != nil || ti.Type != Policy {
+		return &stubVerifier{}, nil //nolint:nilerr // a non-policy component is the leaf
+	}
+
+	return r.d.DeserializeVerifier(ctx, Policy, ti.Identity)
+}
+
+type stubMatcherProvider struct {
+	calls int
+}
+
+func (s *stubMatcherProvider) GetAuditInfoMatcher(context.Context, token.Identity, []byte) (tdriver.Matcher, error) {
+	s.calls++
+
+	return &stubMatcher{}, nil
+}
+
+type stubMatcher struct{}
+
+func (stubMatcher) Match(context.Context, []byte) error { return nil }
+
+// distinctIdentities returns n distinct component identities, so that a test aimed at the fan-out
+// bound is not short-circuited by the duplicate-component check.
+func distinctIdentities(n int) [][]byte {
+	ids := make([][]byte, n)
+	for k := range ids {
+		ids[k] = []byte("identity-" + strconv.Itoa(k))
+	}
+
+	return ids
+}
+
+// wrapPolicy envelopes ids as a policy TypedIdentity without going through WrapPolicyIdentity, so
+// that a test can build the identities an attacker would craft directly on the wire.
+func wrapPolicy(t *testing.T, ids ...[]byte) token.Identity {
+	t.Helper()
+	inner, err := (&PolicyIdentity{Policy: "$0", Identities: ids}).Bytes()
+	require.NoError(t, err)
+	envelope, err := (&identity.TypedIdentity{Type: Policy, Identity: inner}).Bytes()
+	require.NoError(t, err)
+
+	return envelope
+}
+
+// nestedPolicy returns a policy identity nested depth levels deep around leaf.
+func nestedPolicy(t *testing.T, depth int, leaf []byte) token.Identity {
+	t.Helper()
+	id := token.Identity(leaf)
+	for range depth {
+		id = wrapPolicy(t, id)
+	}
+
+	return id
+}
+
+// A single policy identity carrying more components than MaxIdentityComponents must be rejected: one
+// level of nesting that fans out widely is a single recursive step doing unbounded work.
+func TestDeserializeVerifier_RejectsExcessiveFanOut(t *testing.T) {
+	const maxComponents = 4
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), 5, maxComponents)
+
+	des := &recursiveVerifierDES{}
+	d := NewTypedIdentityDeserializer(des, nil)
+	des.d = d
+
+	raw, err := (&PolicyIdentity{Policy: "$0", Identities: distinctIdentities(maxComponents + 1)}).Bytes()
+	require.NoError(t, err)
+
+	_, err = d.DeserializeVerifier(ctx, Policy, raw)
+	require.ErrorIs(t, err, tdriver.ErrTooManyIdentityComponents)
+	assert.Zero(t, des.calls, "the fan-out bound must be enforced before any component is deserialized")
+}
+
+func TestDeserializeVerifier_AllowsFanOutAtTheLimit(t *testing.T) {
+	const maxComponents = 4
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), 5, maxComponents)
+
+	des := &recursiveVerifierDES{}
+	d := NewTypedIdentityDeserializer(des, nil)
+	des.d = d
+
+	raw, err := (&PolicyIdentity{Policy: "$0", Identities: distinctIdentities(maxComponents)}).Bytes()
+	require.NoError(t, err)
+
+	_, err = d.DeserializeVerifier(ctx, Policy, raw)
+	require.NoError(t, err)
+	assert.Equal(t, maxComponents, des.calls)
+}
+
+func TestGetAuditInfoMatcher_RejectsExcessiveFanOut(t *testing.T) {
+	const maxComponents = 4
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), 5, maxComponents)
+
+	provider := &stubMatcherProvider{}
+	d := NewTypedIdentityDeserializer(nil, provider)
+
+	ids := distinctIdentities(maxComponents + 1)
+	infos := make([]IdentityAuditInfo, len(ids))
+	for k := range infos {
+		infos[k].AuditInfo = []byte("audit-info")
+	}
+	auditInfo, err := (&AuditInfo{IdentityAuditInfos: infos}).Bytes()
+	require.NoError(t, err)
+
+	_, err = d.GetAuditInfoMatcher(ctx, wrapPolicy(t, ids...), auditInfo)
+	require.ErrorIs(t, err, tdriver.ErrTooManyIdentityComponents)
+	assert.Zero(t, provider.calls, "the fan-out bound must be enforced before any component matcher is built")
+}
+
+// The depth bound must hold on the verifier path: an identity nested past the limit is rejected
+// rather than walked.
+func TestDeserializeVerifier_RejectsExcessiveDepth(t *testing.T) {
+	const maxDepth = 3
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), maxDepth, 16)
+
+	des := &recursiveVerifierDES{}
+	d := NewTypedIdentityDeserializer(des, nil)
+	des.d = d
+
+	deep := nestedPolicy(t, maxDepth+2, []byte("leaf"))
+	ti, err := identity.UnmarshalTypedIdentity(deep)
+	require.NoError(t, err)
+
+	_, err = d.DeserializeVerifier(ctx, Policy, ti.Identity)
+	require.ErrorIs(t, err, tdriver.ErrIdentityNestingTooDeep)
+}
+
+// Nesting up to the limit must still work - a policy over a multisig over an x509 identity is a real
+// shape, so the bound has to reject only what exceeds it.
+func TestDeserializeVerifier_AllowsDepthAtTheLimit(t *testing.T) {
+	const maxDepth = 3
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), maxDepth, 16)
+
+	des := &recursiveVerifierDES{}
+	d := NewTypedIdentityDeserializer(des, nil)
+	des.d = d
+
+	nested := nestedPolicy(t, maxDepth, []byte("leaf"))
+	ti, err := identity.UnmarshalTypedIdentity(nested)
+	require.NoError(t, err)
+
+	_, err = d.DeserializeVerifier(ctx, Policy, ti.Identity)
+	require.NoError(t, err)
+}
+
+// InfoMatcher.Match recurses separately from the deserialization that built it, so it needs its own
+// bound.
+func TestInfoMatcher_Match_RejectsExcessiveDepth(t *testing.T) {
+	const maxDepth = 2
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), maxDepth, 16)
+
+	var m *InfoMatcher
+	m = &InfoMatcher{AuditInfoMatcher: []tdriver.Matcher{matcherFunc(func(ctx context.Context, raw []byte) error {
+		ti, err := identity.UnmarshalTypedIdentity(raw)
+		if err != nil || ti.Type != Policy {
+			return nil //nolint:nilerr // a non-policy component is the leaf
+		}
+
+		return m.Match(ctx, ti.Identity)
+	})}}
+
+	deep := nestedPolicy(t, maxDepth+2, []byte("leaf"))
+	ti, err := identity.UnmarshalTypedIdentity(deep)
+	require.NoError(t, err)
+
+	require.ErrorIs(t, m.Match(ctx, ti.Identity), tdriver.ErrIdentityNestingTooDeep)
+}
+
+type matcherFunc func(context.Context, []byte) error
+
+func (f matcherFunc) Match(ctx context.Context, raw []byte) error { return f(ctx, raw) }
+
+// A context that no validator seeded must still be bounded, by the defaults.
+func TestDeserializeVerifier_UnseededContextIsStillBounded(t *testing.T) {
+	des := &recursiveVerifierDES{}
+	d := NewTypedIdentityDeserializer(des, nil)
+	des.d = d
+
+	deep := nestedPolicy(t, tdriver.DefaultResourceLimits().MaxIdentityDepth+2, []byte("leaf"))
+	ti, err := identity.UnmarshalTypedIdentity(deep)
+	require.NoError(t, err)
+
+	_, err = d.DeserializeVerifier(context.Background(), Policy, ti.Identity)
+	require.ErrorIs(t, err, tdriver.ErrIdentityNestingTooDeep)
+}
+
+// WrapPolicyIdentity is the honest-caller path and holds to the default fan-out bound, so that an
+// identity built in-process cannot exceed what a validator will later accept.
+func TestWrapPolicyIdentity_RejectsExcessiveFanOut(t *testing.T) {
+	max := tdriver.DefaultResourceLimits().MaxIdentityComponents
+
+	toIdentities := func(raw [][]byte) []token.Identity {
+		ids := make([]token.Identity, len(raw))
+		for k := range raw {
+			ids[k] = raw[k]
+		}
+
+		return ids
+	}
+
+	_, err := WrapPolicyIdentity("$0", toIdentities(distinctIdentities(max))...)
+	require.NoError(t, err, "a component count at the limit must be accepted")
+
+	_, err = WrapPolicyIdentity("$0", toIdentities(distinctIdentities(max+1))...)
+	require.ErrorIs(t, err, tdriver.ErrTooManyIdentityComponents)
+}
+
+// stubAuditInfoProvider is a driver.AuditInfoProvider that records its lookups and, optionally,
+// resolves a composite identity by re-entering the deserializer the way the production provider does.
+type stubAuditInfoProvider struct {
+	calls int
+	fn    func(context.Context, tdriver.Identity) ([]byte, error)
+}
+
+func (s *stubAuditInfoProvider) GetAuditInfo(ctx context.Context, id tdriver.Identity) ([]byte, error) {
+	s.calls++
+	if s.fn != nil {
+		return s.fn(ctx, id)
+	}
+
+	return nil, nil
+}
+
+// The fan-out bound must be enforced on the audit-info collection path too. It resolves one provider
+// lookup per component, and a composite component descends further, so a single level that fans out
+// without limit is unbounded work that the depth bound does not cover.
+func TestGetAuditInfo_RejectsExcessiveFanOut(t *testing.T) {
+	const maxComponents = 4
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), 5, maxComponents)
+
+	p := &stubAuditInfoProvider{}
+	d := NewTypedIdentityDeserializer(nil, nil)
+
+	raw, err := (&PolicyIdentity{Policy: "$0", Identities: distinctIdentities(maxComponents + 1)}).Bytes()
+	require.NoError(t, err)
+
+	_, err = d.GetAuditInfo(ctx, token.Identity("owner"), Policy, raw, p)
+	require.ErrorIs(t, err, tdriver.ErrTooManyIdentityComponents)
+	assert.Equal(t, 1, p.calls,
+		"only the cache probe for the composite identity itself may run before the bound is enforced")
+}
+
+func TestGetAuditInfo_AllowsFanOutAtTheLimit(t *testing.T) {
+	const maxComponents = 4
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), 5, maxComponents)
+
+	p := &stubAuditInfoProvider{}
+	d := NewTypedIdentityDeserializer(nil, nil)
+
+	raw, err := (&PolicyIdentity{Policy: "$0", Identities: distinctIdentities(maxComponents)}).Bytes()
+	require.NoError(t, err)
+
+	_, err = d.GetAuditInfo(ctx, token.Identity("owner"), Policy, raw, p)
+	require.NoError(t, err)
+	assert.Equal(t, 1+maxComponents, p.calls)
+}
+
+// The depth bound holds on the audit-info collection path as well: the provider resolves an unstored
+// composite component by re-entering this deserializer, which is the recursion the bound covers.
+func TestGetAuditInfo_RejectsExcessiveDepth(t *testing.T) {
+	const maxDepth = 3
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), maxDepth, 16)
+
+	d := NewTypedIdentityDeserializer(nil, nil)
+	p := &stubAuditInfoProvider{}
+	// the guard keeps the cache probe for an identity already being resolved from looping back into
+	// it; production has the same shape, the provider only descends into components
+	resolving := map[string]bool{}
+	p.fn = func(ctx context.Context, id tdriver.Identity) ([]byte, error) {
+		if resolving[string(id)] {
+			return nil, nil
+		}
+		ti, err := identity.UnmarshalTypedIdentity(id)
+		if err != nil || ti.Type != Policy {
+			return nil, nil //nolint:nilerr // a non-policy component is the leaf, nothing stored
+		}
+		resolving[string(id)] = true
+
+		return d.GetAuditInfo(ctx, id, Policy, ti.Identity, p)
+	}
+
+	deep := nestedPolicy(t, maxDepth+2, []byte("leaf"))
+	ti, err := identity.UnmarshalTypedIdentity(deep)
+	require.NoError(t, err)
+
+	_, err = d.GetAuditInfo(ctx, deep, Policy, ti.Identity, p)
+	require.ErrorIs(t, err, tdriver.ErrIdentityNestingTooDeep)
+}
+
+// nestedPolicyAuditInfo returns a policy identity nested depth levels deep around a single x509 leaf
+// carrying eid, together with the matching nested composite audit info.
+func nestedPolicyAuditInfo(t *testing.T, depth int, eid string) (token.Identity, []byte) {
+	t.Helper()
+	member, info := newX509Member(t, "cert-leaf", eid)
+	id := token.Identity(member)
+	for range depth {
+		id, info = newPolicyIdentity(t, "$0", [][]byte{id}, [][]byte{info})
+	}
+
+	return id, info
+}
+
+// Deriving the common enrollment ID resolves one component audit info per component through the
+// parent multiplex, so this path needs the fan-out bound just like the other component-resolving
+// steps. It is reachable from an auditor inspecting an untrusted owner identity.
+func TestPolicyEnrollmentID_RejectsExcessiveFanOut(t *testing.T) {
+	const maxComponents = 4
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), 5, maxComponents)
+
+	members := make([][]byte, maxComponents+1)
+	infos := make([][]byte, len(members))
+	for k := range members {
+		members[k], infos[k] = newX509Member(t, "cert-"+strconv.Itoa(k), "wallet-42")
+	}
+	policyID, wrapped := newPolicyIdentity(t, "$0", members, infos)
+
+	_, _, err := newEIDRHDeserializer().GetEIDAndRH(ctx, policyID, wrapped)
+	require.ErrorIs(t, err, tdriver.ErrTooManyIdentityComponents)
+}
+
+// The depth bound holds on the same path: a component's audit info is resolved through the parent
+// multiplex, which re-enters this deserializer for a nested policy component.
+func TestPolicyEnrollmentID_RejectsExcessiveDepth(t *testing.T) {
+	const maxDepth = 3
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), maxDepth, 16)
+
+	policyID, wrapped := nestedPolicyAuditInfo(t, maxDepth+2, "wallet-42")
+
+	_, _, err := newEIDRHDeserializer().GetEIDAndRH(ctx, policyID, wrapped)
+	require.ErrorIs(t, err, tdriver.ErrIdentityNestingTooDeep)
+}
+
+// A chain that nests exactly to the limit still resolves, so the bound cannot be satisfied by an
+// off-by-one that rejects legitimate identities.
+func TestPolicyEnrollmentID_AllowsDepthAtTheLimit(t *testing.T) {
+	const maxDepth = 3
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), maxDepth, 16)
+
+	policyID, wrapped := nestedPolicyAuditInfo(t, maxDepth, "wallet-42")
+
+	eid, _, err := newEIDRHDeserializer().GetEIDAndRH(ctx, policyID, wrapped)
+	require.NoError(t, err)
+	assert.Equal(t, "wallet-42", eid)
+}

--- a/token/services/identity/interop/htlc/deserializer.go
+++ b/token/services/identity/interop/htlc/deserializer.go
@@ -58,20 +58,29 @@ func (t *TypedIdentityDeserializer) DeserializeVerifier(ctx context.Context, typ
 	if typ != ScriptType {
 		return nil, errors.Errorf("cannot deserializer type [%s], expected [%s]", typ, ScriptType)
 	}
+	// account for this level of nesting before recursing into the sender and recipient: the
+	// embedded Deserializer is the parent multiplex, so either may be an htlc script in turn and
+	// this is the step an attacker-crafted identity drives, ahead of any signature check
+	ctx, err := driver.EnterCompositeIdentity(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot deserialize htlc script identity")
+	}
 
 	script := &htlc.Script{}
-	err := json.Unmarshal(raw, script)
-	if err != nil {
+	if err := json.Unmarshal(raw, script); err != nil {
 		return nil, errors.Errorf("failed to unmarshal TypedIdentity as an htlc script")
 	}
 	v := &htlc.Verifier{}
 	v.Sender, err = t.deserializer.DeserializeVerifier(ctx, script.Sender)
 	if err != nil {
-		return nil, errors.Errorf("failed to unmarshal the identity of the sender in the htlc script")
+		// wrap rather than replace: the sender may itself be a composite identity, and the reason
+		// its deserialization failed - an over-nested identity in particular - has to stay testable
+		// with errors.Is by the caller
+		return nil, errors.Wrap(err, "failed to unmarshal the identity of the sender in the htlc script")
 	}
 	v.Recipient, err = t.deserializer.DeserializeVerifier(ctx, script.Recipient)
 	if err != nil {
-		return nil, errors.Errorf("failed to unmarshal the identity of the recipient in the htlc script")
+		return nil, errors.Wrap(err, "failed to unmarshal the identity of the recipient in the htlc script")
 	}
 	v.Deadline = script.Deadline
 	v.HashInfo.Hash = script.HashInfo.Hash
@@ -106,10 +115,14 @@ func (t *TypedIdentityDeserializer) GetAuditInfo(ctx context.Context, id driver.
 	if typ != ScriptType {
 		return nil, errors.Errorf("invalid type, got [%s], expected [%s]", typ, ScriptType)
 	}
-	script := &htlc.Script{}
-	var err error
-	err = json.Unmarshal(raw, script)
+	// account for this level of nesting before recursing into the components; p may resolve the
+	// sender's or recipient's audit info by re-entering this deserializer for a nested script
+	ctx, err := driver.EnterCompositeIdentity(ctx)
 	if err != nil {
+		return nil, errors.Wrap(err, "cannot get audit info for htlc script identity")
+	}
+	script := &htlc.Script{}
+	if err := json.Unmarshal(raw, script); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal htlc script")
 	}
 
@@ -194,7 +207,15 @@ type AuditInfoMatcher struct {
 // the stored audit info.
 // It unmarshals both the audit info and the script
 // and then delegates to the underlying Deserializer for sender and recipient matching.
+//
+// The delegation recurses: MatchIdentity resolves a matcher through the parent multiplex, and for a
+// nested script identity that lands back here. That recursion is independent of the one in
+// DeserializeVerifier, so it accounts for its own depth against ctx.
 func (a *AuditInfoMatcher) Match(ctx context.Context, id []byte) error {
+	ctx, err := driver.EnterCompositeIdentity(ctx)
+	if err != nil {
+		return errors.Wrap(err, "cannot match htlc script identity")
+	}
 	scriptInf := &ScriptInfo{}
 	if err := json.Unmarshal(a.AuditInfo, scriptInf); err != nil {
 		return errors.Wrapf(err, "failed to unmarshal script info")

--- a/token/services/identity/multisig/deserializer.go
+++ b/token/services/identity/multisig/deserializer.go
@@ -52,6 +52,12 @@ func (d *TypedIdentityDeserializer) GetAuditInfo(ctx context.Context, id driver.
 	if typ != Multisig {
 		return nil, errors.Errorf("invalid type, got [%s], expected [%s]", typ, Multisig)
 	}
+	// account for this level of nesting before recursing into the components; p may resolve a
+	// component's audit info by re-entering this deserializer for a nested multisig identity
+	ctx, err := driver.EnterCompositeIdentity(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot get audit info for multisig identity")
+	}
 
 	// if there is already some audit info for id, return it
 	auditInfoRaw, err := p.GetAuditInfo(ctx, id)
@@ -68,6 +74,12 @@ func (d *TypedIdentityDeserializer) GetAuditInfo(ctx context.Context, id driver.
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal mid")
 	}
+	// the fan-out bound has to hold here too: this path resolves the audit info of every component
+	// in turn, which is one provider lookup each and, for a nested composite component, a further
+	// descent. The depth bound above does not cover a single level that fans out without limit.
+	if err := validateComponentIdentities(mid.Identities, driver.MaxIdentityComponentsFrom(ctx)); err != nil {
+		return nil, errors.Wrap(err, "invalid multisig identity")
+	}
 	auditInfo := &AuditInfo{}
 	auditInfo.IdentityAuditInfos = make([]IdentityAuditInfo, len(mid.Identities))
 	for k, identity := range mid.Identities {
@@ -81,9 +93,14 @@ func (d *TypedIdentityDeserializer) GetAuditInfo(ctx context.Context, id driver.
 }
 
 func (d *TypedIdentityDeserializer) GetAuditInfoMatcher(ctx context.Context, owner driver.Identity, auditInfo []byte) (driver.Matcher, error) {
-	ei := &AuditInfo{}
-	err := json.Unmarshal(auditInfo, ei)
+	// account for this level of nesting before recursing into the components, whose matchers are
+	// resolved through the parent multiplex and may be multisig identities in turn
+	ctx, err := driver.EnterCompositeIdentity(ctx)
 	if err != nil {
+		return nil, errors.Wrap(err, "cannot build a matcher for multisig identity")
+	}
+	ei := &AuditInfo{}
+	if err := json.Unmarshal(auditInfo, ei); err != nil {
 		return nil, err
 	}
 	id, err := identity.UnmarshalTypedIdentity(owner)
@@ -91,11 +108,10 @@ func (d *TypedIdentityDeserializer) GetAuditInfoMatcher(ctx context.Context, own
 		return nil, err
 	}
 	mid := MultiIdentity{}
-	err = mid.Deserialize(id.Identity)
-	if err != nil {
+	if err := mid.Deserialize(id.Identity); err != nil {
 		return nil, err
 	}
-	if err = validateComponentIdentities(mid.Identities); err != nil {
+	if err := validateComponentIdentities(mid.Identities, driver.MaxIdentityComponentsFrom(ctx)); err != nil {
 		return nil, errors.Wrap(err, "invalid multisig identity")
 	}
 	if len(mid.Identities) != len(ei.IdentityAuditInfos) {
@@ -113,15 +129,21 @@ func (d *TypedIdentityDeserializer) GetAuditInfoMatcher(ctx context.Context, own
 }
 
 func (d *TypedIdentityDeserializer) DeserializeVerifier(ctx context.Context, typ identity.Type, raw []byte) (driver.Verifier, error) {
-	multisigIdentity := &MultiIdentity{}
-	err := multisigIdentity.Deserialize(raw)
+	// account for this level of nesting before recursing into the components: the component
+	// deserializer is the parent multiplex, so a component may be a multisig identity in turn and
+	// this is the step an attacker-crafted identity drives, ahead of any signature check
+	ctx, err := driver.EnterCompositeIdentity(ctx)
 	if err != nil {
+		return nil, errors.Wrap(err, "cannot deserialize multisig identity")
+	}
+	multisigIdentity := &MultiIdentity{}
+	if err := multisigIdentity.Deserialize(raw); err != nil {
 		return nil, errors.New("failed to unmarshal multisig identity")
 	}
 	if len(multisigIdentity.Identities) == 0 {
 		return nil, errors.New("multisig identity has no members")
 	}
-	if err = validateComponentIdentities(multisigIdentity.Identities); err != nil {
+	if err := validateComponentIdentities(multisigIdentity.Identities, driver.MaxIdentityComponentsFrom(ctx)); err != nil {
 		return nil, errors.Wrap(err, "invalid multisig identity")
 	}
 	verifier := &Verifier{}

--- a/token/services/identity/multisig/identity.go
+++ b/token/services/identity/multisig/identity.go
@@ -42,15 +42,23 @@ func (m *MultiIdentity) Bytes() ([]byte, error) {
 	return asn1.Marshal(*m)
 }
 
-// validateComponentIdentities rejects an empty/none component identity and
-// any duplicate among ids. This is the single choke point applied both when
-// constructing a multisig identity via WrapIdentities and when accepting one
-// from raw (potentially attacker-controlled) wire bytes during
-// deserialization in deserializer.go — an attacker who crafts a
-// MultiIdentity's DER bytes directly bypasses WrapIdentities entirely, so
-// validation must also happen at the deserialization boundary to actually
-// close the gap.
-func validateComponentIdentities(ids []token.Identity) error {
+// validateComponentIdentities rejects an empty/none component identity, any
+// duplicate among ids, and more than maxComponents of them. This is the single
+// choke point applied both when constructing a multisig identity via
+// WrapIdentities and when accepting one from raw (potentially
+// attacker-controlled) wire bytes during deserialization in deserializer.go —
+// an attacker who crafts a MultiIdentity's DER bytes directly bypasses
+// WrapIdentities entirely, so validation must also happen at the
+// deserialization boundary to actually close the gap.
+//
+// The maxComponents bound is the fan-out half of the recursion budget: each
+// component is deserialized in turn, and a multisig identity may nest, so the
+// depth bound enforced in deserializer.go does not by itself bound the total
+// amount of recursive work.
+func validateComponentIdentities(ids []token.Identity, maxComponents int) error {
+	if len(ids) > maxComponents {
+		return errors.Wrapf(tdriver.ErrTooManyIdentityComponents, "got %d component identities, the maximum is %d", len(ids), maxComponents)
+	}
 	seen := make(map[string]struct{}, len(ids))
 	for k, id := range ids {
 		if id.IsNone() {
@@ -70,7 +78,7 @@ func WrapIdentities(ids ...token.Identity) (token.Identity, error) {
 	if len(ids) == 0 {
 		return nil, errors.New("no identities provided")
 	}
-	if err := validateComponentIdentities(ids); err != nil {
+	if err := validateComponentIdentities(ids, tdriver.DefaultResourceLimits().MaxIdentityComponents); err != nil {
 		return nil, err
 	}
 
@@ -112,10 +120,20 @@ type InfoMatcher struct {
 	AuditInfoMatcher []tdriver.Matcher
 }
 
+// Match matches raw, the inner MultiIdentity bytes of a multisig identity, against the
+// per-component audit info this matcher was built from.
+//
+// It recurses into the component matchers, which for a nested multisig identity are themselves
+// InfoMatchers. That recursion is independent of the one in
+// TypedIdentityDeserializer.GetAuditInfoMatcher that built this matcher, so it accounts for its own
+// depth against ctx rather than inheriting a budget already spent during construction.
 func (e *InfoMatcher) Match(ctx context.Context, raw []byte) error {
-	mid := MultiIdentity{}
-	err := mid.Deserialize(raw)
+	ctx, err := tdriver.EnterCompositeIdentity(ctx)
 	if err != nil {
+		return errors.Wrap(err, "cannot match multisig identity")
+	}
+	mid := MultiIdentity{}
+	if err := mid.Deserialize(raw); err != nil {
 		return err
 	}
 	if len(e.AuditInfoMatcher) != len(mid.Identities) {

--- a/token/services/identity/multisig/nesting_test.go
+++ b/token/services/identity/multisig/nesting_test.go
@@ -1,0 +1,304 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package multisig
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	tdriver "github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/multisig/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// distinctIdentities returns n component identities that are distinct, so that a test aimed at the
+// fan-out bound is not short-circuited by the duplicate-component check.
+func distinctIdentities(n int) []token.Identity {
+	ids := make([]token.Identity, n)
+	for k := range ids {
+		ids[k] = token.Identity("identity-" + strconv.Itoa(k))
+	}
+
+	return ids
+}
+
+// wrapMultisig envelopes ids as a multisig TypedIdentity without going through WrapIdentities, so
+// that a test can build the identities an attacker would craft directly on the wire - which is the
+// only surface that matters here, since WrapIdentities is the honest-caller path.
+func wrapMultisig(t *testing.T, ids ...token.Identity) token.Identity {
+	t.Helper()
+	inner, err := (&MultiIdentity{Identities: ids}).Bytes()
+	require.NoError(t, err)
+	envelope, err := (&identity.TypedIdentity{Type: Multisig, Identity: inner}).Bytes()
+	require.NoError(t, err)
+
+	return envelope
+}
+
+// nestedMultisig returns a multisig identity nested depth levels deep around leaf. Each level holds
+// a single component, which is the cheapest shape per level and therefore the one that reaches the
+// greatest depth for a given identity size.
+func nestedMultisig(t *testing.T, depth int, leaf token.Identity) token.Identity {
+	t.Helper()
+	id := leaf
+	for range depth {
+		id = wrapMultisig(t, id)
+	}
+
+	return id
+}
+
+// A single multisig identity carrying more components than MaxIdentityComponents must be rejected.
+// The depth bound does not cover this: one level of nesting that fans out to thousands of components
+// is a single recursive step that does an unbounded amount of work.
+func TestDeserializeVerifier_RejectsExcessiveFanOut(t *testing.T) {
+	const maxComponents = 4
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), 5, maxComponents)
+
+	verifierDES := &mock.VerifierDES{}
+	verifierDES.DeserializeVerifierReturns(&mock.Verifier{}, nil)
+	d := NewTypedIdentityDeserializer(verifierDES, nil)
+
+	raw, err := (&MultiIdentity{Identities: distinctIdentities(maxComponents + 1)}).Bytes()
+	require.NoError(t, err)
+
+	_, err = d.DeserializeVerifier(ctx, Multisig, raw)
+	require.ErrorIs(t, err, tdriver.ErrTooManyIdentityComponents)
+	assert.Zero(t, verifierDES.DeserializeVerifierCallCount(),
+		"the fan-out bound must be enforced before any component is deserialized")
+}
+
+// A component count exactly at the limit must still be accepted - an off-by-one here would break
+// legitimate multisig identities.
+func TestDeserializeVerifier_AllowsFanOutAtTheLimit(t *testing.T) {
+	const maxComponents = 4
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), 5, maxComponents)
+
+	verifierDES := &mock.VerifierDES{}
+	verifierDES.DeserializeVerifierReturns(&mock.Verifier{}, nil)
+	d := NewTypedIdentityDeserializer(verifierDES, nil)
+
+	raw, err := (&MultiIdentity{Identities: distinctIdentities(maxComponents)}).Bytes()
+	require.NoError(t, err)
+
+	_, err = d.DeserializeVerifier(ctx, Multisig, raw)
+	require.NoError(t, err)
+	assert.Equal(t, maxComponents, verifierDES.DeserializeVerifierCallCount())
+}
+
+// The fan-out bound must be enforced on the matcher-construction path too, not only when building
+// verifiers - it recurses into the components just the same.
+func TestGetAuditInfoMatcher_RejectsExcessiveFanOut(t *testing.T) {
+	const maxComponents = 4
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), 5, maxComponents)
+
+	matcher := &mock.AuditInfoMatcher{}
+	matcher.GetAuditInfoMatcherReturns(&mock.Matcher{}, nil)
+	d := NewTypedIdentityDeserializer(nil, matcher)
+
+	ids := distinctIdentities(maxComponents + 1)
+	infos := make([]IdentityAuditInfo, len(ids))
+	for k := range infos {
+		infos[k].AuditInfo = []byte("audit-info")
+	}
+	auditInfo, err := (&AuditInfo{IdentityAuditInfos: infos}).Bytes()
+	require.NoError(t, err)
+
+	_, err = d.GetAuditInfoMatcher(ctx, wrapMultisig(t, ids...), auditInfo)
+	require.ErrorIs(t, err, tdriver.ErrTooManyIdentityComponents)
+	assert.Zero(t, matcher.GetAuditInfoMatcherCallCount(),
+		"the fan-out bound must be enforced before any component matcher is built")
+}
+
+// The depth bound must hold on the verifier path. The component deserializer here is the parent
+// multiplex in production, so an identity nested past the limit is rejected rather than walked.
+func TestDeserializeVerifier_RejectsExcessiveDepth(t *testing.T) {
+	const maxDepth = 3
+
+	verifierDES := &mock.VerifierDES{}
+	d := NewTypedIdentityDeserializer(verifierDES, nil)
+
+	// each recursive step re-enters this same deserializer, as the production multiplex wiring does
+	verifierDES.DeserializeVerifierCalls(func(ctx context.Context, id token.Identity) (tdriver.Verifier, error) {
+		ti, err := identity.UnmarshalTypedIdentity(id)
+		if err != nil || ti.Type != Multisig {
+			return &mock.Verifier{}, nil //nolint:nilerr // a non-multisig component is the leaf
+		}
+
+		return d.DeserializeVerifier(ctx, Multisig, ti.Identity)
+	})
+
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), maxDepth, 16)
+	deep := nestedMultisig(t, maxDepth+2, token.Identity("leaf"))
+	ti, err := identity.UnmarshalTypedIdentity(deep)
+	require.NoError(t, err)
+
+	_, err = d.DeserializeVerifier(ctx, Multisig, ti.Identity)
+	require.ErrorIs(t, err, tdriver.ErrIdentityNestingTooDeep)
+}
+
+// Nesting up to the limit must still work: a policy over a multisig over an x509 identity is a real
+// shape, so the bound has to reject only what exceeds it.
+func TestDeserializeVerifier_AllowsDepthAtTheLimit(t *testing.T) {
+	const maxDepth = 3
+
+	verifierDES := &mock.VerifierDES{}
+	d := NewTypedIdentityDeserializer(verifierDES, nil)
+	verifierDES.DeserializeVerifierCalls(func(ctx context.Context, id token.Identity) (tdriver.Verifier, error) {
+		ti, err := identity.UnmarshalTypedIdentity(id)
+		if err != nil || ti.Type != Multisig {
+			return &mock.Verifier{}, nil //nolint:nilerr // a non-multisig component is the leaf
+		}
+
+		return d.DeserializeVerifier(ctx, Multisig, ti.Identity)
+	})
+
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), maxDepth, 16)
+	nested := nestedMultisig(t, maxDepth, token.Identity("leaf"))
+	ti, err := identity.UnmarshalTypedIdentity(nested)
+	require.NoError(t, err)
+
+	_, err = d.DeserializeVerifier(ctx, Multisig, ti.Identity)
+	require.NoError(t, err)
+}
+
+// InfoMatcher.Match recurses separately from the deserialization that built it, so it needs its own
+// bound. Without one, an identity that was cheap to deserialize could still drive deep recursion at
+// match time.
+func TestInfoMatcher_Match_RejectsExcessiveDepth(t *testing.T) {
+	const maxDepth = 2
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), maxDepth, 16)
+
+	// a matcher that recurses into itself, mirroring a nested multisig identity's matcher tree
+	var m *InfoMatcher
+	inner := &mock.Matcher{}
+	inner.MatchCalls(func(ctx context.Context, raw []byte) error {
+		ti, err := identity.UnmarshalTypedIdentity(raw)
+		if err != nil || ti.Type != Multisig {
+			return nil //nolint:nilerr // a non-multisig component is the leaf
+		}
+
+		return m.Match(ctx, ti.Identity)
+	})
+	m = &InfoMatcher{AuditInfoMatcher: []tdriver.Matcher{inner}}
+
+	deep := nestedMultisig(t, maxDepth+2, token.Identity("leaf"))
+	ti, err := identity.UnmarshalTypedIdentity(deep)
+	require.NoError(t, err)
+
+	require.ErrorIs(t, m.Match(ctx, ti.Identity), tdriver.ErrIdentityNestingTooDeep)
+}
+
+// A context that no validator seeded must still be bounded, by the defaults - deserialization is
+// reachable from wallet and auditor paths that never carry ResourceLimits.
+func TestDeserializeVerifier_UnseededContextIsStillBounded(t *testing.T) {
+	verifierDES := &mock.VerifierDES{}
+	d := NewTypedIdentityDeserializer(verifierDES, nil)
+	verifierDES.DeserializeVerifierCalls(func(ctx context.Context, id token.Identity) (tdriver.Verifier, error) {
+		ti, err := identity.UnmarshalTypedIdentity(id)
+		if err != nil || ti.Type != Multisig {
+			return &mock.Verifier{}, nil //nolint:nilerr // a non-multisig component is the leaf
+		}
+
+		return d.DeserializeVerifier(ctx, Multisig, ti.Identity)
+	})
+
+	deep := nestedMultisig(t, tdriver.DefaultResourceLimits().MaxIdentityDepth+2, token.Identity("leaf"))
+	ti, err := identity.UnmarshalTypedIdentity(deep)
+	require.NoError(t, err)
+
+	_, err = d.DeserializeVerifier(context.Background(), Multisig, ti.Identity)
+	require.ErrorIs(t, err, tdriver.ErrIdentityNestingTooDeep)
+}
+
+// WrapIdentities is the honest-caller path and holds to the default fan-out bound, so that an
+// identity built in-process cannot exceed what a validator will later accept.
+func TestWrapIdentities_RejectsExcessiveFanOut(t *testing.T) {
+	max := tdriver.DefaultResourceLimits().MaxIdentityComponents
+
+	_, err := WrapIdentities(distinctIdentities(max)...)
+	require.NoError(t, err, "a component count at the limit must be accepted")
+
+	_, err = WrapIdentities(distinctIdentities(max + 1)...)
+	require.ErrorIs(t, err, tdriver.ErrTooManyIdentityComponents)
+}
+
+// The fan-out bound must be enforced on the audit-info collection path too. It resolves one provider
+// lookup per component, and a composite component descends further, so a single level that fans out
+// without limit is unbounded work that the depth bound does not cover.
+func TestGetAuditInfo_RejectsExcessiveFanOut(t *testing.T) {
+	const maxComponents = 4
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), 5, maxComponents)
+
+	p := &mock.AuditInfoProvider{}
+	// nothing stored for the composite identity itself, so it is assembled from its components
+	p.GetAuditInfoReturns([]byte("audit-info"), nil)
+	p.GetAuditInfoReturnsOnCall(0, nil, nil)
+
+	d := NewTypedIdentityDeserializer(nil, nil)
+	raw, err := (&MultiIdentity{Identities: distinctIdentities(maxComponents + 1)}).Bytes()
+	require.NoError(t, err)
+
+	_, err = d.GetAuditInfo(ctx, token.Identity("owner"), Multisig, raw, p)
+	require.ErrorIs(t, err, tdriver.ErrTooManyIdentityComponents)
+	assert.Equal(t, 1, p.GetAuditInfoCallCount(),
+		"only the cache probe for the composite identity itself may run before the bound is enforced")
+}
+
+func TestGetAuditInfo_AllowsFanOutAtTheLimit(t *testing.T) {
+	const maxComponents = 4
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), 5, maxComponents)
+
+	p := &mock.AuditInfoProvider{}
+	p.GetAuditInfoReturns([]byte("audit-info"), nil)
+	p.GetAuditInfoReturnsOnCall(0, nil, nil)
+
+	d := NewTypedIdentityDeserializer(nil, nil)
+	raw, err := (&MultiIdentity{Identities: distinctIdentities(maxComponents)}).Bytes()
+	require.NoError(t, err)
+
+	_, err = d.GetAuditInfo(ctx, token.Identity("owner"), Multisig, raw, p)
+	require.NoError(t, err)
+	assert.Equal(t, 1+maxComponents, p.GetAuditInfoCallCount())
+}
+
+// The depth bound holds on the audit-info collection path as well: the provider resolves an unstored
+// composite component by re-entering this deserializer, which is the recursion the bound covers.
+func TestGetAuditInfo_RejectsExcessiveDepth(t *testing.T) {
+	const maxDepth = 3
+	ctx := tdriver.WithIdentityNestingLimits(context.Background(), maxDepth, 16)
+
+	p := &mock.AuditInfoProvider{}
+	d := NewTypedIdentityDeserializer(nil, nil)
+	// a provider that has nothing stored and resolves a composite identity through the deserializer.
+	// The guard keeps the cache probe for an identity already being resolved from looping back into
+	// it; production has the same shape, the provider only descends into components.
+	resolving := map[string]bool{}
+	p.GetAuditInfoCalls(func(ctx context.Context, id tdriver.Identity) ([]byte, error) {
+		if resolving[string(id)] {
+			return nil, nil
+		}
+		ti, err := identity.UnmarshalTypedIdentity(id)
+		if err != nil || ti.Type != Multisig {
+			return nil, nil //nolint:nilerr // a non-multisig component is the leaf, nothing stored
+		}
+		resolving[string(id)] = true
+
+		return d.GetAuditInfo(ctx, id, Multisig, ti.Identity, p)
+	})
+
+	deep := nestedMultisig(t, maxDepth+2, token.Identity("leaf"))
+	ti, err := identity.UnmarshalTypedIdentity(deep)
+	require.NoError(t, err)
+
+	_, err = d.GetAuditInfo(ctx, deep, Multisig, ti.Identity, p)
+	require.ErrorIs(t, err, tdriver.ErrIdentityNestingTooDeep)
+}

--- a/token/services/network/fabric/tcc/limits.go
+++ b/token/services/network/fabric/tcc/limits.go
@@ -31,6 +31,9 @@ const (
 	EnvMaxMetadataValueBytes = "TOKEN_VALIDATION_MAX_METADATA_VALUE_BYTES"
 
 	EnvMaxProofBytes = "TOKEN_VALIDATION_MAX_PROOF_BYTES"
+
+	EnvMaxIdentityDepth      = "TOKEN_VALIDATION_MAX_IDENTITY_DEPTH"
+	EnvMaxIdentityComponents = "TOKEN_VALIDATION_MAX_IDENTITY_COMPONENTS"
 )
 
 // EnvResourceLimitsProvider resolves driver.ResourceLimits from environment variables, overlaying
@@ -70,6 +73,8 @@ func (p *EnvResourceLimitsProvider) ResourceLimits() (driver.ResourceLimits, err
 		{EnvMaxMetadataKeyBytes, &l.MaxMetadataKeyBytes},
 		{EnvMaxMetadataValueBytes, &l.MaxMetadataValueBytes},
 		{EnvMaxProofBytes, &l.MaxProofBytes},
+		{EnvMaxIdentityDepth, &l.MaxIdentityDepth},
+		{EnvMaxIdentityComponents, &l.MaxIdentityComponents},
 	}
 	for _, f := range fields {
 		raw := getenv(f.env)

--- a/token/services/network/fabric/tcc/limits_test.go
+++ b/token/services/network/fabric/tcc/limits_test.go
@@ -51,6 +51,8 @@ func TestEnvResourceLimitsProvider_AllOverridden(t *testing.T) {
 		EnvMaxMetadataKeyBytes:   "9",
 		EnvMaxMetadataValueBytes: "10",
 		EnvMaxProofBytes:         "11",
+		EnvMaxIdentityDepth:      "12",
+		EnvMaxIdentityComponents: "13",
 	}
 	p := &EnvResourceLimitsProvider{Getenv: func(key string) string { return env[key] }}
 
@@ -68,6 +70,8 @@ func TestEnvResourceLimitsProvider_AllOverridden(t *testing.T) {
 		MaxMetadataKeyBytes:   9,
 		MaxMetadataValueBytes: 10,
 		MaxProofBytes:         11,
+		MaxIdentityDepth:      12,
+		MaxIdentityComponents: 13,
 	}, limits)
 }
 


### PR DESCRIPTION
Fixes #2076

## Problem

A token's owner field can be a *composite* identity whose components are themselves identities:
`multisig` (N co-owners), `boolpolicy` (a boolean expression over N identities), `htlc` (a script's
sender and recipient). Each driver's `NewDeserializer` registers the verifier multiplex as the
component deserializer for all three — including for itself:

```go
des := deserializer.NewTypedVerifierDeserializerMultiplex()
...
des.AddTypedVerifierDeserializer(htlc2.ScriptType, htlc.NewTypedIdentityDeserializer(des))
des.AddTypedVerifierDeserializer(multisig.Multisig, multisig.NewTypedIdentityDeserializer(des, des))
des.AddTypedVerifierDeserializer(boolpolicy.Policy, boolpolicy.NewTypedIdentityDeserializer(des, des))
```

That self-registration is what makes composite identities compose. It is also what makes the
recursion unbounded, in four independent chains, with nothing counting depth or fan-out:

| Chain | Entry point |
| --- | --- |
| Verifier deserialization | `DeserializeVerifier` in all three packages |
| Matcher construction | `GetAuditInfoMatcher` (`multisig`, `boolpolicy`) |
| Matcher evaluation | `InfoMatcher.Match` (`multisig`, `boolpolicy`), `AuditInfoMatcher.Match` (`htlc`) |
| Audit-info collection | `GetAuditInfo` in all three packages |

Step by step, as an attacker:

1. Own any token, any amount.
2. Build a transfer spending it, with an owner identity that is a `multisig` nested inside a
   `multisig` inside a `multisig`, as deep as you care to type.
3. Submit it. No permission needed — anyone can submit.
4. A validating peer calls `GetOwnerVerifier` once per input token
   (`validator_transfer.go`) to work out *whose signature to demand*.
5. Answering that means opening the identity, which means descending every level.
6. `MultiIdentity.Deserialize` is `asn1.Unmarshal` over the whole remaining subtree at every
   level, so a depth-`d`, size-`n` identity costs **O(n²)** — times up to `MaxInputs` tokens.
7. All of it lands **before any signature is checked**, so no authorization gates it.

`validateComponentIdentities` only rejected empties and intra-level duplicates, so distinct
components at each level walked straight through, and fan-out was uncapped.

### On severity

The issue describes an unrecoverable Go stack overflow. That part does not reproduce:
`MaxRequestBytes` (256 KiB) already caps nesting at roughly 8k levels, well short of exhausting a
1 GiB goroutine stack. What *is* reachable is the quadratic re-parsing above — CPU amplification
ahead of signature verification, not a crash. So this reads closer to **MEDIUM** than HIGH. Still
worth closing, and the existing size limit should not be the only thing standing in the way.

The recursion being genuinely unbounded is not theoretical: with the new guards stubbed out, the
end-to-end test package below does not fail — it **hangs**.


## Example 

Composite identities can be nested in two main forms:

```
1. Multisig — N co-owners

Multisig(Alice, Bob, Multisig(Carol, Dave, Multisig(Eve, Frank)))

Multisig
├── Alice
├── Bob
└── Multisig
    ├── Carol
    ├── Dave
    └── Multisig
        ├── Eve
        └── Frank

2. BoolPolicy — Boolean expression over N identities

BoolPolicy((Alice AND Bob) OR (Carol AND Dave))

          OR
         /  \
       AND  AND
      / \    / \
   Alice Bob Carol Dave

Both structures can be nested recursively, so validation needs limits on:
- MaxIdentityDepth: maximum nesting depth.
- MaxIdentityComponents: maximum components per composite identity.

Depth limits the vertical nesting; component limits the fan-out at each level.
```



## Fix

Two bounds, added to the existing `driver.ResourceLimits`, which already exists for exactly this
class of limit ("resources a validator will spend deserializing and validating an untrusted token
request, before any cryptographic work is performed"):

| Field | Default | Bounds |
| --- | --- | --- |
| `MaxIdentityDepth` | 5 | How deeply composite identities may nest |
| `MaxIdentityComponents` | 16 | How many components one composite identity may carry |

1. Depth rides in `context.Context` (`token/driver/identity_nesting.go`), already the first
   parameter of every method in all four chains — no interface or constructor signature changes.
   This follows `token/driver/validation_time.go`, which threads the validation reference time the
   same way. `driver.EnterCompositeIdentity(ctx)` accounts for one level and returns the context for
   the components; past the limit it errors with `driver.ErrIdentityNestingTooDeep`.
2. Called at the top of every recursive step in all four chains. The matcher paths recurse
   *separately* from the deserialization that built them, so each accounts for its own depth rather
   than inheriting a budget already spent.
3. Fan-out capped in both `validateComponentIdentities`, returning
   `driver.ErrTooManyIdentityComponents`, checked before any component is touched. Both bounds are
   needed: depth does not bound fan-out (one level with thousands of components is a single
   recursive step doing unbounded work), and fan-out does not bound depth.
4. Validators seed the configured limits at each public entry point
   (`(*Validator).withIdentityNestingLimits`).
5. Also applied in `WrapIdentities` / `WrapPolicyIdentity`, so an identity built in-process cannot
   exceed what a validator will later accept.

Real deployments nest 2–3 levels — a policy over a multisig over x509 — comfortably inside the
default, and a test asserts that shape is *not* rejected.

**Depth is per-path, not global.** `context.WithValue` returns a new context per descent, so sibling
components each start from their parent's depth instead of sharing a running total. That is the
correct semantics for a depth bound, and it is precisely why the fan-out bound is needed too.

**An unseeded context gets the defaults, not "unlimited."** Composite identity deserialization is
also reachable from paths with no `ResourceLimits` in scope — a wallet resolving a recipient, an
auditor inspecting a request, tests. Defaulting means a seeding site added later and forgotten
weakens the bound to the default rather than switching it off.

## Two adjacent defects the tests surfaced

- `htlc.DeserializeVerifier` replaced its component error with `errors.Errorf` instead of wrapping
  it, so **nothing** underneath an htlc level was testable with `errors.Is` — including the new
  sentinel. Both sites now `errors.Wrap`.
- `ResourceLimits` is only reachable through two providers that map fields **explicitly**
  (`services/config`, `network/fabric/tcc`), so a new field is silently unconfigurable until added
  to both. Both now carry `maxIdentityDepth` / `maxIdentityComponents` and
  `TOKEN_VALIDATION_MAX_IDENTITY_{DEPTH,COMPONENTS}`.

## Consensus note

These bounds change which requests a validator accepts, so they are consensus-relevant. No public
parameters version bump: `driver.ResourceLimits` already established the convention — configurable,
defaults every peer shares, and the keep-your-peers-in-sync requirement documented on the struct.
This follows that precedent rather than adding a new mechanism.

## Tests

- `nesting_test.go` in `multisig` and `boolpolicy` — each of the four chains at `limit` and
  `limit+1`, depth-is-per-path, and unseeded-context-still-bounded.
- `deserializer_nesting_test.go` (`fabtoken/v1/driver`) — the same against the **real assembled
  multiplex**, including composite types alternating so no type gets a fresh budget, plus the
  realistic three-level shape passing the bound.
- Every new test was confirmed to fail with the guards stubbed out; the end-to-end package hangs.
- `FuzzOwnerVerifierNoPanic` — fuzzes the owner deserialization path itself, seeded with identities
  nested 1 to 600 levels deep. 400k+ execs clean, and **wired into
  `.github/workflows/nightly-fuzz.yml`**.
- `make checks` and `make lint` clean; `-race` clean on the touched packages.

Pre-existing and unrelated: `TestTranslatePath`
(`token/services/identity/config`) asserts an absolute path contains `"panurus"` and fails in any
checkout whose directory is named otherwise.

## Docs

`docs/drivers/validation-resource-limits.md` gains an enforcement-points section covering the
composite types, the four chains, the per-path semantics and the unseeded-context behaviour;
`docs/configuration.md` gains both keys with defaults.

## Note on the branch

Cut from `origin/main` rather than the local `2076` branch, which carries the commit behind #2160
(htlc deterministic deadlines) — unrelated to this fix, so it is kept out and this reviews on its
own. One consequence: the `fabric-fsc-channel-header-timestamp` nightly-fuzz entry belongs to #2160
and is deliberately not duplicated here.
