### PR TITLE
feat(zkatsnark): add driver module for zkatsnark

### DIFF
--- a/x/token/core/zkatsnark/auditor.go
+++ b/x/token/core/zkatsnark/auditor.go
@@ -1,0 +1,46 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package zkatsnark
+
+import (
+	"context"
+
+	"github.com/LFDT-Panurus/panurus/token/core/common"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/pp"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type AuditorService struct {
+	Logger                  logging.Logger
+	PublicParametersManager common.PublicParametersManager[*pp.PublicParams]
+	Deserializer            driver.Deserializer
+	QueryEngine             driver.QueryEngine
+	TracerProvider          trace.TracerProvider
+}
+
+func NewAuditorService(
+	logger logging.Logger,
+	publicParametersManager common.PublicParametersManager[*pp.PublicParams],
+	deserializer driver.Deserializer,
+	queryEngine driver.QueryEngine,
+	tracerProvider trace.TracerProvider,
+) *AuditorService {
+	return &AuditorService{
+		Logger:                  logger,
+		PublicParametersManager: publicParametersManager,
+		Deserializer:            deserializer,
+		QueryEngine:             queryEngine,
+		TracerProvider:          tracerProvider,
+	}
+}
+
+func (s *AuditorService) AuditorCheck(ctx context.Context, tokenRequest *driver.TokenRequest, tokenRequestMetadata *driver.TokenRequestMetadata, anchor driver.TokenRequestAnchor) error {
+	return errors.New("auditor check not fully implemented for zkatsnark")
+}

--- a/x/token/core/zkatsnark/driver/deserializer.go
+++ b/x/token/core/zkatsnark/driver/deserializer.go
@@ -1,0 +1,80 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import (
+	"github.com/LFDT-Panurus/panurus/token/core/common"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/boolpolicy"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/deserializer"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/idemix"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/idemixnym"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/interop/htlc"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/multisig"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/x509"
+	htlc2 "github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/pp"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// Deserializer deserializes verifiers associated with issuers, owners, and auditors.
+type Deserializer struct {
+	*common.Deserializer
+}
+
+// NewDeserializer returns a new zkatsnark deserializer.
+func NewDeserializer(ppp *pp.PublicParams) (*Deserializer, error) {
+	if ppp == nil {
+		return nil, errors.New("failed to get deserializer: nil public parameters")
+	}
+
+	des := deserializer.NewTypedVerifierDeserializerMultiplex()
+
+	des.AddTypedVerifierDeserializer(x509.IdentityType, deserializer.NewTypedIdentityVerifierDeserializer(&x509.IdentityDeserializer{}, &x509.AuditMatcherDeserializer{}))
+	des.AddTypedVerifierDeserializer(htlc2.ScriptType, htlc.NewTypedIdentityDeserializer(des))
+	des.AddTypedVerifierDeserializer(multisig.Multisig, multisig.NewTypedIdentityDeserializer(des, des))
+	des.AddTypedVerifierDeserializer(boolpolicy.Policy, boolpolicy.NewTypedIdentityDeserializer(des, des))
+
+	return &Deserializer{Deserializer: common.NewDeserializer(des, des, des, des, des)}, nil
+}
+
+// PublicParamsDeserializer deserializes zkatsnark public parameters.
+type PublicParamsDeserializer struct{}
+
+// DeserializePublicParams deserializes the passed bytes into zkatsnark public parameters.
+func (p *PublicParamsDeserializer) DeserializePublicParams(raw []byte, name driver.TokenDriverName, version driver.TokenDriverVersion) (*pp.PublicParams, error) {
+	return pp.DeserializePublicParams(raw)
+}
+
+// EIDRHDeserializer returns enrollment ID and revocation handle behind the owners of token.
+type EIDRHDeserializer = deserializer.EIDRHDeserializer
+
+// NewEIDRHDeserializer returns a new zkatsnark EIDRHDeserializer.
+func NewEIDRHDeserializer() *EIDRHDeserializer {
+	d := deserializer.NewEIDRHDeserializer()
+	d.AddDeserializer(idemix.IdentityType, &idemix.AuditInfoDeserializer{})
+	d.AddDeserializer(idemixnym.IdentityType, &idemixnym.AuditInfoDeserializer{})
+	d.AddDeserializer(x509.IdentityType, &x509.AuditInfoDeserializer{})
+	d.AddDeserializer(htlc2.ScriptType, htlc.NewAuditDeserializer(d))
+	d.AddDeserializer(multisig.Multisig, &multisig.AuditInfoDeserializer{})
+	d.AddDeserializer(boolpolicy.Policy, &boolpolicy.AuditInfoDeserializer{})
+
+	return d
+}
+
+// PublicParametersDeserializer contains the logic to deserialize public parameters
+type PublicParametersDeserializer struct{}
+
+// PublicParametersFromBytes unmarshals the passed bytes into zkatsnark public parameters.
+func (d PublicParametersDeserializer) PublicParametersFromBytes(params []byte) (driver.PublicParameters, error) {
+	ppp, err := pp.DeserializePublicParams(params)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal public parameters")
+	}
+
+	return ppp, nil
+}

