### PR TITLE
identity/deserializer: unsynchronized map access in the signer multiplex can crash the process

### DIFF
--- a/token/services/identity/deserializer/deserializer_test.go
+++ b/token/services/identity/deserializer/deserializer_test.go
@@ -9,6 +9,7 @@ package deserializer
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
@@ -879,4 +880,77 @@ func TestTypedIdentityVerifierDeserializer(t *testing.T) {
 		assert.Equal(t, mockMatcher, matcher)
 		assert.Equal(t, 1, mockMatcherDeserializer.GetAuditInfoMatcherCallCount())
 	})
+}
+
+// TestDeserializerMultiplexConcurrency exercises the three deserializer
+// multiplexes under concurrent registration (map writes) and deserialization
+// (map reads). Without the internal mutex this reliably trips the race
+// detector or the runtime's fatal "concurrent map read and map write" check;
+// with it, the test runs clean. Run under `go test -race` for full coverage.
+func TestDeserializerMultiplexConcurrency(t *testing.T) {
+	const (
+		goroutines = 16
+		iterations = 200
+	)
+
+	signerMultiplex := NewTypedSignerDeserializerMultiplex()
+	verifierMultiplex := NewTypedVerifierDeserializerMultiplex()
+	eidrhDeserializer := NewEIDRHDeserializer()
+
+	// Pre-register a deserializer for the type the readers look up so the read
+	// paths traverse the stored slice rather than bailing out on a miss.
+	mockSigner := &drivermock.Signer{}
+	signerDes := &identitydrivermock.TypedSignerDeserializer{}
+	signerDes.DeserializeSignerReturns(mockSigner, nil)
+	signerMultiplex.AddTypedSignerDeserializer(identity.Type(99), signerDes)
+
+	mockVerifier := &drivermock.Verifier{}
+	verifierDes := &identitydrivermock.TypedVerifierDeserializer{}
+	verifierDes.DeserializeVerifierReturns(mockVerifier, nil)
+	verifierDes.RecipientsReturns([]driver.Identity{[]byte("recipient")}, nil)
+	verifierDes.GetAuditInfoMatcherReturns(&drivermock.Matcher{}, nil)
+	verifierDes.GetAuditInfoReturns([]byte("audit-info"), nil)
+	verifierMultiplex.AddTypedVerifierDeserializer(identity.Type(99), verifierDes)
+
+	mockAuditInfo := &identitydrivermock.AuditInfo{}
+	auditDes := &identitydrivermock.AuditInfoDeserializer{}
+	auditDes.DeserializeAuditInfoReturns(mockAuditInfo, nil)
+	eidrhDeserializer.AddDeserializer(identity.Type(99), auditDes)
+
+	typedID := createTypedIdentity(t, identity.Type(99), []byte("raw-identity"))
+	provider := &drivermock.AuditInfoProvider{}
+
+	var wg sync.WaitGroup
+
+	// Writers: keep registering new deserializers concurrently.
+	for range goroutines {
+		wg.Go(func() {
+			for range iterations {
+				// Register under a distinct type so writers keep hammering the
+				// same map concurrently without clobbering the entry the
+				// readers rely on below.
+				signerMultiplex.AddTypedSignerDeserializer(identity.Type(100), &identitydrivermock.TypedSignerDeserializer{})
+				verifierMultiplex.AddTypedVerifierDeserializer(identity.Type(100), &identitydrivermock.TypedVerifierDeserializer{})
+				eidrhDeserializer.AddDeserializer(identity.Type(100), &identitydrivermock.AuditInfoDeserializer{})
+			}
+		})
+	}
+
+	// Readers: keep deserializing concurrently.
+	for range goroutines {
+		wg.Go(func() {
+			ctx := context.Background()
+			for range iterations {
+				_, _ = signerMultiplex.DeserializeSigner(ctx, typedID)
+				_, _ = verifierMultiplex.DeserializeVerifier(ctx, typedID)
+				_, _ = verifierMultiplex.Recipients(typedID)
+				_, _ = verifierMultiplex.GetAuditInfoMatcher(ctx, typedID, []byte("audit-info"))
+				_ = verifierMultiplex.MatchIdentity(ctx, typedID, []byte("audit-info"))
+				_, _ = verifierMultiplex.GetAuditInfo(ctx, typedID, provider)
+				_, _, _ = eidrhDeserializer.GetEIDAndRH(ctx, typedID, []byte("audit-info"))
+			}
+		})
+	}
+
+	wg.Wait()
 }

