### PR TITLE
feat(zkatsnark): add commitment for token types in actions

### DIFF
--- a/x/token/core/zkatsnark/circuit/migration.go
+++ b/x/token/core/zkatsnark/circuit/migration.go
@@ -23,11 +23,12 @@ import (
 // zkatsnark token (MiMC commitment + Jubjub value commitment) has been
 // correctly created for the same value, in zero knowledge.
 //
-// It enforces four constraint groups:
+// It enforces five constraint groups:
 //  1. Pedersen opening: CommitmentPedersen == TokenTypePed·G[0] + Value·G[1] + RandomnessPed·G[2]
 //  2. MiMC commitment: CommitmentMiMC == MiMC(Value, TokenType, RandomnessNew)
 //  3. Value commitment: (ValueCommitOutX, ValueCommitOutY) == Value·V + RCV·R
 //  4. Range check: Value ∈ [1, 2^MaxBits)
+//  5. Type commitment: TypeCommitment == MiMC(TokenType, TypeRandomness)
 //
 // The shared Value witness variable across groups 1–3 is the structural
 // binding that proves the same denomination carries over (Decision C:
@@ -56,16 +57,21 @@ type MigrationCircuit struct {
 	// commitment.
 	ValueCommitOutY frontend.Variable `gnark:",public"`
 
-	// TokenType is the canonical field-element encoding of the token type,
-	// produced by EncodeTokenType (SetBytes). Public for type-homogeneity
-	// checks, consistent with SpendCircuit/OutputCircuit.
-	TokenType frontend.Variable `gnark:",public"`
+	// TypeCommitment is the hiding commitment to the token type:
+	// MiMC(EncodeTokenType(tokenType), TypeRandomness). Public for
+	// type-homogeneity checks, consistent with SpendCircuit/OutputCircuit.
+	TypeCommitment frontend.Variable `gnark:",public"`
 
 	// ── Private inputs ──────────────────────────────────────────────────
 
-	// Value is the token denomination, shared across all four constraint
+	// Value is the token denomination, shared across all five constraint
 	// groups. This shared variable is the conservation proof.
 	Value frontend.Variable
+
+	// TokenType is the canonical field-element encoding of the token type,
+	// produced by EncodeTokenType (SetBytes). Private — the validator
+	// only sees the TypeCommitment, not the plaintext type.
+	TokenType frontend.Variable
 
 	// TokenTypePed is the zkatdlog encoding of the token type:
 	// HashToZr(tokenType) = SHA256(tokenType) mod r. This is a DIFFERENT
@@ -83,6 +89,10 @@ type MigrationCircuit struct {
 	// RCV is the Jubjub value-commitment randomness, generated fresh for
 	// this proof.
 	RCV frontend.Variable
+
+	// TypeRandomness is the randomness used to hide the token type in
+	// the TypeCommitment. Shared across all descriptions in one action.
+	TypeRandomness frontend.Variable
 
 	// ── Compile-time parameters ─────────────────────────────────────────
 
@@ -222,6 +232,18 @@ func (c *MigrationCircuit) Define(api frontend.API) error {
 	// freshly-issued token (Decision A).
 	_ = api.ToBinary(c.Value, maxBits)
 	api.AssertIsDifferent(c.Value, 0)
+
+	// ── Constraint Group 5: Type Commitment Integrity ───────────────────
+	// Enforce: TypeCommitment == MiMC(TokenType, TypeRandomness)
+	//
+	// The same TokenType private variable used in Group 2 (MiMC commitment)
+	// appears here, so the ZK proof structurally binds the committed type
+	// to the type encoded in the note commitment.
+	tc, err := gadgets.HashCircuit(api, c.TokenType, c.TypeRandomness)
+	if err != nil {
+		return err
+	}
+	api.AssertIsEqual(tc, c.TypeCommitment)
 
 	return nil
 }

--- a/x/token/core/zkatsnark/circuit/migration_test.go
+++ b/x/token/core/zkatsnark/circuit/migration_test.go
@@ -106,13 +106,14 @@ func setupMigration(t *testing.T) {
 // ── Test inputs ─────────────────────────────────────────────────────────────
 
 type migrationInputs struct {
-	value         uint64
-	tokenType     string
-	tokenTypeFr   fr.Element // EncodeTokenType(tokenType)
-	tokenTypePed  fr.Element // HashToZr(tokenType) for Pedersen
-	randomnessPed fr.Element // Pedersen blinding factor
-	randomnessNew fr.Element // MiMC randomness
-	rcv           fr.Element // Jubjub value-commitment randomness
+	value          uint64
+	tokenType      string
+	tokenTypeFr    fr.Element // EncodeTokenType(tokenType)
+	tokenTypePed   fr.Element // HashToZr(tokenType) for Pedersen
+	randomnessPed  fr.Element // Pedersen blinding factor
+	randomnessNew  fr.Element // MiMC randomness
+	rcv            fr.Element // Jubjub value-commitment randomness
+	typeRandomness fr.Element // TypeCommitment randomness
 }
 
 func newRandomMigrationInputs(t *testing.T) migrationInputs {
@@ -131,22 +132,25 @@ func newRandomMigrationInputs(t *testing.T) migrationInputs {
 	var tokenTypePed fr.Element
 	tokenTypePed.SetBigInt(digestBig)
 
-	var randomnessPed, randomnessNew, rcv fr.Element
+	var randomnessPed, randomnessNew, rcv, typeRandomness fr.Element
 	_, err := randomnessPed.SetRandom()
 	require.NoError(t, err)
 	_, err = randomnessNew.SetRandom()
 	require.NoError(t, err)
 	_, err = rcv.SetRandom()
 	require.NoError(t, err)
+	_, err = typeRandomness.SetRandom()
+	require.NoError(t, err)
 
 	return migrationInputs{
-		value:         value,
-		tokenType:     tokenType,
-		tokenTypeFr:   tokenTypeFr,
-		tokenTypePed:  tokenTypePed,
-		randomnessPed: randomnessPed,
-		randomnessNew: randomnessNew,
-		rcv:           rcv,
+		value:          value,
+		tokenType:      tokenType,
+		tokenTypeFr:    tokenTypeFr,
+		tokenTypePed:   tokenTypePed,
+		randomnessPed:  randomnessPed,
+		randomnessNew:  randomnessNew,
+		rcv:            rcv,
+		typeRandomness: typeRandomness,
 	}
 }
 
@@ -210,6 +214,10 @@ func buildMigrationAssignment(t *testing.T, inp migrationInputs) *circuit.Migrat
 	cv, err := jubjub.ValueCommit(inp.value, inp.rcv)
 	require.NoError(t, err, "jubjub.ValueCommit failed")
 
+	// Compute type commitment: MiMC(TokenType, TypeRandomness)
+	tc, err := mimc.Hash(inp.tokenTypeFr, inp.typeRandomness)
+	require.NoError(t, err, "mimc.Hash failed for type commitment")
+
 	return &circuit.MigrationCircuit{
 		// Public inputs
 		CommitmentPedersenX: emulated.ValueOf[emulated.BLS12381Fp](pedXBig),
@@ -217,13 +225,15 @@ func buildMigrationAssignment(t *testing.T, inp migrationInputs) *circuit.Migrat
 		CommitmentMiMC:      cm,
 		ValueCommitOutX:     cv.X,
 		ValueCommitOutY:     cv.Y,
-		TokenType:           inp.tokenTypeFr,
+		TypeCommitment:      tc,
 		// Private inputs
-		Value:         vField,
-		TokenTypePed:  inp.tokenTypePed,
-		RandomnessPed: inp.randomnessPed,
-		RandomnessNew: inp.randomnessNew,
-		RCV:           inp.rcv,
+		Value:          vField,
+		TokenType:      inp.tokenTypeFr,
+		TokenTypePed:   inp.tokenTypePed,
+		RandomnessPed:  inp.randomnessPed,
+		RandomnessNew:  inp.randomnessNew,
+		RCV:            inp.rcv,
+		TypeRandomness: inp.typeRandomness,
 		// Compile-time parameters
 		MaxBits: params.DefaultMaxBits,
 		PedG0X:  testPedGens.G0X, PedG0Y: testPedGens.G0Y,
@@ -410,6 +420,10 @@ func TestMigrationCircuitInvalid_OverflowValue(t *testing.T) {
 	cm, err := mimc.Hash(overflowValue, inp.tokenTypeFr, inp.randomnessNew)
 	require.NoError(t, err)
 
+	// Compute type commitment
+	tc, err := mimc.Hash(inp.tokenTypeFr, inp.typeRandomness)
+	require.NoError(t, err)
+
 	pedXBig := pedCommit.X.BigInt(new(big.Int))
 	pedYBig := pedCommit.Y.BigInt(new(big.Int))
 
@@ -426,12 +440,14 @@ func TestMigrationCircuitInvalid_OverflowValue(t *testing.T) {
 		CommitmentMiMC:      cm,
 		ValueCommitOutX:     fakeCVX,
 		ValueCommitOutY:     fakeCVY,
-		TokenType:           inp.tokenTypeFr,
+		TypeCommitment:      tc,
 		Value:               overflowValue,
+		TokenType:           inp.tokenTypeFr,
 		TokenTypePed:        inp.tokenTypePed,
 		RandomnessPed:       inp.randomnessPed,
 		RandomnessNew:       inp.randomnessNew,
 		RCV:                 inp.rcv,
+		TypeRandomness:      inp.typeRandomness,
 		MaxBits:             params.DefaultMaxBits,
 		PedG0X:              testPedGens.G0X, PedG0Y: testPedGens.G0Y,
 		PedG1X: testPedGens.G1X, PedG1Y: testPedGens.G1Y,
@@ -444,4 +460,23 @@ func TestMigrationCircuitInvalid_OverflowValue(t *testing.T) {
 	err = migrationCS.IsSolved(witness)
 	require.Error(t, err,
 		"MigrationCircuit must reject values >= 2^MaxBits, overflow attack possible if not")
+}
+
+func TestMigrationCircuitInvalid_WrongTypeRandomness(t *testing.T) {
+	setupMigration(t)
+
+	inp := newRandomMigrationInputs(t)
+	assignment := buildMigrationAssignment(t, inp)
+
+	var wrongTR fr.Element
+	_, err := wrongTR.SetRandom()
+	require.NoError(t, err)
+	assignment.TypeRandomness = wrongTR
+
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
+
+	err = migrationCS.IsSolved(witness)
+	require.Error(t, err,
+		"MigrationCircuit must reject a witness where TypeRandomness doesn't produce the public TypeCommitment")
 }

--- a/x/token/core/zkatsnark/circuit/output.go
+++ b/x/token/core/zkatsnark/circuit/output.go
@@ -16,21 +16,24 @@ import (
 
 // OutputCircuit proves that a newly created output token is well-formed.
 //
-// It enforces three constraint groups:
+// It enforces four constraint groups:
 //  1. CommitmentOut == MiMC(Value, TokenType, Randomness)
 //  2. (ValueCommitOutX, ValueCommitOutY) == Value·V + RCV·R
 //  3. Value ∈ [1, 2^MaxBits)
+//  4. TypeCommitment == MiMC(TokenType, TypeRandomness)
 type OutputCircuit struct {
 	// Public inputs
 	CommitmentOut   frontend.Variable `gnark:"public"`
 	ValueCommitOutX frontend.Variable `gnark:"public"`
 	ValueCommitOutY frontend.Variable `gnark:"public"`
-	TokenType       frontend.Variable `gnark:"public"`
+	TypeCommitment  frontend.Variable `gnark:"public"`
 
 	// Private inputs
-	Value      frontend.Variable
-	Randomness frontend.Variable
-	RCV        frontend.Variable
+	Value          frontend.Variable
+	TokenType      frontend.Variable
+	Randomness     frontend.Variable
+	RCV            frontend.Variable
+	TypeRandomness frontend.Variable
 
 	// Compile-time parameter
 	// MaxBits is the bit-width of the value range constraint.
@@ -76,6 +79,19 @@ func (c *OutputCircuit) Define(api frontend.API) error {
 	// the value to bits, it has to kepp running the comparison checks, bit by bit, which can require extra machinery.
 	_ = api.ToBinary(c.Value, maxBits)
 	api.AssertIsDifferent(c.Value, 0)
+
+	// ── Constraint Group 4: Type Commitment Integrity ───────────────────────
+	// Enforce: TypeCommitment == MiMC(TokenType, TypeRandomness)
+	//
+	// The same TokenType private variable used in Group 1 (note commitment)
+	// appears here, so the ZK proof structurally binds the committed type
+	// to the type encoded in the note commitment. The validator only sees
+	// TypeCommitment (a hiding commitment) — not the plaintext type.
+	tc, err := gadgets.HashCircuit(api, c.TokenType, c.TypeRandomness)
+	if err != nil {
+		return err
+	}
+	api.AssertIsEqual(tc, c.TypeCommitment)
 
 	return nil
 }

--- a/x/token/core/zkatsnark/circuit/output_test.go
+++ b/x/token/core/zkatsnark/circuit/output_test.go
@@ -55,22 +55,25 @@ func setupOutput(t *testing.T) {
 }
 
 type outputInputs struct {
-	value      uint64
-	tokenType  fr.Element
-	randomness fr.Element
-	rcv        fr.Element
+	value          uint64
+	tokenType      fr.Element
+	randomness     fr.Element
+	rcv            fr.Element
+	typeRandomness fr.Element
 }
 
 func newRandomOutputInputs(t *testing.T) outputInputs {
 	t.Helper()
-	var tokenType, randomness, rcv fr.Element
+	var tokenType, randomness, rcv, typeRandomness fr.Element
 	tokenType.SetBytes([]byte("USD"))
 	_, err := randomness.SetRandom()
 	require.NoError(t, err)
 	_, err = rcv.SetRandom()
 	require.NoError(t, err)
+	_, err = typeRandomness.SetRandom()
+	require.NoError(t, err)
 
-	return outputInputs{value: 250, tokenType: tokenType, randomness: randomness, rcv: rcv}
+	return outputInputs{value: 250, tokenType: tokenType, randomness: randomness, rcv: rcv, typeRandomness: typeRandomness}
 }
 
 func buildOutputAssignment(t *testing.T, inp outputInputs) *circuit.OutputCircuit {
@@ -84,14 +87,20 @@ func buildOutputAssignment(t *testing.T, inp outputInputs) *circuit.OutputCircui
 	cv, err := jubjub.ValueCommit(inp.value, inp.rcv)
 	require.NoError(t, err)
 
+	// Compute the type commitment: MiMC(TokenType, TypeRandomness)
+	tc, err := mimc.Hash(inp.tokenType, inp.typeRandomness)
+	require.NoError(t, err)
+
 	return &circuit.OutputCircuit{
 		CommitmentOut:   cm,
 		ValueCommitOutX: cv.X,
 		ValueCommitOutY: cv.Y,
-		TokenType:       inp.tokenType,
+		TypeCommitment:  tc,
 		Value:           vField,
+		TokenType:       inp.tokenType,
 		Randomness:      inp.randomness,
 		RCV:             inp.rcv,
+		TypeRandomness:  inp.typeRandomness,
 		MaxBits:         params.DefaultMaxBits,
 	}
 }
@@ -124,8 +133,11 @@ func TestOutputCircuitInvalid_WrongValue(t *testing.T) {
 	wrongValue.SetUint64(inp.value + 500)
 	assignment.Value = wrongValue
 
-	witness, _ := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-	require.Error(t, outputCS.IsSolved(witness), "must reject wrong Value")
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
+
+	err = outputCS.IsSolved(witness)
+	require.Error(t, err, "must reject wrong Value")
 }
 
 func TestOutputCircuitInvalid_WrongRandomness(t *testing.T) {
@@ -138,8 +150,11 @@ func TestOutputCircuitInvalid_WrongRandomness(t *testing.T) {
 	require.NoError(t, err)
 	assignment.Randomness = wrongR
 
-	witness, _ := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-	require.Error(t, outputCS.IsSolved(witness), "must reject wrong Randomness")
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
+
+	err = outputCS.IsSolved(witness)
+	require.Error(t, err, "must reject wrong Randomness")
 }
 
 func TestOutputCircuitInvalid_WrongValueCommit(t *testing.T) {
@@ -154,8 +169,11 @@ func TestOutputCircuitInvalid_WrongValueCommit(t *testing.T) {
 	assignment.ValueCommitOutX = fakeCV.X
 	assignment.ValueCommitOutY = fakeCV.Y
 
-	witness, _ := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-	require.Error(t, outputCS.IsSolved(witness), "must reject wrong ValueCommit")
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
+
+	err = outputCS.IsSolved(witness)
+	require.Error(t, err, "must reject wrong ValueCommit")
 }
 
 // TestOutputCircuitInvalid_ZeroValue is the critical range test.
@@ -164,11 +182,13 @@ func TestOutputCircuitInvalid_WrongValueCommit(t *testing.T) {
 func TestOutputCircuitInvalid_ZeroValue(t *testing.T) {
 	setupOutput(t)
 
-	var tokenType, randomness, rcv fr.Element
+	var tokenType, randomness, rcv, typeRandomness fr.Element
 	tokenType.SetBytes([]byte("USD"))
 	_, err := randomness.SetRandom()
 	require.NoError(t, err)
 	_, err = rcv.SetRandom()
+	require.NoError(t, err)
+	_, err = typeRandomness.SetRandom()
 	require.NoError(t, err)
 
 	var zeroField fr.Element
@@ -183,14 +203,19 @@ func TestOutputCircuitInvalid_ZeroValue(t *testing.T) {
 	cv, err := jubjub.ValueCommit(0, rcv)
 	require.NoError(t, err)
 
+	tc, err := mimc.Hash(tokenType, typeRandomness)
+	require.NoError(t, err)
+
 	assignment := &circuit.OutputCircuit{
 		CommitmentOut:   cm,
 		ValueCommitOutX: cv.X,
 		ValueCommitOutY: cv.Y,
-		TokenType:       tokenType,
+		TypeCommitment:  tc,
 		Value:           zeroField, // ← the invalid field
+		TokenType:       tokenType,
 		Randomness:      randomness,
 		RCV:             rcv,
+		TypeRandomness:  typeRandomness,
 		MaxBits:         params.DefaultMaxBits,
 	}
 
@@ -216,15 +241,20 @@ func TestOutputCircuitInvalid_OverflowValue(t *testing.T) {
 	b.SetBit(&b, params.DefaultMaxBits, 1) // 2^64
 	overflowValue.SetBigInt(&b)
 
-	var tokenType, randomness, rcv fr.Element
+	var tokenType, randomness, rcv, typeRandomness fr.Element
 	tokenType.SetBytes([]byte("USD"))
 	_, err := randomness.SetRandom()
 	require.NoError(t, err)
 	_, err = rcv.SetRandom()
 	require.NoError(t, err)
+	_, err = typeRandomness.SetRandom()
+	require.NoError(t, err)
 
 	// Compute a consistent commitment so only the range check fires.
 	cm, err := mimc.Hash(overflowValue, tokenType, randomness)
+	require.NoError(t, err)
+
+	tc, err := mimc.Hash(tokenType, typeRandomness)
 	require.NoError(t, err)
 
 	// We cannot call jubjub.ValueCommit with a field element value > uint64 max.
@@ -239,10 +269,12 @@ func TestOutputCircuitInvalid_OverflowValue(t *testing.T) {
 		CommitmentOut:   cm,
 		ValueCommitOutX: fakeCVX,
 		ValueCommitOutY: fakeCVY,
-		TokenType:       tokenType,
+		TypeCommitment:  tc,
 		Value:           overflowValue,
+		TokenType:       tokenType,
 		Randomness:      randomness,
 		RCV:             rcv,
+		TypeRandomness:  typeRandomness,
 		MaxBits:         params.DefaultMaxBits,
 	}
 
@@ -252,4 +284,22 @@ func TestOutputCircuitInvalid_OverflowValue(t *testing.T) {
 	err = outputCS.IsSolved(witness)
 	require.Error(t, err,
 		"OutputCircuit must reject values >= 2^MaxBits — overflow attack possible if not")
+}
+
+func TestOutputCircuitInvalid_WrongTypeRandomness(t *testing.T) {
+	setupOutput(t)
+	inp := newRandomOutputInputs(t)
+	assignment := buildOutputAssignment(t, inp)
+
+	var wrongTR fr.Element
+	_, err := wrongTR.SetRandom()
+	require.NoError(t, err)
+	assignment.TypeRandomness = wrongTR
+
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
+
+	err = outputCS.IsSolved(witness)
+	require.Error(t, err,
+		"OutputCircuit must reject a witness where TypeRandomness doesn't produce the public TypeCommitment")
 }

--- a/x/token/core/zkatsnark/circuit/spend.go
+++ b/x/token/core/zkatsnark/circuit/spend.go
@@ -14,19 +14,22 @@ import (
 )
 
 // SpendCircuit proves that the prover knows a valid opening of a commitment
-// recorded on the ledger, and that the published value commitment is correctly
-// formed from the same value.
+// recorded on the ledger, that the published value commitment is correctly
+// formed from the same value, and that the type commitment is correctly
+// formed from the same token type.
 type SpendCircuit struct {
 	// Public inputs
 	CommitmentIn   frontend.Variable `gnark:",public"`
 	ValueCommitInX frontend.Variable `gnark:",public"`
 	ValueCommitInY frontend.Variable `gnark:",public"`
-	TokenType      frontend.Variable `gnark:",public"`
+	TypeCommitment frontend.Variable `gnark:",public"`
 
 	// Private inputs
-	Value      frontend.Variable
-	Randomness frontend.Variable
-	RCV        frontend.Variable
+	Value          frontend.Variable
+	TokenType      frontend.Variable
+	Randomness     frontend.Variable
+	RCV            frontend.Variable
+	TypeRandomness frontend.Variable
 }
 
 // Define encodes the SpendCircuit constraints into the R1CS.
@@ -58,6 +61,19 @@ func (c *SpendCircuit) Define(api frontend.API) error {
 	}
 	api.AssertIsEqual(cv.X, c.ValueCommitInX)
 	api.AssertIsEqual(cv.Y, c.ValueCommitInY)
+
+	// ── Constraint Group 3: Type Commitment Integrity ───────────────────────
+	// Enforce: TypeCommitment == MiMC(TokenType, TypeRandomness)
+	//
+	// The same TokenType private variable used in Group 1 (note commitment)
+	// appears here, so the ZK proof structurally binds the committed type
+	// to the type encoded in the note commitment. The validator only sees
+	// TypeCommitment (a hiding commitment) — not the plaintext type.
+	tc, err := gadgets.HashCircuit(api, c.TokenType, c.TypeRandomness)
+	if err != nil {
+		return err
+	}
+	api.AssertIsEqual(tc, c.TypeCommitment)
 
 	return nil
 }

--- a/x/token/core/zkatsnark/circuit/spend_test.go
+++ b/x/token/core/zkatsnark/circuit/spend_test.go
@@ -55,26 +55,30 @@ func setupSpend(t *testing.T) {
 }
 
 type spendInputs struct {
-	value      uint64
-	tokenType  fr.Element
-	randomness fr.Element
-	rcv        fr.Element
+	value          uint64
+	tokenType      fr.Element
+	randomness     fr.Element
+	rcv            fr.Element
+	typeRandomness fr.Element
 }
 
 func newRandomSpendInputs(t *testing.T) spendInputs {
 	t.Helper()
-	var tokenType, randomness, rcv fr.Element
+	var tokenType, randomness, rcv, typeRandomness fr.Element
 	tokenType.SetBytes([]byte("USD"))
 	_, err := randomness.SetRandom()
 	require.NoError(t, err)
 	_, err = rcv.SetRandom()
 	require.NoError(t, err)
+	_, err = typeRandomness.SetRandom()
+	require.NoError(t, err)
 
 	return spendInputs{
-		value:      100,
-		tokenType:  tokenType,
-		randomness: randomness,
-		rcv:        rcv,
+		value:          100,
+		tokenType:      tokenType,
+		randomness:     randomness,
+		rcv:            rcv,
+		typeRandomness: typeRandomness,
 	}
 }
 
@@ -94,16 +98,22 @@ func buildSpendAssignment(t *testing.T, inp spendInputs) *circuit.SpendCircuit {
 	cv, err := jubjub.ValueCommit(inp.value, inp.rcv)
 	require.NoError(t, err, "jubjub.ValueCommit failed in buildSpendAssignment")
 
+	// Compute the type commitment: MiMC(TokenType, TypeRandomness)
+	tc, err := mimc.Hash(inp.tokenType, inp.typeRandomness)
+	require.NoError(t, err, "mimc.Hash failed for type commitment in buildSpendAssignment")
+
 	return &circuit.SpendCircuit{
 		// Public inputs — computed from private inputs
 		CommitmentIn:   cm,
 		ValueCommitInX: cv.X,
 		ValueCommitInY: cv.Y,
-		TokenType:      inp.tokenType,
+		TypeCommitment: tc,
 		// Private inputs
-		Value:      vField,
-		Randomness: inp.randomness,
-		RCV:        inp.rcv,
+		Value:          vField,
+		TokenType:      inp.tokenType,
+		Randomness:     inp.randomness,
+		RCV:            inp.rcv,
+		TypeRandomness: inp.typeRandomness,
 	}
 }
 
@@ -223,4 +233,23 @@ func TestSpendCircuitInvalid_WrongRCV(t *testing.T) {
 	err = spendCS.IsSolved(witness)
 	require.Error(t, err,
 		"SpendCircuit must reject a witness where RCV doesn't produce the public value commitment")
+}
+
+func TestSpendCircuitInvalid_WrongTypeRandomness(t *testing.T) {
+	setupSpend(t)
+
+	inp := newRandomSpendInputs(t)
+	assignment := buildSpendAssignment(t, inp)
+
+	var wrongTR fr.Element
+	_, err := wrongTR.SetRandom()
+	require.NoError(t, err)
+	assignment.TypeRandomness = wrongTR
+
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
+
+	err = spendCS.IsSolved(witness)
+	require.Error(t, err,
+		"SpendCircuit must reject a witness where TypeRandomness doesn't produce the public TypeCommitment")
 }

--- a/x/token/core/zkatsnark/prover/binding.go
+++ b/x/token/core/zkatsnark/prover/binding.go
@@ -73,11 +73,15 @@ func writeLengthPrefixed(h hash.Hash, b []byte) {
 // any divergence in sorting, encoding, or field ordering causes every
 // legitimate binding signature to fail verification with no useful
 // diagnostic.
-func ComputeActionHash(actionType string, tokenType string, inputs, outputs []ProofResult) []byte {
+func ComputeActionHash(actionType string, typeCommitment fr.Element, inputs, outputs []ProofResult) []byte {
 	h := sha256.New()
 	h.Write([]byte(domainSeparator))
 	writeLengthPrefixed(h, []byte(actionType))
-	writeLengthPrefixed(h, []byte(tokenType))
+
+	// TypeCommitment is a fixed-length field element (32 bytes), so no
+	// length prefix is needed — there is no concatenation ambiguity.
+	tcBytes := typeCommitment.Bytes()
+	h.Write(tcBytes[:])
 
 	for _, r := range sortedByCommitment(inputs) {
 		cm := r.Commitment.Bytes()
@@ -156,7 +160,7 @@ func ComputeBVK(inputs, outputs []ProofResult, valueBalance uint64) twistededwar
 // For issuance (empty inputs), bsk becomes −Σrcv_out. There is no
 // conservation requirement for issuance, the signature instead attests
 // that the published output value commitments are correctly formed.
-func ComputeBindingSignature(actionType string, tokenType string, inputs, outputs []ProofResult) (jubjub.Signature, error) {
+func ComputeBindingSignature(actionType string, typeCommitment fr.Element, inputs, outputs []ProofResult) (jubjub.Signature, error) {
 	// bsk must be computed modulo the Jubjub subgroup order, NOT the
 	// BLS12-381 scalar field modulus. fr.Element.Add/Sub reduce mod r
 	// (the BLS12-381 scalar field), but the Schnorr signature scheme
@@ -179,7 +183,7 @@ func ComputeBindingSignature(actionType string, tokenType string, inputs, output
 	var bsk fr.Element
 	bsk.SetBigInt(bskBig)
 
-	actionHash := ComputeActionHash(actionType, tokenType, inputs, outputs)
+	actionHash := ComputeActionHash(actionType, typeCommitment, inputs, outputs)
 
 	sig, err := jubjub.Sign(bsk, actionHash, jubjub.R)
 	if err != nil {

--- a/x/token/core/zkatsnark/prover/binding_test.go
+++ b/x/token/core/zkatsnark/prover/binding_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
 	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/prover"
+	snarktoken "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/token"
 )
 
 func mustProofResult(t *testing.T, value uint64) prover.ProofResult {
@@ -32,12 +33,25 @@ func mustProofResult(t *testing.T, value uint64) prover.ProofResult {
 	return prover.ProofResult{Commitment: cm, ValueCommit: cv, RCV: rcv}
 }
 
+func mustTypeCommitment(t *testing.T, tokenType string) fr.Element {
+	t.Helper()
+	var typeRandomness fr.Element
+	_, err := typeRandomness.SetRandom()
+	require.NoError(t, err)
+
+	tc, err := snarktoken.ComputeTypeCommitment(tokenType, typeRandomness)
+	require.NoError(t, err)
+
+	return tc
+}
+
 func TestActionHashDeterminism(t *testing.T) {
 	in := []prover.ProofResult{mustProofResult(t, 100)}
 	out := []prover.ProofResult{mustProofResult(t, 100)}
+	tc := mustTypeCommitment(t, "USD")
 
-	h1 := prover.ComputeActionHash("transfer", "USD", in, out)
-	h2 := prover.ComputeActionHash("transfer", "USD", in, out)
+	h1 := prover.ComputeActionHash("transfer", tc, in, out)
+	h2 := prover.ComputeActionHash("transfer", tc, in, out)
 
 	require.Equal(t, h1, h2)
 }
@@ -45,9 +59,10 @@ func TestActionHashDeterminism(t *testing.T) {
 func TestActionHashOrderIndependence(t *testing.T) {
 	pr1 := mustProofResult(t, 50)
 	pr2 := mustProofResult(t, 100)
+	tc := mustTypeCommitment(t, "USD")
 
-	h1 := prover.ComputeActionHash("transfer", "USD", []prover.ProofResult{pr1, pr2}, nil)
-	h2 := prover.ComputeActionHash("transfer", "USD", []prover.ProofResult{pr2, pr1}, nil)
+	h1 := prover.ComputeActionHash("transfer", tc, []prover.ProofResult{pr1, pr2}, nil)
+	h2 := prover.ComputeActionHash("transfer", tc, []prover.ProofResult{pr2, pr1}, nil)
 
 	require.Equal(t, h1, h2, "hash must be independent of input slice order — this is what makes "+
 		"the hash canonical regardless of goroutine completion order")
@@ -56,17 +71,19 @@ func TestActionHashOrderIndependence(t *testing.T) {
 func TestActionHashSensitivity(t *testing.T) {
 	in := []prover.ProofResult{mustProofResult(t, 100)}
 	out := []prover.ProofResult{mustProofResult(t, 100)}
+	tc := mustTypeCommitment(t, "USD")
 
-	h := prover.ComputeActionHash("transfer", "USD", in, out)
+	h := prover.ComputeActionHash("transfer", tc, in, out)
 
-	withDifferentActionType := prover.ComputeActionHash("issue", "USD", in, out)
+	withDifferentActionType := prover.ComputeActionHash("issue", tc, in, out)
 	require.NotEqual(t, h, withDifferentActionType)
 
-	withDifferentTokenType := prover.ComputeActionHash("transfer", "EUR", in, out)
-	require.NotEqual(t, h, withDifferentTokenType)
+	tcEUR := mustTypeCommitment(t, "EUR")
+	withDifferentTypeCommitment := prover.ComputeActionHash("transfer", tcEUR, in, out)
+	require.NotEqual(t, h, withDifferentTypeCommitment)
 
 	differentOut := []prover.ProofResult{mustProofResult(t, 999)}
-	withDifferentOutputs := prover.ComputeActionHash("transfer", "USD", in, differentOut)
+	withDifferentOutputs := prover.ComputeActionHash("transfer", tc, in, differentOut)
 	require.NotEqual(t, h, withDifferentOutputs)
 }
 
@@ -75,10 +92,11 @@ func TestActionHashSensitivity(t *testing.T) {
 func TestComputeBindingSignatureValid(t *testing.T) {
 	in := []prover.ProofResult{mustProofResult(t, 100), mustProofResult(t, 50)}
 	out := []prover.ProofResult{mustProofResult(t, 120), mustProofResult(t, 30)}
+	tc := mustTypeCommitment(t, "USD")
 
-	h := prover.ComputeActionHash("transfer", "USD", in, out)
+	h := prover.ComputeActionHash("transfer", tc, in, out)
 
-	sig, err := prover.ComputeBindingSignature("transfer", "USD", in, out)
+	sig, err := prover.ComputeBindingSignature("transfer", tc, in, out)
 	require.NoError(t, err)
 
 	bvk := prover.ComputeBVK(in, out, 0)
@@ -96,10 +114,11 @@ func TestComputeBindingSignatureValid(t *testing.T) {
 func TestComputeBindingSignatureRejectsNonConservation(t *testing.T) {
 	in := []prover.ProofResult{mustProofResult(t, 100), mustProofResult(t, 50)}
 	out := []prover.ProofResult{mustProofResult(t, 120), mustProofResult(t, 40)}
+	tc := mustTypeCommitment(t, "USD")
 
-	h := prover.ComputeActionHash("transfer", "USD", in, out)
+	h := prover.ComputeActionHash("transfer", tc, in, out)
 
-	sig, err := prover.ComputeBindingSignature("transfer", "USD", in, out)
+	sig, err := prover.ComputeBindingSignature("transfer", tc, in, out)
 	require.NoError(t, err)
 
 	bvk := prover.ComputeBVK(in, out, 0)
@@ -112,29 +131,32 @@ func TestComputeBindingSignatureRejectsNonConservation(t *testing.T) {
 
 func TestComputeBindingSignatureIssuance(t *testing.T) {
 	out := []prover.ProofResult{mustProofResult(t, 500)}
+	tc := mustTypeCommitment(t, "USD")
 
-	sig, err := prover.ComputeBindingSignature("issue", "USD", nil, out)
+	sig, err := prover.ComputeBindingSignature("issue", tc, nil, out)
 	require.NoError(t, err)
 
 	bvk := prover.ComputeBVK(nil, out, 500)
-	actionHash := prover.ComputeActionHash("issue", "USD", nil, out)
+	actionHash := prover.ComputeActionHash("issue", tc, nil, out)
 
 	err = jubjub.Verify(bvk, actionHash, sig, jubjub.R)
 	require.NoError(t, err, "issuance binding signature (zero inputs) must verify")
 }
 
-func TestComputeBindingSignatureRejectsWrongTokenTypeAtVerification(t *testing.T) {
+func TestComputeBindingSignatureRejectsWrongTypeCommitmentAtVerification(t *testing.T) {
 	in := []prover.ProofResult{mustProofResult(t, 100)}
 	out := []prover.ProofResult{mustProofResult(t, 100)}
+	tcUSD := mustTypeCommitment(t, "USD")
 
-	sig, err := prover.ComputeBindingSignature("transfer", "USD", in, out)
+	sig, err := prover.ComputeBindingSignature("transfer", tcUSD, in, out)
 	require.NoError(t, err)
 
 	bvk := prover.ComputeBVK(in, out, 0)
-	h := prover.ComputeActionHash("transfer", "EUR", in, out)
+	tcEUR := mustTypeCommitment(t, "EUR")
+	h := prover.ComputeActionHash("transfer", tcEUR, in, out)
 
 	err = jubjub.Verify(bvk, h, sig, jubjub.R)
 	require.Error(t, err,
-		"verifying against a hash computed with the wrong token type must fail, "+
-			"this confirms token type really is bound into the signed message")
+		"verifying against a hash computed with a different type commitment must fail, "+
+			"this confirms type commitment really is bound into the signed message")
 }

--- a/x/token/core/zkatsnark/prover/migration.go
+++ b/x/token/core/zkatsnark/prover/migration.go
@@ -46,6 +46,7 @@ type MigrationWitnessResult struct {
 	RCV             fr.Element
 	Commitment      fr.Element
 	ValueCommitment twistededwards.PointAffine
+	TypeCommitment  fr.Element
 	// PedersenCommitX/Y are the extracted affine coordinates of the
 	// original Pedersen commitment, for inclusion in the wire format.
 	PedersenCommitX [48]byte
@@ -58,9 +59,13 @@ type MigrationWitnessResult struct {
 // A fresh Note (with new MiMC randomness) is generated internally and
 // returned alongside the assignment, exactly like BuildOutputWitness does
 // for freshly issued tokens.
+//
+// typeRandomness is the per-action randomness used to compute the type
+// commitment.
 func BuildMigrationWitness(
 	opening snarktoken.PedersenOpening,
 	publicParams *pp.PublicParams,
+	typeRandomness fr.Element,
 ) (*MigrationWitnessResult, error) {
 	if err := opening.Validate(); err != nil {
 		return nil, errors.Wrapf(err, "prover: invalid PedersenOpening")
@@ -119,6 +124,11 @@ func BuildMigrationWitness(
 
 	tField := snarktoken.EncodeTokenType(opening.TokenType)
 
+	tc, err := snarktoken.ComputeTypeCommitment(opening.TokenType, typeRandomness)
+	if err != nil {
+		return nil, errors.Wrapf(err, "prover: migration type commitment failed")
+	}
+
 	assignment := &circuit.MigrationCircuit{
 		// Public inputs — emulated field elements must use ValueOf.
 		CommitmentPedersenX: emulated.ValueOf[emulated.BLS12381Fp](pedXBig),
@@ -126,13 +136,15 @@ func BuildMigrationWitness(
 		CommitmentMiMC:      cm,
 		ValueCommitOutX:     cv.X,
 		ValueCommitOutY:     cv.Y,
-		TokenType:           tField,
+		TypeCommitment:      tc,
 		// Private inputs
-		Value:         vField,
-		TokenTypePed:  tokenTypePed,
-		RandomnessPed: blindingFactor,
-		RandomnessNew: note.Randomness,
-		RCV:           rcv,
+		Value:          vField,
+		TokenType:      tField,
+		TokenTypePed:   tokenTypePed,
+		RandomnessPed:  blindingFactor,
+		RandomnessNew:  note.Randomness,
+		RCV:            rcv,
+		TypeRandomness: typeRandomness,
 		// Compile-time parameters
 		MaxBits: publicParams.MaxBits,
 		PedG0X:  gens.G0X, PedG0Y: gens.G0Y,
@@ -146,6 +158,7 @@ func BuildMigrationWitness(
 		RCV:             rcv,
 		Commitment:      cm,
 		ValueCommitment: cv,
+		TypeCommitment:  tc,
 		PedersenCommitX: pedXBytes,
 		PedersenCommitY: pedYBytes,
 	}, nil

--- a/x/token/core/zkatsnark/prover/orchestrator.go
+++ b/x/token/core/zkatsnark/prover/orchestrator.go
@@ -81,7 +81,10 @@ type migrationOutcome struct {
 // computes the per-action binding signature, and assembles the resulting
 // TransferAction. Returns the newly created output Notes alongside the
 // action, persisting or transmitting them is the caller's responsibility.
-// All inputs and outputs must share tokenType
+// All inputs and outputs must share tokenType.
+//
+// A single typeRandomness is generated per action and shared across all
+// inputs and outputs, ensuring they all produce the same TypeCommitment.
 func (o *Orchestrator) BuildTransferAction(
 	ctx context.Context,
 	inputs []SpendRequest,
@@ -93,15 +96,27 @@ func (o *Orchestrator) BuildTransferAction(
 		return nil, nil, errors.New("orchestrator: transfer action requires at least one input or output")
 	}
 
+	// Generate a single typeRandomness for the entire action.
+	var typeRandomness fr.Element
+	if _, err := typeRandomness.SetRandom(); err != nil {
+		return nil, nil, fmt.Errorf("orchestrator: type randomness generation failed: %w", err)
+	}
+
+	// Compute the shared TypeCommitment once for the action envelope.
+	typeCommitment, err := snarktoken.ComputeTypeCommitment(tokenType, typeRandomness)
+	if err != nil {
+		return nil, nil, fmt.Errorf("orchestrator: type commitment computation failed: %w", err)
+	}
+
 	spendCh := make(chan spendOutcome, len(inputs))
 	outputCh := make(chan outputOutcome, len(outputs))
 
 	for i, req := range inputs {
-		go o.proveSpend(i, req, spendCh)
+		go o.proveSpend(i, req, typeRandomness, spendCh)
 	}
 
 	for j, req := range outputs {
-		go o.proveOutput(j, req, publicParams, outputCh)
+		go o.proveOutput(j, req, publicParams, typeRandomness, outputCh)
 	}
 
 	spendOutcomes := make([]spendOutcome, len(inputs))
@@ -138,7 +153,7 @@ func (o *Orchestrator) BuildTransferAction(
 		newNotes[j] = oc.note
 	}
 
-	sig, err := ComputeBindingSignature(snarktoken.ActionTypeTransfer, tokenType, inputResults, outputResults)
+	sig, err := ComputeBindingSignature(snarktoken.ActionTypeTransfer, typeCommitment, inputResults, outputResults)
 	if err != nil {
 		return nil, nil, fmt.Errorf("orchestrator: binding signature failed: %w", err)
 	}
@@ -147,8 +162,10 @@ func (o *Orchestrator) BuildTransferAction(
 		return nil, nil, fmt.Errorf("orchestrator: binding signature serialization failed: %w", err)
 	}
 
+	tcBytes := typeCommitment.Bytes()
+
 	action := &snarktoken.TransferAction{
-		TokenType:        tokenType,
+		TypeCommitment:   tcBytes[:],
 		Inputs:           inputDescs,
 		Outputs:          outputDescs,
 		BindingSignature: sigBytes,
@@ -171,10 +188,22 @@ func (o *Orchestrator) BuildIssueAction(
 		return nil, nil, errors.New("orchestrator: issue action requires at least one output")
 	}
 
+	// Generate a single typeRandomness for the entire action.
+	var typeRandomness fr.Element
+	if _, err := typeRandomness.SetRandom(); err != nil {
+		return nil, nil, fmt.Errorf("orchestrator: type randomness generation failed: %w", err)
+	}
+
+	// Compute the shared TypeCommitment once for the action envelope.
+	typeCommitment, err := snarktoken.ComputeTypeCommitment(tokenType, typeRandomness)
+	if err != nil {
+		return nil, nil, fmt.Errorf("orchestrator: type commitment computation failed: %w", err)
+	}
+
 	var totalValue uint64
 	outputCh := make(chan outputOutcome, len(outputs))
 	for j, req := range outputs {
-		go o.proveOutput(j, req, publicParams, outputCh)
+		go o.proveOutput(j, req, publicParams, typeRandomness, outputCh)
 		totalValue += req.Value
 	}
 
@@ -196,7 +225,7 @@ func (o *Orchestrator) BuildIssueAction(
 		newNotes[j] = oc.note
 	}
 
-	sig, err := ComputeBindingSignature(snarktoken.ActionTypeIssue, tokenType, nil, outputResults)
+	sig, err := ComputeBindingSignature(snarktoken.ActionTypeIssue, typeCommitment, nil, outputResults)
 	if err != nil {
 		return nil, nil, fmt.Errorf("orchestrator: binding signature failed: %w", err)
 	}
@@ -208,10 +237,12 @@ func (o *Orchestrator) BuildIssueAction(
 	var totalValueField fr.Element
 	totalValueField.SetUint64(totalValue)
 	totalValueBytes := totalValueField.Bytes()
+	tcBytes := typeCommitment.Bytes()
 
 	action := &snarktoken.IssueAction{
 		Issuer:           issuer,
 		TokenType:        tokenType,
+		TypeCommitment:   tcBytes[:],
 		Outputs:          outputDescs,
 		BindingSignature: sigBytes,
 		TotalValue:       totalValueBytes[:],
@@ -265,8 +296,8 @@ func (o *Orchestrator) BuildMigrationAction(
 	return actions, notes, nil
 }
 
-func (o *Orchestrator) proveSpend(index int, req SpendRequest, out chan<- spendOutcome) {
-	witnessRes, err := BuildSpendWitness(req.Note)
+func (o *Orchestrator) proveSpend(index int, req SpendRequest, typeRandomness fr.Element, out chan<- spendOutcome) {
+	witnessRes, err := BuildSpendWitness(req.Note, typeRandomness)
 	if err != nil {
 		out <- spendOutcome{index: index, err: err}
 
@@ -290,8 +321,7 @@ func (o *Orchestrator) proveSpend(index int, req SpendRequest, out chan<- spendO
 	cm := witnessRes.Commitment.Bytes()
 	cx := witnessRes.ValueCommitment.X.Bytes()
 	cy := witnessRes.ValueCommitment.Y.Bytes()
-	tokenTypeField := snarktoken.EncodeTokenType(req.Note.TokenType)
-	tb := tokenTypeField.Bytes()
+	tc := witnessRes.TypeCommitment.Bytes()
 
 	out <- spendOutcome{
 		index: index,
@@ -304,14 +334,14 @@ func (o *Orchestrator) proveSpend(index int, req SpendRequest, out chan<- spendO
 			CommitmentIn:   cm[:],
 			ValueCommitInX: cx[:],
 			ValueCommitInY: cy[:],
-			TokenType:      tb[:],
+			TypeCommitment: tc[:],
 			SpendProof:     proofBytes,
 		},
 	}
 }
 
-func (o *Orchestrator) proveOutput(index int, req OutputRequest, publicParams *pp.PublicParams, out chan<- outputOutcome) {
-	witnessRes, err := BuildOutputWitness(req.Value, req.TokenType, publicParams)
+func (o *Orchestrator) proveOutput(index int, req OutputRequest, publicParams *pp.PublicParams, typeRandomness fr.Element, out chan<- outputOutcome) {
+	witnessRes, err := BuildOutputWitness(req.Value, req.TokenType, publicParams, typeRandomness)
 	if err != nil {
 		out <- outputOutcome{index: index, err: err}
 
@@ -335,8 +365,7 @@ func (o *Orchestrator) proveOutput(index int, req OutputRequest, publicParams *p
 	cm := witnessRes.Commitment.Bytes()
 	cx := witnessRes.ValueCommitment.X.Bytes()
 	cy := witnessRes.ValueCommitment.Y.Bytes()
-	tokenTypeField := snarktoken.EncodeTokenType(req.TokenType)
-	tb := tokenTypeField.Bytes()
+	tc := witnessRes.TypeCommitment.Bytes()
 
 	out <- outputOutcome{
 		index: index,
@@ -349,7 +378,7 @@ func (o *Orchestrator) proveOutput(index int, req OutputRequest, publicParams *p
 			CommitmentOut:   cm[:],
 			ValueCommitOutX: cx[:],
 			ValueCommitOutY: cy[:],
-			TokenType:       tb[:],
+			TypeCommitment:  tc[:],
 			OutputProof:     proofBytes,
 			Recipient:       req.Recipient,
 		},
@@ -358,7 +387,16 @@ func (o *Orchestrator) proveOutput(index int, req OutputRequest, publicParams *p
 }
 
 func (o *Orchestrator) proveMigration(index int, req MigrationRequest, publicParams *pp.PublicParams, out chan<- migrationOutcome) {
-	witnessRes, err := BuildMigrationWitness(req.Opening, publicParams)
+	// Each migration request gets its own typeRandomness since
+	// each produces an independent MigrationAction.
+	var typeRandomness fr.Element
+	if _, err := typeRandomness.SetRandom(); err != nil {
+		out <- migrationOutcome{index: index, err: fmt.Errorf("type randomness generation failed: %w", err)}
+
+		return
+	}
+
+	witnessRes, err := BuildMigrationWitness(req.Opening, publicParams, typeRandomness)
 	if err != nil {
 		out <- migrationOutcome{index: index, err: err}
 
@@ -382,8 +420,7 @@ func (o *Orchestrator) proveMigration(index int, req MigrationRequest, publicPar
 	cm := witnessRes.Commitment.Bytes()
 	cx := witnessRes.ValueCommitment.X.Bytes()
 	cy := witnessRes.ValueCommitment.Y.Bytes()
-	tokenTypeField := snarktoken.EncodeTokenType(req.Opening.TokenType)
-	tb := tokenTypeField.Bytes()
+	tc := witnessRes.TypeCommitment.Bytes()
 
 	out <- migrationOutcome{
 		index: index,
@@ -393,7 +430,7 @@ func (o *Orchestrator) proveMigration(index int, req MigrationRequest, publicPar
 			CommitmentMiMC:      cm[:],
 			ValueCommitOutX:     cx[:],
 			ValueCommitOutY:     cy[:],
-			TokenType:           tb[:],
+			TypeCommitment:      tc[:],
 			MigrationProof:      proofBytes,
 			Recipient:           req.Recipient,
 		},

--- a/x/token/core/zkatsnark/prover/orchestrator_test.go
+++ b/x/token/core/zkatsnark/prover/orchestrator_test.go
@@ -36,13 +36,13 @@ func publicWitnessFromSpendDescription(t *testing.T, desc snarktoken.SpendDescri
 	require.NoError(t, cm.SetBytesCanonical(desc.CommitmentIn), "CommitmentIn")
 	require.NoError(t, cx.SetBytesCanonical(desc.ValueCommitInX), "ValueCommitInX")
 	require.NoError(t, cy.SetBytesCanonical(desc.ValueCommitInY), "ValueCommitInY")
-	require.NoError(t, tt.SetBytesCanonical(desc.TokenType), "TokenType")
+	require.NoError(t, tt.SetBytesCanonical(desc.TypeCommitment), "TypeCommitment")
 
 	assignment := &circuit.SpendCircuit{
 		CommitmentIn:   cm,
 		ValueCommitInX: cx,
 		ValueCommitInY: cy,
-		TokenType:      tt,
+		TypeCommitment: tt,
 		// Private fields left as zero values, PublicOnly() below only
 		// extracts the gnark:",public" fields, so these are never read.
 	}
@@ -61,13 +61,13 @@ func publicWitnessFromOutputDescription(t *testing.T, desc snarktoken.OutputDesc
 	require.NoError(t, cm.SetBytesCanonical(desc.CommitmentOut), "CommitmentOut")
 	require.NoError(t, cx.SetBytesCanonical(desc.ValueCommitOutX), "ValueCommitOutX")
 	require.NoError(t, cy.SetBytesCanonical(desc.ValueCommitOutY), "ValueCommitOutY")
-	require.NoError(t, tt.SetBytesCanonical(desc.TokenType), "TokenType")
+	require.NoError(t, tt.SetBytesCanonical(desc.TypeCommitment), "TypeCommitment")
 
 	assignment := &circuit.OutputCircuit{
 		CommitmentOut:   cm,
 		ValueCommitOutX: cx,
 		ValueCommitOutY: cy,
-		TokenType:       tt,
+		TypeCommitment:  tt,
 		MaxBits:         testPP.MaxBits, // MaxBits is a plain
 		// int, not a frontend.Variable, so frontend.NewWitness never reads
 		// it; it only matters at compile time, already baked into outputVK.
@@ -155,7 +155,10 @@ func TestBuildTransferAction_Valid(t *testing.T) {
 	}
 
 	bvk := prover.ComputeBVK(inResults, outResults, 0)
-	actionHash := prover.ComputeActionHash(snarktoken.ActionTypeTransfer, action.TokenType, inResults, outResults)
+
+	var actionTC fr.Element
+	require.NoError(t, actionTC.SetBytesCanonical(action.TypeCommitment))
+	actionHash := prover.ComputeActionHash(snarktoken.ActionTypeTransfer, actionTC, inResults, outResults)
 
 	sig, err := jubjub.DeserializeSignature(action.BindingSignature)
 	require.NoError(t, err)

--- a/x/token/core/zkatsnark/prover/prover_test.go
+++ b/x/token/core/zkatsnark/prover/prover_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/frontend"
 	"github.com/stretchr/testify/require"
@@ -54,7 +55,10 @@ func TestSpendProver(t *testing.T) {
 	note, err := snarktoken.NewRandomNote(500, "USD")
 	require.NoError(t, err)
 
-	witnessRes, err := prover.BuildSpendWitness(note)
+	var typeRandomness fr.Element
+	_, _ = typeRandomness.SetRandom()
+
+	witnessRes, err := prover.BuildSpendWitness(note, typeRandomness)
 	require.NoError(t, err)
 
 	proof, err := spendProver.Prove(witnessRes.Assignment)
@@ -73,7 +77,10 @@ func TestSpendProver(t *testing.T) {
 func TestOutputProver(t *testing.T) {
 	setupProvers(t)
 
-	witnessRes, err := prover.BuildOutputWitness(750, "EUR", testPP)
+	var typeRandomness fr.Element
+	_, _ = typeRandomness.SetRandom()
+
+	witnessRes, err := prover.BuildOutputWitness(750, "EUR", testPP, typeRandomness)
 	require.NoError(t, err)
 
 	proof, err := outputProver.Prove(witnessRes.Assignment)

--- a/x/token/core/zkatsnark/prover/witness.go
+++ b/x/token/core/zkatsnark/prover/witness.go
@@ -30,6 +30,7 @@ type SpendWitnessResult struct {
 	RCV             fr.Element
 	Commitment      fr.Element
 	ValueCommitment twistededwards.PointAffine
+	TypeCommitment  fr.Element
 }
 
 // BuildSpendWitness constructs a SpendCircuit assignment for spending an
@@ -38,7 +39,11 @@ type SpendWitnessResult struct {
 // note.Randomness must be the EXACT randomness originally used when this
 // token's commitment was recorded on the ledger, the wallet holding this
 // Note must have retained it unchanged since the token was received.
-func BuildSpendWitness(note *snarktoken.Note) (*SpendWitnessResult, error) {
+//
+// typeRandomness is the per-action randomness used to compute the type
+// commitment. All inputs and outputs in the same action must share the
+// same typeRandomness to produce the same TypeCommitment.
+func BuildSpendWitness(note *snarktoken.Note, typeRandomness fr.Element) (*SpendWitnessResult, error) {
 	if note == nil {
 		return nil, errors.New("prover: cannot build spend witness for a nil note")
 	}
@@ -58,6 +63,11 @@ func BuildSpendWitness(note *snarktoken.Note) (*SpendWitnessResult, error) {
 		return nil, fmt.Errorf("prover: value commitment failed: %w", err)
 	}
 
+	tc, err := snarktoken.ComputeTypeCommitment(note.TokenType, typeRandomness)
+	if err != nil {
+		return nil, fmt.Errorf("prover: type commitment failed: %w", err)
+	}
+
 	var vField fr.Element
 	vField.SetUint64(note.Value)
 	tField := snarktoken.EncodeTokenType(note.TokenType)
@@ -66,10 +76,12 @@ func BuildSpendWitness(note *snarktoken.Note) (*SpendWitnessResult, error) {
 		CommitmentIn:   cm,
 		ValueCommitInX: cv.X,
 		ValueCommitInY: cv.Y,
-		TokenType:      tField,
+		TypeCommitment: tc,
 		Value:          vField,
+		TokenType:      tField,
 		Randomness:     note.Randomness,
 		RCV:            rcv,
+		TypeRandomness: typeRandomness,
 	}
 
 	return &SpendWitnessResult{
@@ -77,6 +89,7 @@ func BuildSpendWitness(note *snarktoken.Note) (*SpendWitnessResult, error) {
 		RCV:             rcv,
 		Commitment:      cm,
 		ValueCommitment: cv,
+		TypeCommitment:  tc,
 	}, nil
 }
 
@@ -91,13 +104,18 @@ type OutputWitnessResult struct {
 	RCV             fr.Element
 	Commitment      fr.Element
 	ValueCommitment twistededwards.PointAffine
+	TypeCommitment  fr.Element
 }
 
 // BuildOutputWitness constructs an OutputCircuit assignment for creating a
 // new token of the given value and type. A fresh Note (including fresh
 // commitment randomness) is generated internally and returned to the
 // caller, it does not previously exist anywhere.
-func BuildOutputWitness(value uint64, tokenType string, publicParams *pp.PublicParams) (*OutputWitnessResult, error) {
+//
+// typeRandomness is the per-action randomness used to compute the type
+// commitment. All inputs and outputs in the same action must share the
+// same typeRandomness to produce the same TypeCommitment.
+func BuildOutputWitness(value uint64, tokenType string, publicParams *pp.PublicParams, typeRandomness fr.Element) (*OutputWitnessResult, error) {
 	note, err := snarktoken.NewRandomNote(value, tokenType)
 	if err != nil {
 		return nil, fmt.Errorf("prover: new output note failed: %w", err)
@@ -118,6 +136,11 @@ func BuildOutputWitness(value uint64, tokenType string, publicParams *pp.PublicP
 		return nil, fmt.Errorf("prover: value commitment failed: %w", err)
 	}
 
+	tc, err := snarktoken.ComputeTypeCommitment(tokenType, typeRandomness)
+	if err != nil {
+		return nil, fmt.Errorf("prover: type commitment failed: %w", err)
+	}
+
 	var vField fr.Element
 	vField.SetUint64(value)
 	tField := snarktoken.EncodeTokenType(tokenType)
@@ -126,10 +149,12 @@ func BuildOutputWitness(value uint64, tokenType string, publicParams *pp.PublicP
 		CommitmentOut:   cm,
 		ValueCommitOutX: cv.X,
 		ValueCommitOutY: cv.Y,
-		TokenType:       tField,
+		TypeCommitment:  tc,
 		Value:           vField,
+		TokenType:       tField,
 		Randomness:      note.Randomness,
 		RCV:             rcv,
+		TypeRandomness:  typeRandomness,
 		MaxBits:         publicParams.MaxBits,
 	}
 
@@ -139,5 +164,6 @@ func BuildOutputWitness(value uint64, tokenType string, publicParams *pp.PublicP
 		RCV:             rcv,
 		Commitment:      cm,
 		ValueCommitment: cv,
+		TypeCommitment:  tc,
 	}, nil
 }

--- a/x/token/core/zkatsnark/prover/witness_test.go
+++ b/x/token/core/zkatsnark/prover/witness_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/frontend"
 	"github.com/stretchr/testify/require"
@@ -49,7 +50,10 @@ func TestBuildSpendWitness_Satisfiable(t *testing.T) {
 	note, err := snarktoken.NewRandomNote(500, "USD")
 	require.NoError(t, err)
 
-	witnessRes, err := prover.BuildSpendWitness(note)
+	var typeRandomness fr.Element
+	_, _ = typeRandomness.SetRandom()
+
+	witnessRes, err := prover.BuildSpendWitness(note, typeRandomness)
 	require.NoError(t, err)
 
 	witness, err := frontend.NewWitness(witnessRes.Assignment, ecc.BLS12_381.ScalarField())
@@ -63,7 +67,10 @@ func TestBuildSpendWitness_CommitmentMatchesNote(t *testing.T) {
 	note, err := snarktoken.NewRandomNote(500, "USD")
 	require.NoError(t, err)
 
-	witnessRes, err := prover.BuildSpendWitness(note)
+	var typeRandomness fr.Element
+	_, _ = typeRandomness.SetRandom()
+
+	witnessRes, err := prover.BuildSpendWitness(note, typeRandomness)
 	require.NoError(t, err)
 
 	commitment, err := note.Commitment()
@@ -74,14 +81,20 @@ func TestBuildSpendWitness_CommitmentMatchesNote(t *testing.T) {
 }
 
 func TestBuildSpendWitness_NilNote(t *testing.T) {
-	_, err := prover.BuildSpendWitness(nil)
+	var typeRandomness fr.Element
+	_, _ = typeRandomness.SetRandom()
+
+	_, err := prover.BuildSpendWitness(nil, typeRandomness)
 	require.Error(t, err)
 }
 
 func TestBuildOutputWitness_Satisfiable(t *testing.T) {
 	compileTestCircuits(t)
 
-	witnessRes, err := prover.BuildOutputWitness(500, "USD", pp.DefaultPublicParams())
+	var typeRandomness fr.Element
+	_, _ = typeRandomness.SetRandom()
+
+	witnessRes, err := prover.BuildOutputWitness(500, "USD", pp.DefaultPublicParams(), typeRandomness)
 	require.NoError(t, err)
 
 	witness, err := frontend.NewWitness(witnessRes.Assignment, ecc.BLS12_381.ScalarField())
@@ -94,7 +107,10 @@ func TestBuildOutputWitness_Satisfiable(t *testing.T) {
 func TestBuildOutputWitness_ReturnsSpendableNote(t *testing.T) {
 	compileTestCircuits(t)
 
-	wr, err := prover.BuildOutputWitness(500, "USD", pp.DefaultPublicParams())
+	var typeRandomness fr.Element
+	_, _ = typeRandomness.SetRandom()
+
+	wr, err := prover.BuildOutputWitness(500, "USD", pp.DefaultPublicParams(), typeRandomness)
 	require.NoError(t, err)
 	require.NotNil(t, wr.Note)
 
@@ -109,7 +125,10 @@ func TestBuildOutputWitness_ReturnsSpendableNote(t *testing.T) {
 func TestBuildOutputWitness_ZeroValueRejectedBySolver(t *testing.T) {
 	compileTestCircuits(t)
 
-	wr, err := prover.BuildOutputWitness(0, "USD", testPP)
+	var typeRandomness fr.Element
+	_, _ = typeRandomness.SetRandom()
+
+	wr, err := prover.BuildOutputWitness(0, "USD", testPP, typeRandomness)
 	require.NoError(t, err, "BuildOutputWitness itself does not enforce value > 0")
 
 	witness, err := frontend.NewWitness(wr.Assignment, ecc.BLS12_381.ScalarField())

--- a/x/token/core/zkatsnark/token/issue.go
+++ b/x/token/core/zkatsnark/token/issue.go
@@ -20,7 +20,7 @@ type OutputDescription struct {
 	CommitmentOut   []byte // 32 bytes: MiMC(value, type, randomness)
 	ValueCommitOutX []byte // 32 bytes: Jubjub X coordinate of cv
 	ValueCommitOutY []byte // 32 bytes: Jubjub Y coordinate of cv
-	TokenType       []byte // 32 bytes: canonical field-element encoding of type
+	TypeCommitment  []byte // 32 bytes: MiMC(TokenType, TypeRandomness)
 	OutputProof     []byte // 244 bytes: Groth16 proof for OutputCircuit
 	Recipient       []byte // intended recipient identity
 }
@@ -60,7 +60,8 @@ func (o *OutputDescription) GetOwner() []byte {
 // validator infrastructure can be used.
 type IssueAction struct {
 	Issuer           []byte
-	TokenType        string
+	TokenType        string // kept in cleartext for issuer authorization policy checks
+	TypeCommitment   []byte // 32 bytes: MiMC(TokenType, TypeRandomness), shared across all outputs
 	Outputs          []OutputDescription
 	BindingSignature []byte // 96 bytes: R.X || R.Y || S
 	TotalValue       []byte

--- a/x/token/core/zkatsnark/token/migration.go
+++ b/x/token/core/zkatsnark/token/migration.go
@@ -78,7 +78,7 @@ type MigrationAction struct {
 	// commitment (BLS12-381 Fr embedded Edwards coordinate, 32 bytes).
 	ValueCommitOutY []byte
 
-	TokenType      []byte
+	TypeCommitment []byte // 32 bytes: MiMC(TokenType, TypeRandomness)
 	MigrationProof []byte
 	Recipient      []byte
 }

--- a/x/token/core/zkatsnark/token/note.go
+++ b/x/token/core/zkatsnark/token/note.go
@@ -39,6 +39,22 @@ func EncodeTokenType(tokenType string) fr.Element {
 	return t
 }
 
+// ComputeTypeCommitment computes a hiding commitment to the token type:
+// MiMC(EncodeTokenType(tokenType), typeRandomness). All inputs and outputs
+// in a single action share the same typeRandomness, so they produce the
+// same TypeCommitment, letting the validator confirm type homogeneity
+// without learning the plaintext type.
+func ComputeTypeCommitment(tokenType string, typeRandomness fr.Element) (fr.Element, error) {
+	t := EncodeTokenType(tokenType)
+
+	tc, err := mimc.Hash(t, typeRandomness)
+	if err != nil {
+		return fr.Element{}, fmt.Errorf("note: type commitment computation failed: %w", err)
+	}
+
+	return tc, nil
+}
+
 // Commitment computes cm = MiMC(Value, TokenType, Randomness).
 // This must match Constraint Group 1 in circuit.SpendCircuit.Define and
 // circuit.OutputCircuit.Define exactly, same three inputs, same order.

--- a/x/token/core/zkatsnark/token/transfer.go
+++ b/x/token/core/zkatsnark/token/transfer.go
@@ -15,13 +15,13 @@ import (
 
 // SpendDescription is the public wire-format record for one token being
 // consumed as an input. The commitment being spent, its value commitment,
-// and its type are all public; the value, randomness, and value-commitment
-// randomness that open them are not.
+// and its type commitment are all public; the value, token type, randomness,
+// type randomness, and value-commitment randomness that open them are not.
 type SpendDescription struct {
 	CommitmentIn   []byte // 32 bytes
 	ValueCommitInX []byte // 32 bytes
 	ValueCommitInY []byte // 32 bytes
-	TokenType      []byte // 32 bytes
+	TypeCommitment []byte // 32 bytes: MiMC(TokenType, TypeRandomness)
 	SpendProof     []byte // 244 bytes: Groth16 proof for SpendCircuit
 }
 
@@ -32,7 +32,7 @@ type SpendDescription struct {
 // It implements the driver.TransferAction interface so that the common
 // validator infrastructure can be used.
 type TransferAction struct {
-	TokenType        string
+	TypeCommitment   []byte // 32 bytes: MiMC(TokenType, TypeRandomness), shared across all inputs/outputs
 	Inputs           []SpendDescription
 	Outputs          []OutputDescription
 	BindingSignature []byte // 96 bytes: R.X || R.Y || S

--- a/x/token/core/zkatsnark/validator/binding.go
+++ b/x/token/core/zkatsnark/validator/binding.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package validator
 
 import (
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 
@@ -39,7 +40,8 @@ func toOutputProofResult(d decodedOutput) prover.ProofResult {
 // publicValueDelta convention must match the prover exactly: prover.NoPublicValue
 // for TransferAction, the decoded TotalValue for IssueAction.
 func verifyBindingSignature(
-	actionType, tokenType string,
+	actionType string,
+	typeCommitment fr.Element,
 	decodedInputs []decodedSpend,
 	decodedOutputs []decodedOutput,
 	sigBytes []byte,
@@ -56,7 +58,7 @@ func verifyBindingSignature(
 	}
 
 	bvk := prover.ComputeBVK(spendResults, outputResults, publicValueDelta)
-	actionHash := prover.ComputeActionHash(actionType, tokenType, spendResults, outputResults)
+	actionHash := prover.ComputeActionHash(actionType, typeCommitment, spendResults, outputResults)
 
 	sig, err := jubjub.DeserializeSignature(sigBytes)
 	if err != nil {

--- a/x/token/core/zkatsnark/validator/binding_test.go
+++ b/x/token/core/zkatsnark/validator/binding_test.go
@@ -13,7 +13,20 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
 	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/prover"
+	snarktoken "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/token"
 )
+
+func mustTypeCommitmentV(t *testing.T, tokenType string) fr.Element {
+	t.Helper()
+	var typeRandomness fr.Element
+	_, err := typeRandomness.SetRandom()
+	require.NoError(t, err)
+
+	tc, err := snarktoken.ComputeTypeCommitment(tokenType, typeRandomness)
+	require.NoError(t, err)
+
+	return tc
+}
 
 // TestVerifyBindingSignature_AgreesWithProverSideConstruction is the most
 // important test in this file: it independently proves that a signature
@@ -36,10 +49,12 @@ func TestVerifyBindingSignature_AgreesWithProverSideConstruction(t *testing.T) {
 	_, _ = cm1.SetRandom()
 	_, _ = cm2.SetRandom()
 
+	tc := mustTypeCommitmentV(t, "USD")
+
 	inputs := []prover.ProofResult{{Commitment: cm1, ValueCommit: cv1, RCV: rcv1}}
 	outputs := []prover.ProofResult{{Commitment: cm2, ValueCommit: cv2, RCV: rcv2}}
 
-	sig, err := prover.ComputeBindingSignature("transfer", "USD", inputs, outputs)
+	sig, err := prover.ComputeBindingSignature("transfer", tc, inputs, outputs)
 	require.NoError(t, err)
 	sigBytes, err := jubjub.SerializeSignature(sig)
 	require.NoError(t, err)
@@ -49,13 +64,15 @@ func TestVerifyBindingSignature_AgreesWithProverSideConstruction(t *testing.T) {
 	decodedIn := []decodedSpend{{Commitment: cm1, ValueCommitX: cv1.X, ValueCommitY: cv1.Y}}
 	decodedOut := []decodedOutput{{Commitment: cm2, ValueCommitX: cv2.X, ValueCommitY: cv2.Y}}
 
-	err = verifyBindingSignature("transfer", "USD", decodedIn, decodedOut, sigBytes, 0)
+	err = verifyBindingSignature("transfer", tc, decodedIn, decodedOut, sigBytes, 0)
 	require.NoError(t, err)
 }
 
 func TestVerifyBindingSignature_RejectsCorruptedSignatureBytes(t *testing.T) {
 	corrupted := make([]byte, 96) // all-zero, not a valid signature
-	err := verifyBindingSignature("transfer", "USD", nil, nil, corrupted, 0)
+	tc := mustTypeCommitmentV(t, "USD")
+
+	err := verifyBindingSignature("transfer", tc, nil, nil, corrupted, 0)
 	require.Error(t, err)
 }
 
@@ -68,11 +85,13 @@ func TestVerifyBindingSignature_WrongPublicValueDeltaFailsIssuance(t *testing.T)
 	var cm fr.Element
 	_, _ = cm.SetRandom()
 
+	tc := mustTypeCommitmentV(t, "USD")
+
 	outputs := []prover.ProofResult{{Commitment: cm, ValueCommit: cv, RCV: rcv}}
 	var totalIssued fr.Element
 	totalIssued.SetUint64(500)
 
-	sig, err := prover.ComputeBindingSignature("issue", "USD", nil, outputs)
+	sig, err := prover.ComputeBindingSignature("issue", tc, nil, outputs)
 	require.NoError(t, err)
 	sigBytes, err := jubjub.SerializeSignature(sig)
 	require.NoError(t, err)
@@ -82,6 +101,6 @@ func TestVerifyBindingSignature_WrongPublicValueDeltaFailsIssuance(t *testing.T)
 	// Deliberately verify with 0 instead of the real
 	// totalIssued, this is exactly the "forgot to pass TotalValue" bug
 	// this test exists to catch permanently.
-	err = verifyBindingSignature("issue", "USD", nil, decodedOut, sigBytes, 0)
+	err = verifyBindingSignature("issue", tc, nil, decodedOut, sigBytes, 0)
 	require.Error(t, err, "wrong publicValueDelta must fail, this is the exact bug class already found once in prover/binding_test.go")
 }

--- a/x/token/core/zkatsnark/validator/decode.go
+++ b/x/token/core/zkatsnark/validator/decode.go
@@ -21,18 +21,18 @@ import (
 // witness usage inside proof.go) and ProofResult construction
 // (binding-signature verification)
 type decodedSpend struct {
-	Commitment   fr.Element
-	ValueCommitX fr.Element
-	ValueCommitY fr.Element
-	TokenType    fr.Element
+	Commitment     fr.Element
+	ValueCommitX   fr.Element
+	ValueCommitY   fr.Element
+	TypeCommitment fr.Element
 }
 
 // decodedOutput is the OutputDescription equivalent.
 type decodedOutput struct {
-	Commitment   fr.Element
-	ValueCommitX fr.Element
-	ValueCommitY fr.Element
-	TokenType    fr.Element
+	Commitment     fr.Element
+	ValueCommitX   fr.Element
+	ValueCommitY   fr.Element
+	TypeCommitment fr.Element
 }
 
 // decodedMigration is the canonical decoding of a MigrationAction's public
@@ -50,7 +50,7 @@ type decodedMigration struct {
 	CommitmentMiMC fr.Element
 	ValueCommitX   fr.Element
 	ValueCommitY   fr.Element
-	TokenType      fr.Element
+	TypeCommitment fr.Element
 }
 
 // decodeSpendDescription decodes a SpendDescription's public bytes into
@@ -69,8 +69,8 @@ func decodeSpendDescription(i int, d snarktoken.SpendDescription) (decodedSpend,
 	if err := out.ValueCommitY.SetBytesCanonical(d.ValueCommitInY); err != nil {
 		return decodedSpend{}, errors.Wrapf(err, "validator: input %d ValueCommitInY not canonical", i)
 	}
-	if err := out.TokenType.SetBytesCanonical(d.TokenType); err != nil {
-		return decodedSpend{}, errors.Wrapf(err, "validator: input %d TokenType not canonical", i)
+	if err := out.TypeCommitment.SetBytesCanonical(d.TypeCommitment); err != nil {
+		return decodedSpend{}, errors.Wrapf(err, "validator: input %d TypeCommitment not canonical", i)
 	}
 
 	pt := twistededwards.PointAffine{X: out.ValueCommitX, Y: out.ValueCommitY}
@@ -93,8 +93,8 @@ func decodeOutputDescription(j int, d snarktoken.OutputDescription) (decodedOutp
 	if err := out.ValueCommitY.SetBytesCanonical(d.ValueCommitOutY); err != nil {
 		return decodedOutput{}, errors.Wrapf(err, "validator: output %d ValueCommitOutY not canonical", j)
 	}
-	if err := out.TokenType.SetBytesCanonical(d.TokenType); err != nil {
-		return decodedOutput{}, errors.Wrapf(err, "validator: output %d TokenType not canonical", j)
+	if err := out.TypeCommitment.SetBytesCanonical(d.TypeCommitment); err != nil {
+		return decodedOutput{}, errors.Wrapf(err, "validator: output %d TypeCommitment not canonical", j)
 	}
 
 	pt := twistededwards.PointAffine{X: out.ValueCommitX, Y: out.ValueCommitY}
@@ -173,8 +173,8 @@ func decodeMigrationAction(a *snarktoken.MigrationAction) (decodedMigration, err
 	if err := out.ValueCommitY.SetBytesCanonical(a.ValueCommitOutY); err != nil {
 		return decodedMigration{}, errors.Wrapf(err, "validator: ValueCommitOutY not canonical")
 	}
-	if err := out.TokenType.SetBytesCanonical(a.TokenType); err != nil {
-		return decodedMigration{}, errors.Wrapf(err, "validator: TokenType not canonical")
+	if err := out.TypeCommitment.SetBytesCanonical(a.TypeCommitment); err != nil {
+		return decodedMigration{}, errors.Wrapf(err, "validator: TypeCommitment not canonical")
 	}
 
 	jubjubPt := twistededwards.PointAffine{X: out.ValueCommitX, Y: out.ValueCommitY}

--- a/x/token/core/zkatsnark/validator/decode_test.go
+++ b/x/token/core/zkatsnark/validator/decode_test.go
@@ -44,7 +44,7 @@ func validSpendBytes(t *testing.T) snarktoken.SpendDescription {
 		CommitmentIn:   cmBytes[:],
 		ValueCommitInX: cxBytes[:],
 		ValueCommitInY: cyBytes[:],
-		TokenType:      ttBytes[:],
+		TypeCommitment: ttBytes[:],
 		SpendProof:     make([]byte, 192),
 	}
 }
@@ -143,7 +143,7 @@ func validMigrationBytes(t *testing.T) *snarktoken.MigrationAction {
 		CommitmentMiMC:      cmBytes[:],
 		ValueCommitOutX:     cxBytes[:],
 		ValueCommitOutY:     cyBytes[:],
-		TokenType:           ttBytes[:],
+		TypeCommitment:      ttBytes[:],
 		MigrationProof:      make([]byte, 192),
 	}
 }

--- a/x/token/core/zkatsnark/validator/homogeneity.go
+++ b/x/token/core/zkatsnark/validator/homogeneity.go
@@ -6,33 +6,27 @@ SPDX-License-Identifier: Apache-2.0
 package validator
 
 import (
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
-
-	snarktoken "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/token"
 )
 
-// checkTypeHomogeneitySpend confirms every input's decoded TokenType
-// matches EncodeTokenType(declaredType), the same function token/note.go
-// uses everywhere else, called directly rather than reimplemented, so the
-// encoding this check compares against can never silently drift from what
-// the rest of the system actually produces.
-func checkTypeHomogeneitySpend(declaredType string, decoded []decodedSpend) error {
-	expected := snarktoken.EncodeTokenType(declaredType)
-	for i, d := range decoded {
-		if !d.TokenType.Equal(&expected) {
-			return errors.Wrapf(ErrTypeMismatch, "input %d: token type does not match declared type %q", i, declaredType)
+// checkTypeCommitmentHomogeneity verifies that every input and output in the
+// action shares the same TypeCommitment value. Since the ZK proofs guarantee
+// that each TypeCommitment correctly opens to the actual token type, equal
+// commitments ⟹ equal types. No plaintext type string is needed.
+//
+// actionTC is the TypeCommitment from the action envelope (TransferAction or
+// IssueAction). Each individual input/output TypeCommitment must match it.
+func checkTypeCommitmentHomogeneity(actionTC fr.Element, decodedInputs []decodedSpend, decodedOutputs []decodedOutput) error {
+	for i, d := range decodedInputs {
+		if !d.TypeCommitment.Equal(&actionTC) {
+			return errors.Wrapf(ErrTypeMismatch, "input %d: TypeCommitment does not match action's TypeCommitment", i)
 		}
 	}
 
-	return nil
-}
-
-// checkTypeHomogeneityOutput is the OutputDescription equivalent.
-func checkTypeHomogeneityOutput(declaredType string, decoded []decodedOutput) error {
-	expected := snarktoken.EncodeTokenType(declaredType)
-	for j, d := range decoded {
-		if !d.TokenType.Equal(&expected) {
-			return errors.Wrapf(ErrTypeMismatch, "output %d: token type does not match declared type %q", j, declaredType)
+	for j, d := range decodedOutputs {
+		if !d.TypeCommitment.Equal(&actionTC) {
+			return errors.Wrapf(ErrTypeMismatch, "output %d: TypeCommitment does not match action's TypeCommitment", j)
 		}
 	}
 

--- a/x/token/core/zkatsnark/validator/homogeneity_test.go
+++ b/x/token/core/zkatsnark/validator/homogeneity_test.go
@@ -8,30 +8,50 @@ package validator
 import (
 	"testing"
 
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/stretchr/testify/require"
+
+	snarktoken "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/token"
 )
 
-func TestCheckTypeHomogeneitySpend_Consistent(t *testing.T) {
-	d := validSpendBytes(t)
-	decoded, err := decodeSpendDescription(0, d)
+func TestCheckTypeCommitmentHomogeneity_Consistent(t *testing.T) {
+	// Build a spend description with a valid TypeCommitment.
+	var typeRandomness fr.Element
+	_, err := typeRandomness.SetRandom()
 	require.NoError(t, err)
 
-	err = checkTypeHomogeneitySpend("USD", []decodedSpend{decoded})
+	tc, err := snarktoken.ComputeTypeCommitment("USD", typeRandomness)
+	require.NoError(t, err)
 
+	spend := decodedSpend{TypeCommitment: tc}
+	output := decodedOutput{TypeCommitment: tc}
+
+	err = checkTypeCommitmentHomogeneity(tc, []decodedSpend{spend}, []decodedOutput{output})
 	require.NoError(t, err)
 }
 
-func TestCheckTypeHomogeneitySpend_Mismatch(t *testing.T) {
-	d := validSpendBytes(t)
-	decoded, err := decodeSpendDescription(0, d)
+func TestCheckTypeCommitmentHomogeneity_Mismatch(t *testing.T) {
+	var typeRandomness1, typeRandomness2 fr.Element
+	_, err := typeRandomness1.SetRandom()
+	require.NoError(t, err)
+	_, err = typeRandomness2.SetRandom()
 	require.NoError(t, err)
 
-	err = checkTypeHomogeneitySpend("EUR", []decodedSpend{decoded})
+	tcUSD, err := snarktoken.ComputeTypeCommitment("USD", typeRandomness1)
+	require.NoError(t, err)
+	tcEUR, err := snarktoken.ComputeTypeCommitment("EUR", typeRandomness2)
+	require.NoError(t, err)
 
+	spend := decodedSpend{TypeCommitment: tcEUR}
+
+	err = checkTypeCommitmentHomogeneity(tcUSD, []decodedSpend{spend}, nil)
 	require.ErrorIs(t, err, ErrTypeMismatch)
 }
 
-func TestCheckTypeHomogeneity_EmptySliceIsVacuouslyValid(t *testing.T) {
-	require.NoError(t, checkTypeHomogeneitySpend("USD", nil))
-	require.NoError(t, checkTypeHomogeneityOutput("USD", nil))
+func TestCheckTypeCommitmentHomogeneity_EmptySliceIsVacuouslyValid(t *testing.T) {
+	var tc fr.Element
+	_, err := tc.SetRandom()
+	require.NoError(t, err)
+
+	require.NoError(t, checkTypeCommitmentHomogeneity(tc, nil, nil))
 }

--- a/x/token/core/zkatsnark/validator/proof.go
+++ b/x/token/core/zkatsnark/validator/proof.go
@@ -31,7 +31,7 @@ func publicWitnessForSpend(d decodedSpend) (witness.Witness, error) {
 		CommitmentIn:   d.Commitment,
 		ValueCommitInX: d.ValueCommitX,
 		ValueCommitInY: d.ValueCommitY,
-		TokenType:      d.TokenType,
+		TypeCommitment: d.TypeCommitment,
 	}
 
 	w, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField(), frontend.PublicOnly())
@@ -52,7 +52,7 @@ func publicWitnessForOutput(d decodedOutput) (witness.Witness, error) {
 		CommitmentOut:   d.Commitment,
 		ValueCommitOutX: d.ValueCommitX,
 		ValueCommitOutY: d.ValueCommitY,
-		TokenType:       d.TokenType,
+		TypeCommitment:  d.TypeCommitment,
 	}
 	w, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField(), frontend.PublicOnly())
 	if err != nil {
@@ -83,7 +83,7 @@ func publicWitnessForMigration(d decodedMigration) (witness.Witness, error) {
 		CommitmentMiMC:      d.CommitmentMiMC,
 		ValueCommitOutX:     d.ValueCommitX,
 		ValueCommitOutY:     d.ValueCommitY,
-		TokenType:           d.TokenType,
+		TypeCommitment:      d.TypeCommitment,
 	}
 	w, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField(), frontend.PublicOnly())
 	if err != nil {

--- a/x/token/core/zkatsnark/validator/structural.go
+++ b/x/token/core/zkatsnark/validator/structural.go
@@ -36,8 +36,8 @@ func validateSpendDescriptionShape(i int, d snarktoken.SpendDescription) error {
 	if len(d.ValueCommitInY) != fieldElementLen {
 		return errors.Wrapf(ErrMalformedAction, "input %d: ValueCommitInY must be %d bytes, got %d", i, fieldElementLen, len(d.ValueCommitInY))
 	}
-	if len(d.TokenType) != fieldElementLen {
-		return errors.Wrapf(ErrMalformedAction, "input %d: TokenType must be %d bytes, got %d", i, fieldElementLen, len(d.TokenType))
+	if len(d.TypeCommitment) != fieldElementLen {
+		return errors.Wrapf(ErrMalformedAction, "input %d: TypeCommitment must be %d bytes, got %d", i, fieldElementLen, len(d.TypeCommitment))
 	}
 	if len(d.SpendProof) != groth16ProofLen {
 		return errors.Wrapf(ErrMalformedAction, "input %d: SpendProof must be %d bytes, got %d", i, groth16ProofLen, len(d.SpendProof))
@@ -57,8 +57,8 @@ func validateOutputDescriptionShape(j int, d snarktoken.OutputDescription) error
 	if len(d.ValueCommitOutY) != fieldElementLen {
 		return errors.Wrapf(ErrMalformedAction, "output %d: ValueCommitOutY must be %d bytes, got %d", j, fieldElementLen, len(d.ValueCommitOutY))
 	}
-	if len(d.TokenType) != fieldElementLen {
-		return errors.Wrapf(ErrMalformedAction, "output %d: TokenType must be %d bytes, got %d", j, fieldElementLen, len(d.TokenType))
+	if len(d.TypeCommitment) != fieldElementLen {
+		return errors.Wrapf(ErrMalformedAction, "output %d: TypeCommitment must be %d bytes, got %d", j, fieldElementLen, len(d.TypeCommitment))
 	}
 	if len(d.OutputProof) != groth16ProofLen {
 		return errors.Wrapf(ErrMalformedAction, "output %d: OutputProof must be %d bytes, got %d", j, groth16ProofLen, len(d.OutputProof))
@@ -80,6 +80,9 @@ func validateBindingSignatureShape(sig []byte) error {
 func validateTransferActionShape(a *snarktoken.TransferAction) error {
 	if len(a.Inputs) == 0 && len(a.Outputs) == 0 {
 		return errors.Wrapf(ErrMalformedAction, "transfer action has no inputs and no outputs")
+	}
+	if len(a.TypeCommitment) != fieldElementLen {
+		return errors.Wrapf(ErrMalformedAction, "TypeCommitment must be %d bytes, got %d", fieldElementLen, len(a.TypeCommitment))
 	}
 	for i, d := range a.Inputs {
 		if err := validateSpendDescriptionShape(i, d); err != nil {
@@ -103,6 +106,9 @@ func validateIssueActionShape(a *snarktoken.IssueAction) error {
 	}
 	if len(a.TotalValue) != fieldElementLen {
 		return errors.Wrapf(ErrMalformedAction, "TotalValue must be %d bytes, got %d", fieldElementLen, len(a.TotalValue))
+	}
+	if len(a.TypeCommitment) != fieldElementLen {
+		return errors.Wrapf(ErrMalformedAction, "TypeCommitment must be %d bytes, got %d", fieldElementLen, len(a.TypeCommitment))
 	}
 	for j, d := range a.Outputs {
 		if err := validateOutputDescriptionShape(j, d); err != nil {
@@ -130,8 +136,8 @@ func validateMigrationActionShape(a *snarktoken.MigrationAction) error {
 	if len(a.ValueCommitOutY) != fieldElementLen {
 		return errors.Wrapf(ErrMalformedAction, "ValueCommitOutY must be %d bytes, got %d", fieldElementLen, len(a.ValueCommitOutY))
 	}
-	if len(a.TokenType) != fieldElementLen {
-		return errors.Wrapf(ErrMalformedAction, "TokenType must be %d bytes, got %d", fieldElementLen, len(a.TokenType))
+	if len(a.TypeCommitment) != fieldElementLen {
+		return errors.Wrapf(ErrMalformedAction, "TypeCommitment must be %d bytes, got %d", fieldElementLen, len(a.TypeCommitment))
 	}
 	if len(a.MigrationProof) != migrationProofLen {
 		return errors.Wrapf(ErrMalformedAction, "MigrationProof must be %d bytes, got %d", migrationProofLen, len(a.MigrationProof))

--- a/x/token/core/zkatsnark/validator/structural_test.go
+++ b/x/token/core/zkatsnark/validator/structural_test.go
@@ -18,7 +18,7 @@ func validSpendDescription() snarktoken.SpendDescription {
 		CommitmentIn:   make([]byte, 32),
 		ValueCommitInX: make([]byte, 32),
 		ValueCommitInY: make([]byte, 32),
-		TokenType:      make([]byte, 32),
+		TypeCommitment: make([]byte, 32),
 		SpendProof:     make([]byte, 244),
 	}
 }
@@ -44,7 +44,7 @@ func validOutputDescription() snarktoken.OutputDescription {
 		CommitmentOut:   make([]byte, 32),
 		ValueCommitOutX: make([]byte, 32),
 		ValueCommitOutY: make([]byte, 32),
-		TokenType:       make([]byte, 32),
+		TypeCommitment:  make([]byte, 32),
 		OutputProof:     make([]byte, 244),
 	}
 }
@@ -53,9 +53,9 @@ func TestValidateOutputDescriptionShape_Valid(t *testing.T) {
 	require.NoError(t, validateOutputDescriptionShape(0, validOutputDescription()))
 }
 
-func TestValidateOutputDescriptionShape_WrongTokenTypeLength(t *testing.T) {
+func TestValidateOutputDescriptionShape_WrongTypeCommitmentLength(t *testing.T) {
 	d := validOutputDescription()
-	d.TokenType = make([]byte, 16)
+	d.TypeCommitment = make([]byte, 16)
 	require.ErrorIs(t, validateOutputDescriptionShape(0, d), ErrMalformedAction)
 }
 
@@ -65,13 +65,14 @@ func TestValidateBindingSignatureShape(t *testing.T) {
 }
 
 func TestValidateTransferActionShape_RejectsEmpty(t *testing.T) {
-	a := &snarktoken.TransferAction{TokenType: "USD"}
+	a := &snarktoken.TransferAction{TypeCommitment: make([]byte, 32)}
 	require.ErrorIs(t, validateTransferActionShape(a), ErrMalformedAction)
 }
 
 func TestValidateIssueActionShape_RequiresTotalValue(t *testing.T) {
 	a := &snarktoken.IssueAction{
 		TokenType:        "USD",
+		TypeCommitment:   make([]byte, 32),
 		Outputs:          []snarktoken.OutputDescription{validOutputDescription()},
 		BindingSignature: make([]byte, 96),
 		// TotalValue deliberately omitted
@@ -86,7 +87,7 @@ func validMigrationAction() *snarktoken.MigrationAction {
 		CommitmentMiMC:      make([]byte, 32),
 		ValueCommitOutX:     make([]byte, 32),
 		ValueCommitOutY:     make([]byte, 32),
-		TokenType:           make([]byte, 32),
+		TypeCommitment:      make([]byte, 32),
 		MigrationProof:      make([]byte, 292),
 	}
 }

--- a/x/token/core/zkatsnark/validator/validator.go
+++ b/x/token/core/zkatsnark/validator/validator.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package validator
 
 import (
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 
@@ -98,8 +99,8 @@ func NewValidator(p *pp.PublicParams) (*Validator, error) {
 }
 
 // ValidateTransfer checks the cryptographic validity of a TransferAction.
-// Order: structural shape → decode → type homogeneity → parallel proof
-// verification → binding signature.
+// Order: structural shape → decode → type commitment homogeneity → parallel
+// proof verification → binding signature.
 func (v *Validator) ValidateTransfer(a *snarktoken.TransferAction) error {
 	if err := validateTransferActionShape(a); err != nil {
 		return err
@@ -115,11 +116,12 @@ func (v *Validator) ValidateTransfer(a *snarktoken.TransferAction) error {
 		return err
 	}
 
-	if err := checkTypeHomogeneitySpend(a.TokenType, decodedInputs); err != nil {
+	var actionTC fr.Element
+	if err := actionTC.SetBytesCanonical(a.TypeCommitment); err != nil {
 		return err
 	}
 
-	if err := checkTypeHomogeneityOutput(a.TokenType, decodedOutputs); err != nil {
+	if err := checkTypeCommitmentHomogeneity(actionTC, decodedInputs, decodedOutputs); err != nil {
 		return err
 	}
 
@@ -128,7 +130,7 @@ func (v *Validator) ValidateTransfer(a *snarktoken.TransferAction) error {
 	}
 
 	return verifyBindingSignature(
-		snarktoken.ActionTypeTransfer, a.TokenType,
+		snarktoken.ActionTypeTransfer, actionTC,
 		decodedInputs, decodedOutputs,
 		a.BindingSignature, 0,
 	)
@@ -145,7 +147,12 @@ func (v *Validator) ValidateIssue(a *snarktoken.IssueAction) error {
 		return err
 	}
 
-	if err := checkTypeHomogeneityOutput(a.TokenType, decodedOutputs); err != nil {
+	var actionTC fr.Element
+	if err := actionTC.SetBytesCanonical(a.TypeCommitment); err != nil {
+		return err
+	}
+
+	if err := checkTypeCommitmentHomogeneity(actionTC, nil, decodedOutputs); err != nil {
 		return err
 	}
 
@@ -159,7 +166,7 @@ func (v *Validator) ValidateIssue(a *snarktoken.IssueAction) error {
 	}
 
 	return verifyBindingSignature(
-		snarktoken.ActionTypeIssue, a.TokenType,
+		snarktoken.ActionTypeIssue, actionTC,
 		nil, decodedOutputs,
 		a.BindingSignature, totalValue,
 	)

--- a/x/token/core/zkatsnark/validator/validator_issue.go
+++ b/x/token/core/zkatsnark/validator/validator_issue.go
@@ -27,7 +27,7 @@ func parseTotalValue(raw []byte) (uint64, error) {
 
 // IssueZKValidate is a ValidateIssueFunc callback that performs the full
 // zkatsnark issue verification pipeline: structural shape → decode →
-// type homogeneity → proof verification → binding signature.
+// type commitment homogeneity → proof verification → binding signature.
 //
 // It is invoked by common.Validator when processing issue actions via
 // VerifyTokenRequest / VerifyIssue.
@@ -43,7 +43,13 @@ func (v *Validator) IssueZKValidate(_ context.Context, ctx *Context) error {
 		return err
 	}
 
-	if err := checkTypeHomogeneityOutput(action.TokenType, decodedOutputs); err != nil {
+	// Decode the action-level TypeCommitment.
+	var actionTC fr.Element
+	if err := actionTC.SetBytesCanonical(action.TypeCommitment); err != nil {
+		return err
+	}
+
+	if err := checkTypeCommitmentHomogeneity(actionTC, nil, decodedOutputs); err != nil {
 		return err
 	}
 
@@ -57,7 +63,7 @@ func (v *Validator) IssueZKValidate(_ context.Context, ctx *Context) error {
 	}
 
 	return verifyBindingSignature(
-		snarktoken.ActionTypeIssue, action.TokenType,
+		snarktoken.ActionTypeIssue, actionTC,
 		nil, decodedOutputs,
 		action.BindingSignature, totalValue,
 	)

--- a/x/token/core/zkatsnark/validator/validator_test.go
+++ b/x/token/core/zkatsnark/validator/validator_test.go
@@ -232,9 +232,9 @@ func TestValidateTransfer_RejectsTamperedCommitment(t *testing.T) {
 	require.Error(t, err, "a tampered commitment must be rejected")
 }
 
-// TestValidateTransfer_RejectsWrongTokenType exercises the homogeneity
+// TestValidateTransfer_RejectsWrongTypeCommitment exercises the homogeneity
 // check independently of proof verification.
-func TestValidateTransfer_RejectsWrongTokenType(t *testing.T) {
+func TestValidateTransfer_RejectsWrongTypeCommitment(t *testing.T) {
 	setupEndToEnd(t)
 
 	note, err := snarktoken.NewRandomNote(100, "USD")
@@ -249,10 +249,15 @@ func TestValidateTransfer_RejectsWrongTokenType(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	action.TokenType = "EUR" // declared type now disagrees with every description's actual encoded type
+	var typeRandomness fr.Element
+	_, _ = typeRandomness.SetRandom()
+	tcEUR, _ := snarktoken.ComputeTypeCommitment("EUR", typeRandomness)
+
+	tcBytes := tcEUR.Bytes()
+	action.TypeCommitment = tcBytes[:] // declared type commitment now disagrees with every description's actual encoded type
 
 	err = testVal.ValidateTransfer(action)
-	require.Error(t, err, "a declared type mismatching every description's actual type must be rejected")
+	require.Error(t, err, "a declared type commitment mismatching every description's actual type must be rejected")
 }
 
 // TestValidateTransfer_RejectsCorruptedBindingSignature confirms that
@@ -285,7 +290,7 @@ func TestValidateTransfer_MalformedShape(t *testing.T) {
 	setupEndToEnd(t)
 
 	action := &snarktoken.TransferAction{
-		TokenType: "USD",
+		TypeCommitment: make([]byte, 32),
 		Inputs: []snarktoken.SpendDescription{
 			{CommitmentIn: []byte("too short")},
 		},

--- a/x/token/core/zkatsnark/validator/validator_transfer.go
+++ b/x/token/core/zkatsnark/validator/validator_transfer.go
@@ -8,12 +8,15 @@ package validator
 import (
 	"context"
 
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+
 	snarktoken "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/token"
 )
 
 // TransferZKValidate is a ValidateTransferFunc callback that performs the
 // full zkatsnark transfer verification pipeline: structural shape → decode
-// → type homogeneity → parallel proof verification → binding signature.
+// → type commitment homogeneity → parallel proof verification → binding
+// signature.
 //
 // It is invoked by common.Validator when processing transfer actions via
 // VerifyTokenRequest / VerifyTransfer.
@@ -34,11 +37,13 @@ func (v *Validator) TransferZKValidate(_ context.Context, ctx *Context) error {
 		return err
 	}
 
-	if err := checkTypeHomogeneitySpend(action.TokenType, decodedInputs); err != nil {
+	// Decode the action-level TypeCommitment.
+	var actionTC fr.Element
+	if err := actionTC.SetBytesCanonical(action.TypeCommitment); err != nil {
 		return err
 	}
 
-	if err := checkTypeHomogeneityOutput(action.TokenType, decodedOutputs); err != nil {
+	if err := checkTypeCommitmentHomogeneity(actionTC, decodedInputs, decodedOutputs); err != nil {
 		return err
 	}
 
@@ -47,7 +52,7 @@ func (v *Validator) TransferZKValidate(_ context.Context, ctx *Context) error {
 	}
 
 	return verifyBindingSignature(
-		snarktoken.ActionTypeTransfer, action.TokenType,
+		snarktoken.ActionTypeTransfer, actionTC,
 		decodedInputs, decodedOutputs,
 		action.BindingSignature, 0,
 	)


### PR DESCRIPTION

## Description

This PR replaces the cleartext `TokenType` encoding in the `zkatsnark` wire-formats with a cryptographic commitment (`TypeCommitment`), completing the privacy transition for token types in ZK operations. By decoupling token metadata from the ZK proofs, we ensure that the token types involved in transactions remain hidden while preserving cryptographic homogeneity.

## Key Architectural Changes

1. **Wire-Format Types (`token/`)**:
   - Replaced `TokenType` string fields with `TypeCommitment []byte` across `SpendDescription`, `OutputDescription`, `TransferAction`, and `MigrationAction`. 
   - `IssueAction` retains the cleartext `TokenType` for issuer authorization policy checks, but adds `TypeCommitment` to link against its outputs.

2. **Circuits (`circuit/`)**:
   - Refactored `SpendCircuit`, `OutputCircuit`, and `MigrationCircuit` to transition `TokenType` to a private input.
   - Introduced `TypeCommitment` (public) and `TypeRandomness` (private) as new constraint variables.
   - Added a new constraint group to all circuits enforcing: `TypeCommitment == MiMC(TokenType, TypeRandomness)`.

3. **Prover & Orchestration (`prover/`)**:
   - Updated the `Orchestrator` to generate a single ephemeral `TypeRandomness` per action to ensure type consistency across all inputs and outputs.
   - Modified `ComputeActionHash` (binding) to incorporate `TypeCommitment` instead of plaintext strings, ensuring binding signatures cannot be reused across different token types.
   - Updated Witness Builders to propagate the type randomness constraints correctly.

4. **Validator (`validator/`)**:
   - Swapped out plaintext string comparisons for `checkTypeCommitmentHomogeneity`, which asserts homogeneity by comparing the decoded `fr.Element` commitments.
   - Integrated structural validation for `TypeCommitment` lengths.
   - Migrated two-stage validation: validating the MiMC opening within the proof, and verifying all components share the identical `TypeCommitment`.