--- a/x/token/core/zkatsnark/driver/driver.go
+++ b/x/token/core/zkatsnark/driver/driver.go
@@ -1,0 +1,184 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import (
+	"github.com/LFDT-Panurus/panurus/token/core"
+	"github.com/LFDT-Panurus/panurus/token/core/common"
+	cdriver "github.com/LFDT-Panurus/panurus/token/core/common/driver"
+	"github.com/LFDT-Panurus/panurus/token/core/common/metrics"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/token/services/ttx/boolpolicy"
+	"github.com/LFDT-Panurus/panurus/token/services/ttx/multisig"
+	"github.com/LFDT-Panurus/panurus/token/services/utils"
+	zkatsnark "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/pp"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// Driver contains the non-static logic of the zkatsnark driver (including services).
+type Driver struct {
+	BaseWalletServiceFactory
+	metricsProvider  cdriver.MetricsProvider
+	tracerProvider   cdriver.TracerProvider
+	configService    cdriver.ConfigService
+	storageProvider  cdriver.StorageProvider
+	identityProvider cdriver.IdentityProvider
+	endpointService  cdriver.NetworkBinderService
+	networkProvider  cdriver.NetworkProvider
+	vaultProvider    cdriver.VaultProvider
+}
+
+// NewTokenDriver returns a new factory for the zkatsnark driver.
+func NewTokenDriver(
+	metricsProvider cdriver.MetricsProvider,
+	tracerProvider cdriver.TracerProvider,
+	configService cdriver.ConfigService,
+	storageProvider cdriver.StorageProvider,
+	identityProvider cdriver.IdentityProvider,
+	endpointService cdriver.NetworkBinderService,
+	networkProvider cdriver.NetworkProvider,
+	vaultProvider cdriver.VaultProvider,
+) core.NamedFactory[driver.Driver] {
+	return core.NamedFactory[driver.Driver]{
+		Name: core.DriverIdentifier(driver.TokenDriverName("zkatsnark"), driver.TokenDriverVersion(1)),
+		Driver: newTokenDriver(
+			metricsProvider,
+			tracerProvider,
+			configService,
+			storageProvider,
+			identityProvider,
+			endpointService,
+			networkProvider,
+			vaultProvider,
+		),
+	}
+}
+
+func newTokenDriver(
+	metricsProvider cdriver.MetricsProvider,
+	tracerProvider cdriver.TracerProvider,
+	configService cdriver.ConfigService,
+	storageProvider cdriver.StorageProvider,
+	identityProvider cdriver.IdentityProvider,
+	endpointService cdriver.NetworkBinderService,
+	networkProvider cdriver.NetworkProvider,
+	vaultProvider cdriver.VaultProvider,
+) *Driver {
+	return &Driver{
+		metricsProvider:  metricsProvider,
+		tracerProvider:   tracerProvider,
+		configService:    configService,
+		storageProvider:  storageProvider,
+		identityProvider: identityProvider,
+		endpointService:  endpointService,
+		networkProvider:  networkProvider,
+		vaultProvider:    vaultProvider,
+	}
+}
+
+// NewTokenService returns a new zkatsnark token manager service for the passed TMS ID and public parameters.
+func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (driver.TokenManagerService, error) {
+	logger := logging.DriverLogger("panurus.driver.zkatsnark", tmsID.Network, tmsID.Channel, tmsID.Namespace)
+
+	logger.Debugf("creating new token service with public parameters [%s]", utils.Hashable(publicParams))
+
+	if len(publicParams) == 0 {
+		return nil, errors.Errorf("empty public parameters")
+	}
+	// get network
+	n, err := d.networkProvider.GetNetwork(tmsID.Network, tmsID.Channel)
+	if err != nil {
+		return nil, errors.Errorf("failed getting network [%s]", err)
+	}
+
+	// get vault
+	vault, err := d.vaultProvider.Vault(tmsID.Network, tmsID.Channel, tmsID.Namespace)
+	if err != nil {
+		return nil, errors.Errorf("failed getting vault [%s]", err)
+	}
+
+	networkLocalMembership := n.LocalMembership()
+
+	tmsConfig, err := d.configService.ConfigurationFor(tmsID.Network, tmsID.Channel, tmsID.Namespace)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to get config for token service for [%s:%s:%s]", tmsID.Network, tmsID.Channel, tmsID.Namespace)
+	}
+
+	ppm, err := common.NewPublicParamsManager[*pp.PublicParams](
+		&PublicParamsDeserializer{},
+		"zkatsnark",
+		driver.TokenDriverVersion(1),
+		publicParams,
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to initialize public params manager")
+	}
+
+	ppp := ppm.PublicParams()
+	logger.Infof("new token driver for tms id [%s] with label and version [%s:%s]: [%s]", tmsID, ppp.TokenDriverName(), ppp.TokenDriverVersion(), ppp)
+
+	metricsProvider := metrics.NewTMSProvider(tmsConfig.ID(), d.metricsProvider)
+	qe := vault.QueryEngine()
+	ws, err := d.NewWalletService(
+		tmsConfig,
+		d.endpointService,
+		d.storageProvider,
+		qe,
+		logger,
+		d.identityProvider.DefaultIdentity(),
+		networkLocalMembership.DefaultIdentity(),
+		ppm.PublicParams(),
+		false,
+		metricsProvider,
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to initialize wallet service for [%s:%s]", tmsID.Network, tmsID.Namespace)
+	}
+	deserializer := ws.Deserializer
+	ip := ws.IdentityProvider
+
+	authorization := common.NewAuthorizationMultiplexer(
+		common.NewTMSAuthorization(logger, ppm.PublicParams(), ws),
+		htlc.NewScriptAuth(ws),
+		multisig.NewEscrowAuth(ws),
+		boolpolicy.NewEscrowAuth(ws),
+	)
+
+	valDriver := NewValidatorDriver().Driver
+	validator, err := valDriver.NewValidator(ppp)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to instantiate validator")
+	}
+
+	issueService := zkatsnark.NewIssueService(logger, ppm, ws, deserializer, nil, nil)
+	transferService := zkatsnark.NewTransferService(logger, ppm, ws, nil, deserializer, d.tracerProvider, nil)
+	auditorService := zkatsnark.NewAuditorService(logger, ppm, deserializer, qe, d.tracerProvider)
+
+	service, err := zkatsnark.NewTokenService(
+		logger,
+		ws,
+		ppm,
+		ip,
+		deserializer,
+		tmsConfig,
+		metrics.NewIssueService(issueService, metricsProvider),
+		metrics.NewTransferService(transferService, metricsProvider),
+		metrics.NewAuditorService(auditorService, metricsProvider),
+		nil, // metrics.NewTokensService(tokensService, metricsProvider),
+		nil, // metrics.NewTokensUpgradeService(tokensUpgradeService, metricsProvider),
+		authorization,
+		validator,
+	)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to create token service")
+	}
+
+	return service, err
+}