--- a/token/services/identity/deserializer/eidrh.go
+++ b/token/services/identity/deserializer/eidrh.go
@@ -8,6 +8,7 @@ package deserializer
 
 import (
 	"context"
+	"sync"
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
@@ -17,6 +18,7 @@ import (
 
 // EIDRHDeserializer returns enrollment IDs behind the owners of token
 type EIDRHDeserializer struct {
+	mutex         sync.RWMutex
 	deserializers map[identity.Type]driver2.AuditInfoDeserializer
 }
 
@@ -28,6 +30,8 @@ func NewEIDRHDeserializer() *EIDRHDeserializer {
 }
 
 func (e *EIDRHDeserializer) AddDeserializer(typ identity.Type, d driver2.AuditInfoDeserializer) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
 	e.deserializers[typ] = d
 }
 
@@ -69,7 +73,9 @@ func (e *EIDRHDeserializer) DeserializeAuditInfo(ctx context.Context, id driver.
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal to TypedIdentity")
 	}
+	e.mutex.RLock()
 	d, ok := e.deserializers[si.Type]
+	e.mutex.RUnlock()
 	if !ok {
 		return nil, errors.Errorf("no deserializer found for [%v]", si.Type)
 	}

--- a/token/services/identity/deserializer/signer.go
+++ b/token/services/identity/deserializer/signer.go
@@ -9,6 +9,8 @@ package deserializer
 import (
 	"context"
 	errors2 "errors"
+	"slices"
+	"sync"
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
@@ -20,6 +22,7 @@ import (
 type TypedSignerDeserializer = idriver.TypedSignerDeserializer
 
 type TypedSignerDeserializerMultiplex struct {
+	mutex         sync.RWMutex
 	deserializers map[idriver.IdentityType][]TypedSignerDeserializer
 }
 
@@ -28,6 +31,8 @@ func NewTypedSignerDeserializerMultiplex() *TypedSignerDeserializerMultiplex {
 }
 
 func (v *TypedSignerDeserializerMultiplex) AddTypedSignerDeserializer(typ idriver.IdentityType, d idriver.TypedSignerDeserializer) {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
 	_, ok := v.deserializers[typ]
 	if !ok {
 		v.deserializers[typ] = []TypedSignerDeserializer{d}
@@ -42,8 +47,10 @@ func (v *TypedSignerDeserializerMultiplex) DeserializeSigner(ctx context.Context
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal to TypedIdentity")
 	}
-	dess, ok := v.deserializers[si.Type]
-	if !ok {
+	v.mutex.RLock()
+	dess := slices.Clone(v.deserializers[si.Type])
+	v.mutex.RUnlock()
+	if dess == nil {
 		return nil, errors.Errorf("no deserializer found for [%v]", si.Type)
 	}
 	logger.DebugfContext(ctx, "deserializing [%s] with type [%v]", logging.Base64(id), si.Type)

--- a/token/services/identity/deserializer/verifier.go
+++ b/token/services/identity/deserializer/verifier.go
@@ -9,6 +9,8 @@ package deserializer
 import (
 	"context"
 	errors2 "errors"
+	"slices"
+	"sync"
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
@@ -23,6 +25,7 @@ var logger = logging.MustGetLogger()
 type TypedVerifierDeserializer = idriver.TypedVerifierDeserializer
 
 type TypedVerifierDeserializerMultiplex struct {
+	mutex         sync.RWMutex
 	deserializers map[idriver.IdentityType][]idriver.TypedVerifierDeserializer
 }
 
@@ -31,6 +34,8 @@ func NewTypedVerifierDeserializerMultiplex() *TypedVerifierDeserializerMultiplex
 }
 
 func (v *TypedVerifierDeserializerMultiplex) AddTypedVerifierDeserializer(typ idriver.IdentityType, d TypedVerifierDeserializer) {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
 	_, ok := v.deserializers[typ]
 	if !ok {
 		v.deserializers[typ] = []TypedVerifierDeserializer{d}
@@ -45,8 +50,10 @@ func (v *TypedVerifierDeserializerMultiplex) DeserializeVerifier(ctx context.Con
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal to TypedIdentity")
 	}
-	dess, ok := v.deserializers[si.Type]
-	if !ok {
+	v.mutex.RLock()
+	dess := slices.Clone(v.deserializers[si.Type])
+	v.mutex.RUnlock()
+	if dess == nil {
 		return nil, errors.Errorf("no deserializer found for [%v]", si.Type)
 	}
 	logger.DebugfContext(ctx, "deserializing [%s] with type [%v]", id, si.Type)
@@ -73,8 +80,10 @@ func (v *TypedVerifierDeserializerMultiplex) Recipients(id driver.Identity) ([]d
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal to TypedIdentity")
 	}
-	dess, ok := v.deserializers[si.Type]
-	if !ok {
+	v.mutex.RLock()
+	dess := slices.Clone(v.deserializers[si.Type])
+	v.mutex.RUnlock()
+	if dess == nil {
 		return nil, errors.Errorf("no deserializer found for [%v]", si.Type)
 	}
 
@@ -110,8 +119,10 @@ func (v *TypedVerifierDeserializerMultiplex) GetAuditInfoMatcher(ctx context.Con
 }
 
 func (v *TypedVerifierDeserializerMultiplex) getMatcher(ctx context.Context, idType idriver.IdentityType, id driver.Identity, auditInfo []byte) (driver.Matcher, error) {
-	dess, ok := v.deserializers[idType]
-	if !ok {
+	v.mutex.RLock()
+	dess := slices.Clone(v.deserializers[idType])
+	v.mutex.RUnlock()
+	if dess == nil {
 		return nil, errors.Errorf("no deserializer found for [%v]", idType)
 	}
 
@@ -153,8 +164,10 @@ func (v *TypedVerifierDeserializerMultiplex) GetAuditInfo(ctx context.Context, i
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal to TypedIdentity")
 	}
-	dess, ok := v.deserializers[si.Type]
-	if !ok {
+	v.mutex.RLock()
+	dess := slices.Clone(v.deserializers[si.Type])
+	v.mutex.RUnlock()
+	if dess == nil {
 		return nil, errors.Errorf("no deserializer found for [%v]", si.Type)
 	}
 	var errs []error


### PR DESCRIPTION
Fixes #2079

### Summary

The signer deserializer multiplex keeps its per-type deserializer lists in a plain Go map that is
written under one mutex and read without any lock, so a concurrent registration and lookup can race
and trigger Go's "concurrent map read and map write" fatal error.

### Where

`token/services/identity/deserializer/signer.go:23` declares
`deserializers map[IdentityType][]TypedSignerDeserializer`. Writes happen via
`AddTypedSignerDeserializer` (`signer.go:30-38`), called from `membership/lm.go:818` while holding
`localIdentitiesMutex`. Reads happen unlocked at `signer.go:45`, from
`Provider.getSignerAndCache` (`provider.go:325`). These are two different mutexes, so the lock held
during registration provides no protection for the concurrent read path. Registration can happen at
runtime via `refreshAndGet` (`lm.go:889`), so a live `GetSigner` call can genuinely race a new
registration. `verifier.go:26` has the same shape, and `eidrh.go:26`'s `AddDeserializer` has no
mutex at all.

### Impact

A registration happening concurrently with a lookup on the same multiplex can trigger Go's runtime
map-race detector, which terminates the process — this is a stability concern under concurrent
identity-registration workloads, independent of any race detector build (the runtime check is always
active for maps, not just under `-race`).

### Suggested fix

Guard map access consistently — either take the same mutex used for writes on the read path (a small
read-lock around the lookup), or switch to a concurrency-safe map type if lock contention on the read
path is a concern given how frequently `getSignerAndCache` is called. Apply the same fix to
`verifier.go` and add a mutex to `eidrh.go`'s `AddDeserializer`, since all three share the same
pattern.

### Severity

HIGH — a data-race that can crash the process, though it requires registration and lookup to overlap
in time to manifest.