--- a/x/token/core/zkatsnark/driver/ppm.go
+++ b/x/token/core/zkatsnark/driver/ppm.go
@@ -1,0 +1,36 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import (
+	"github.com/LFDT-Panurus/panurus/token/core"
+	"github.com/LFDT-Panurus/panurus/token/core/common"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/pp"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// PPMFactory is a factory for creating zkatsnark public parameters managers.
+type PPMFactory struct{ ValidatorDriver }
+
+// NewPPMFactory returns a new factory for the zkatsnark public parameters manager.
+func NewPPMFactory() core.NamedFactory[driver.PPMFactory] {
+	return core.NamedFactory[driver.PPMFactory]{
+		Name:   core.DriverIdentifier(driver.TokenDriverName("zkatsnark"), driver.TokenDriverVersion(1)),
+		Driver: &PPMFactory{},
+	}
+}
+
+// NewPublicParametersManager returns a new zkatsnark public parameters manager for the passed public parameters.
+func (d *PPMFactory) NewPublicParametersManager(params driver.PublicParameters) (driver.PublicParamsManager, error) {
+	ppp, ok := params.(*pp.PublicParams)
+	if !ok {
+		return nil, errors.Errorf("invalid public parameters type [%T]", params)
+	}
+
+	return common.NewPublicParamsManagerFromParams[*pp.PublicParams](ppp)
+}

--- a/x/token/core/zkatsnark/driver/validator.go
+++ b/x/token/core/zkatsnark/driver/validator.go
@@ -1,0 +1,41 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import (
+	"github.com/LFDT-Panurus/panurus/token/core"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/pp"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/validator"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// ValidatorDriver contains the static logic of the zkatsnark driver.
+type ValidatorDriver struct {
+	PublicParametersDeserializer
+}
+
+// NewValidatorDriver returns a new factory for the zkatsnark validator driver.
+func NewValidatorDriver() core.NamedFactory[driver.ValidatorDriver] {
+	return core.NamedFactory[driver.ValidatorDriver]{
+		Name:   core.DriverIdentifier(driver.TokenDriverName("zkatsnark"), driver.TokenDriverVersion(1)),
+		Driver: ValidatorDriver{},
+	}
+}
+
+// NewValidator returns a new zkatsnark validator for the passed public parameters.
+func (d ValidatorDriver) NewValidator(params driver.PublicParameters) (driver.Validator, error) {
+	ppp, ok := params.(*pp.PublicParams)
+	if !ok {
+		return nil, errors.Errorf("invalid public parameters type [%T]", params)
+	}
+	if err := ppp.Validate(); err != nil {
+		return nil, errors.Wrapf(err, "failed validating public parameters")
+	}
+	// Returns the validator for zkatsnark
+	return validator.NewValidator(ppp)
+}

--- a/x/token/core/zkatsnark/driver/ws.go
+++ b/x/token/core/zkatsnark/driver/ws.go
@@ -1,0 +1,156 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import (
+	"github.com/LFDT-Panurus/panurus/token/core"
+	"github.com/LFDT-Panurus/panurus/token/core/common/metrics"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/config"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/deserializer"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/membership"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/role"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/wallet"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/x509"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/pp"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/disabled"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+type BaseWalletServiceFactory struct {
+	PublicParametersDeserializer
+}
+
+// NewWalletService returns a new zkatsnark wallet service.
+func (d *BaseWalletServiceFactory) NewWalletService(
+	tmsConfig core.Config,
+	binder identity.NetworkBinderService,
+	storageProvider identity.StorageProvider,
+	qe driver.QueryEngine,
+	logger logging.Logger,
+	fscIdentity view.Identity,
+	networkDefaultIdentity view.Identity,
+	publicParams driver.PublicParameters,
+	ignoreRemote bool,
+	metricsProvider metrics.Provider,
+) (*wallet.Service, error) {
+	ppp := publicParams.(*pp.PublicParams)
+	roles := role.NewRoles()
+	deserializerManager := deserializer.NewTypedSignerDeserializerMultiplex()
+	tmsID := tmsConfig.ID()
+	identityDB, err := storageProvider.IdentityStore(tmsID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open identity db for tms [%s]", tmsID)
+	}
+	baseKeyStore, err := storageProvider.Keystore(tmsID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open keystore for tms [%s]", tmsID)
+	}
+	identityProvider := identity.NewProvider(logger.Named("identity"), identityDB, deserializerManager, binder, NewEIDRHDeserializer())
+	identityConfig, err := config.NewIdentityConfig(tmsConfig)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to create identity config")
+	}
+
+	// Prepare roles
+	roleFactory := membership.NewRoleFactory(
+		logger,
+		tmsID,
+		identityConfig,
+		fscIdentity,
+		networkDefaultIdentity,
+		identityProvider,
+		storageProvider,
+		deserializerManager,
+	)
+
+	kmps := make([]membership.KeyManagerProvider, 0, 1)
+	keyStore := x509.NewKeyStore(baseKeyStore)
+	kmps = append(kmps, x509.NewKeyManagerProvider(identityConfig, keyStore, ignoreRemote))
+
+	newRole, err := roleFactory.NewRole(identity.OwnerRole, true, nil, kmps...)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to create owner role")
+	}
+	roles.Register(identity.OwnerRole, newRole)
+	newRole, err = roleFactory.NewRole(identity.IssuerRole, false, ppp.Issuers(), x509.NewKeyManagerProvider(identityConfig, keyStore, ignoreRemote))
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to create issuer role")
+	}
+	roles.Register(identity.IssuerRole, newRole)
+	newRole, err = roleFactory.NewRole(identity.AuditorRole, false, ppp.Auditors(), x509.NewKeyManagerProvider(identityConfig, keyStore, ignoreRemote))
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to create auditor role")
+	}
+	roles.Register(identity.AuditorRole, newRole)
+	newRole, err = roleFactory.NewRole(identity.CertifierRole, false, nil, x509.NewKeyManagerProvider(identityConfig, keyStore, ignoreRemote))
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to create certifier role")
+	}
+	roles.Register(identity.CertifierRole, newRole)
+
+	// wallet service
+	walletDB, err := storageProvider.WalletStore(tmsID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get identity storage provider")
+	}
+	deser, err := NewDeserializer(ppp)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to instantiate the deserializer")
+	}
+
+	return wallet.NewService(
+		logger,
+		identityProvider,
+		deser,
+		wallet.Convert(roles.Registries(logger, walletDB, role.NewDefaultFactory(logger, identityProvider, qe, identityConfig, deser, metricsProvider))),
+	), nil
+}
+
+// WalletServiceFactory is a factory for creating zkatsnark wallet services.
+type WalletServiceFactory struct {
+	*BaseWalletServiceFactory
+
+	storageProvider identity.StorageProvider
+}
+
+// NewWalletServiceFactory returns a new factory for the zkatsnark wallet service.
+func NewWalletServiceFactory(storageProvider identity.StorageProvider) core.NamedFactory[driver.WalletServiceFactory] {
+	return core.NamedFactory[driver.WalletServiceFactory]{
+		Name: core.DriverIdentifier(driver.TokenDriverName("zkatsnark"), driver.TokenDriverVersion(1)),
+		Driver: &WalletServiceFactory{
+			BaseWalletServiceFactory: &BaseWalletServiceFactory{},
+			storageProvider:          storageProvider},
+	}
+}
+
+// NewWalletService returns a new zkatsnark wallet service for the passed configuration and public parameters.
+func (d *WalletServiceFactory) NewWalletService(tmsConfig driver.Configuration, params driver.PublicParameters) (driver.WalletService, error) {
+	tmsID := tmsConfig.ID()
+	logger := logging.DriverLogger("panurus.driver.zkatsnark", tmsID.Network, tmsID.Channel, tmsID.Namespace)
+
+	ppp, ok := params.(*pp.PublicParams)
+	if !ok {
+		return nil, errors.Errorf("invalid public parameters type [%T]", params)
+	}
+
+	return d.BaseWalletServiceFactory.NewWalletService(
+		tmsConfig,
+		&membership.NoBinder{},
+		d.storageProvider,
+		nil,
+		logger,
+		nil,
+		nil,
+		ppp,
+		true,
+		&disabled.Provider{},
+	)
+}

--- a/x/token/core/zkatsnark/go.mod
+++ b/x/token/core/zkatsnark/go.mod
@@ -9,10 +9,12 @@ require (
 	github.com/consensys/gnark-crypto v0.20.1
 	github.com/hyperledger-labs/fabric-smart-client v0.14.2
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/otel/trace v1.44.0
 )
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
+	github.com/IBM/idemix v0.2.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -46,6 +48,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2 // indirect
 	github.com/hyperledger/fabric-lib-go v1.1.5-0.20260607181445-fc4b05c5d38f // indirect
+	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.10.0 // indirect
@@ -63,6 +66,7 @@ require (
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
+	github.com/miekg/pkcs11 v1.1.2 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -97,7 +101,6 @@ require (
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
-	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect

--- a/x/token/core/zkatsnark/issue.go
+++ b/x/token/core/zkatsnark/issue.go
@@ -1,0 +1,64 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package zkatsnark
+
+import (
+	"context"
+
+	"github.com/LFDT-Panurus/panurus/token/core/common"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/pp"
+	snarktoken "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+type IssueService struct {
+	Logger                  logging.Logger
+	PublicParametersManager common.PublicParametersManager[*pp.PublicParams]
+	WalletService           driver.WalletService
+	Deserializer            driver.Deserializer
+	TokensService           driver.TokensService
+	TokensUpgradeService    driver.TokensUpgradeService
+}
+
+func NewIssueService(
+	logger logging.Logger,
+	publicParametersManager common.PublicParametersManager[*pp.PublicParams],
+	walletService driver.WalletService,
+	deserializer driver.Deserializer,
+	tokensService driver.TokensService,
+	tokensUpgradeService driver.TokensUpgradeService,
+) *IssueService {
+	return &IssueService{
+		Logger:                  logger,
+		PublicParametersManager: publicParametersManager,
+		WalletService:           walletService,
+		Deserializer:            deserializer,
+		TokensService:           tokensService,
+		TokensUpgradeService:    tokensUpgradeService,
+	}
+}
+
+func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType token.Type, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+	return nil, nil, errors.New("issue service not fully implemented for zkatsnark")
+}
+
+func (s *IssueService) VerifyIssue(ctx context.Context, ia driver.IssueAction, outputMetadata []*driver.IssueOutputMetadata) error {
+	return errors.New("verify issue not fully implemented for zkatsnark")
+}
+
+func (s *IssueService) DeserializeIssueAction(raw []byte) (driver.IssueAction, error) {
+	issue := &snarktoken.IssueAction{}
+	err := issue.Deserialize(raw)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to deserialize issue action")
+	}
+
+	return issue, nil
+}

--- a/x/token/core/zkatsnark/service.go
+++ b/x/token/core/zkatsnark/service.go
@@ -1,0 +1,61 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package zkatsnark
+
+import (
+	"github.com/LFDT-Panurus/panurus/token/core/common"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/wallet"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/pp"
+)
+
+type Service struct {
+	*common.Service[*pp.PublicParams]
+}
+
+func NewTokenService(
+	logger logging.Logger,
+	ws *wallet.Service,
+	ppm common.PublicParametersManager[*pp.PublicParams],
+	identityProvider driver.IdentityProvider,
+	deserializer driver.Deserializer,
+	configuration driver.Configuration,
+	issueService driver.IssueService,
+	transferService driver.TransferService,
+	auditorService driver.AuditorService,
+	tokensService driver.TokensService,
+	tokensUpgradeService driver.TokensUpgradeService,
+	authorization driver.Authorization,
+	validator driver.Validator,
+) (*Service, error) {
+	root, err := common.NewTokenService[*pp.PublicParams](
+		logger,
+		ws,
+		ppm,
+		identityProvider,
+		deserializer,
+		configuration,
+		nil,
+		issueService,
+		transferService,
+		auditorService,
+		tokensService,
+		tokensUpgradeService,
+		authorization,
+		validator,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Service{
+		Service: root,
+	}
+
+	return s, nil
+}

--- a/x/token/core/zkatsnark/transfer.go
+++ b/x/token/core/zkatsnark/transfer.go
@@ -53,7 +53,14 @@ func NewTransferService(
 	}
 }
 
-func (s *TransferService) Transfer(ctx context.Context, anchor driver.TokenRequestAnchor, wallet driver.OwnerWallet, tokenIDs []*token2.ID, outputTokens []*token2.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+func (s *TransferService) Transfer(
+	ctx context.Context,
+	anchor driver.TokenRequestAnchor,
+	wallet driver.OwnerWallet,
+	tokenIDs []*token2.ID,
+	outputTokens []*token2.Token,
+	opts *driver.TransferOptions,
+) (driver.TransferAction, *driver.TransferMetadata, error) {
 	return nil, nil, errors.New("transfer service not fully implemented for zkatsnark")
 }
 

--- a/x/token/core/zkatsnark/transfer.go
+++ b/x/token/core/zkatsnark/transfer.go
@@ -1,0 +1,72 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package zkatsnark
+
+import (
+	"context"
+
+	"github.com/LFDT-Panurus/panurus/token/core/common"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	token2 "github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/pp"
+	snarktoken "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type TokenLoader interface {
+	LoadTokens(ctx context.Context, ids []*token2.ID) ([]common.LoadedToken[[]byte, []byte], error)
+}
+
+type TransferService struct {
+	Logger                  logging.Logger
+	PublicParametersManager common.PublicParametersManager[*pp.PublicParams]
+	WalletService           driver.WalletService
+	VaultTokenLoader        TokenLoader
+	Deserializer            driver.Deserializer
+	TracerProvider          trace.TracerProvider
+	TokensService           driver.TokensService
+}
+
+func NewTransferService(
+	logger logging.Logger,
+	publicParametersManager common.PublicParametersManager[*pp.PublicParams],
+	walletService driver.WalletService,
+	vaultTokenLoader TokenLoader,
+	deserializer driver.Deserializer,
+	tracerProvider trace.TracerProvider,
+	tokensService driver.TokensService,
+) *TransferService {
+	return &TransferService{
+		Logger:                  logger,
+		PublicParametersManager: publicParametersManager,
+		WalletService:           walletService,
+		VaultTokenLoader:        vaultTokenLoader,
+		Deserializer:            deserializer,
+		TracerProvider:          tracerProvider,
+		TokensService:           tokensService,
+	}
+}
+
+func (s *TransferService) Transfer(ctx context.Context, anchor driver.TokenRequestAnchor, wallet driver.OwnerWallet, tokenIDs []*token2.ID, outputTokens []*token2.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+	return nil, nil, errors.New("transfer service not fully implemented for zkatsnark")
+}
+
+func (s *TransferService) VerifyTransfer(ctx context.Context, action driver.TransferAction, tokenMetadata []*driver.TransferOutputMetadata) error {
+	return errors.New("verify transfer not fully implemented for zkatsnark")
+}
+
+func (s *TransferService) DeserializeTransferAction(raw []byte) (driver.TransferAction, error) {
+	transfer := &snarktoken.TransferAction{}
+	err := transfer.Deserialize(raw)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to deserialize transfer action")
+	}
+
+	return transfer, nil
+}


### PR DESCRIPTION
## Description

This PR introduces the driver module for the `zkatsnark` token backend, effectively wiring up the core Panurus token interfaces (`TokenDriver`, `ValidatorDriver`, `WalletServiceFactory`) to our new zk-SNARK cryptographic primitives. The architecture mirrors the existing `zkatdlog` driver implementation to ensure consistency across the codebase.

## Changes included

- **Driver Registration (`driver.go`)**: Implements `NewTokenDriver` and `NewTokenService` to orchestrate and export the `zkatsnark` capabilities as a factory, registered under the `zkatsnark` driver name and `v1` version.
- **Component Factories**: 
  - `ppm.go`: Implements the `PublicParametersManager` factory.
  - `ws.go`: Implements the `WalletServiceFactory` adapted for zkatsnark identities and roles.
  - `validator.go`: Instantiates the `zkatsnark`-specific validator utilizing the `groth16` proof system.
  - `deserializer.go`: Wires the identity deserialization logic supporting Idemix, X.509, multisig, and HTLC identities.
- **Core Service Stubs**: 
  - Created initial stubs for `service.go`, `issue.go`, `transfer.go`, and `auditor.go` to satisfy the `TokenManagerService` composition requirements. These encapsulate the core action logic (Issue/Transfer/Audit) and will be fully implemented in a follow-up PR alongside the prover orchestrator. 

## Next step

- Implement `TokenTypeCommitment` as part of an action instead of encoding raw token type bytes.