### PR TITLE
identity/role: GetWalletID swallows storage errors, so a transient DB blip creates a duplicate wallet

### DIFF
--- a/docs/upgradability.md
+++ b/docs/upgradability.md
@@ -352,6 +352,71 @@ For more details on the specific Protobuf messages used by each driver, see:
 
 ---
 
+## SDK API Changes (Go)
+
+Panurus is a `v0.x` module (`github.com/LFDT-Panurus/panurus`), so under
+[SemVer](development/versioning.md) its exported Go API is not yet frozen and may change
+between minor releases. Even so, source-level breaking changes to exported symbols are
+called out here so downstream code that imports the SDK can adapt during an upgrade.
+
+### `role.Registry.GetWalletID` return type (issue #2063)
+
+> [!WARNING]
+> **Breaking change**: `(*Registry).GetWalletID` in
+> `token/services/identity/role` changed its return type from `(string, error)` to the
+> new `WalletIDResolution` struct. Code that calls this method directly on a
+> `*role.Registry` will not compile until it is updated. Nothing inside the SDK breaks
+> (the only in-tree callers are `Registry.Lookup` and the package's own tests; the
+> `wallet.RoleRegistry` interface does not include `GetWalletID`), so this affects only
+> downstream code that holds a concrete `*Registry` and calls `.GetWalletID` itself.
+
+**Why it changed.** The old signature swallowed *every* storage error and returned
+`("", nil)`, which callers read as *"no wallet is bound to this identity yet."* A
+transient storage failure (timeout, connection reset) therefore masqueraded as an
+unregistered identity and fell through the lookup chain to **create a duplicate wallet**
+for an identity that already had one. The `(string, error)` shape was ambiguous by
+design — `("", nil)`, `("", err)` and `("id", nil)` each mean something different and the
+difference was easy to get wrong. `WalletIDResolution` makes the three outcomes explicit
+so the "not found" vs "could not check" distinction is decided once and cannot collapse
+into a silent miss.
+
+Note that any downstream caller was already getting the **buggy** behaviour on the error
+path (`("", nil)` instead of a real error); the new type is what surfaces that error
+honestly.
+
+**Migration.** Replace the `(string, error)` destructuring with an explicit branch on the
+resolution's state. Treat anything that is neither `Bound()` nor `Unbound()` — i.e.
+`Failed()`, or a zero-value resolution — as "binding unknown, do not fall through to
+creation":
+
+```go
+// Before
+wID, err := reg.GetWalletID(ctx, identity)
+if err != nil {
+    return err // NOTE: pre-fix this was unreachable — storage errors were swallowed
+}
+if len(wID) != 0 {
+    use(wID) // a wallet is bound
+}
+
+// After
+res := reg.GetWalletID(ctx, identity)
+switch {
+case res.Bound():
+    use(res.WalletID) // a wallet is bound
+case res.Unbound():
+    // authoritative miss: safe to fall through and, ultimately, create a wallet
+default: // res.Failed(), or a non-authoritative zero value
+    return res.Err // storage failure — must NOT be treated as "no binding"
+}
+```
+
+`WalletIDResolution` exposes `Bound()`, `Unbound()` and `Failed()` predicates; read
+`WalletID` only when `Bound()` is true and `Err` only when `Failed()` is true. See the
+type's Godoc in `token/services/identity/role/registry.go` for the full contract.
+
+---
+
 ## Summary of Upgradability Responsibilities
 
 | Component | Responsibility | Mechanism |
@@ -359,3 +424,4 @@ For more details on the specific Protobuf messages used by each driver, see:
 | **Tokens** | Owner / Issuer | `ttx.Transaction.Upgrade` (Burn & Re-issue) |
 | **Driver** | Admin / SDK | `PostInit` (Automatic Spendability Toggle) |
 | **Schema** | Developer / Admin | Manual SQL `ALTER` or Database Re-sync |
+| **SDK API (Go)** | Downstream Developer | Update call sites per release notes (e.g. `Registry.GetWalletID` → `WalletIDResolution`) |

--- a/token/services/identity/driver/storage.go
+++ b/token/services/identity/driver/storage.go
@@ -83,7 +83,10 @@ type WalletID = string
 //
 //go:generate counterfeiter -o mock/wss.go -fake-name WalletStoreService . WalletStoreService
 type WalletStoreService interface {
-	// GetWalletID fetches a walletID that is bound to the identity passed
+	// GetWalletID fetches a walletID that is bound to the identity passed.
+	// It returns an empty WalletID and no error if the identity has no stored
+	// binding; a non-nil error indicates a genuine storage failure and must not
+	// be interpreted by callers as "no binding".
 	GetWalletID(ctx context.Context, identity token.Identity, roleID int) (WalletID, error)
 	// GetWalletIDs fetches all walletID's that have been stored so far without duplicates
 	GetWalletIDs(ctx context.Context, roleID int) ([]WalletID, error)

--- a/token/services/identity/role/registry.go
+++ b/token/services/identity/role/registry.go
@@ -24,6 +24,87 @@ type WalletFactory interface {
 	NewWallet(ctx context.Context, id idriver.WalletID, role idriver.IdentityRoleType, is IdentitySupport, info idriver.IdentityInfo) (driver.Wallet, error)
 }
 
+// WalletIDStatus classifies the outcome of resolving an identity to the wallet id
+// bound to it. It exists so callers branch on an explicit, named state instead of
+// re-deriving intent from the ambiguous "(string, error)" shape — where ("", nil),
+// ("", err) and ("id", nil) each mean something different and the difference is easy
+// to get wrong (see issue #2063).
+type WalletIDStatus int
+
+const (
+	// WalletIDUnknown is the zero value and never returned by GetWalletID. It is the
+	// guard against a WalletIDResolution constructed without going through GetWalletID
+	// (a mock, or a future constructor that forgets to set Status): because callers act
+	// on a fallthrough only when authoritative() is true — Bound or Unbound — this zero
+	// value is treated as a lookup failure, not as a safe "no binding" that would create
+	// a duplicate wallet.
+	WalletIDUnknown WalletIDStatus = iota
+	// WalletIDBound means storage holds a wallet id for the identity. WalletID is set.
+	WalletIDBound
+	// WalletIDUnbound means storage answered authoritatively that the identity has no
+	// wallet binding. This is a definitive, successful miss: it is safe to fall through
+	// to the next resolution step and, ultimately, to create a wallet.
+	WalletIDUnbound
+	// WalletIDFailed means the storage lookup itself failed (timeout, connection reset,
+	// ...), so whether a binding exists is UNKNOWN. Err carries the cause. Callers MUST
+	// NOT treat this as WalletIDUnbound: doing so lets a transient blip masquerade as an
+	// unregistered identity and triggers the creation of a duplicate wallet.
+	WalletIDFailed
+)
+
+// WalletIDResolution is the explicit result of resolving an identity to its bound
+// wallet id. It is the single shared value every wallet-lookup fallback branches on,
+// so the "not found" vs "could not check" distinction is decided once (in GetWalletID)
+// rather than re-inferred at each call site.
+type WalletIDResolution struct {
+	// Status is the outcome of the lookup. Always inspect it via Bound/Unbound/Failed
+	// before reading the other fields, and branch exhaustively: any status that is
+	// neither Bound nor Unbound (Failed, or the WalletIDUnknown zero value) is not
+	// authoritative and must abort the lookup rather than fall through to creation.
+	Status WalletIDStatus
+	// WalletID is the bound wallet id; meaningful only when Status is WalletIDBound.
+	WalletID idriver.WalletID
+	// Err is the underlying storage failure; set only when Status is WalletIDFailed.
+	Err error
+}
+
+// Bound reports whether the identity has a wallet id bound to it.
+func (r WalletIDResolution) Bound() bool { return r.Status == WalletIDBound }
+
+// Unbound reports whether storage answered authoritatively that the identity has no
+// wallet binding. This is the ONLY non-Bound state that a caller may act on by falling
+// through to the next resolution step and, ultimately, wallet creation. Every other
+// state — Failed, or the zero value produced by a WalletIDResolution built without
+// going through GetWalletID — leaves the binding unknown and must abort the lookup.
+func (r WalletIDResolution) Unbound() bool { return r.Status == WalletIDUnbound }
+
+// Failed reports whether the storage lookup failed, leaving the binding unknown.
+// A failed resolution must abort the enclosing lookup, never fall through to creation.
+func (r WalletIDResolution) Failed() bool { return r.Status == WalletIDFailed }
+
+// authoritative reports whether the resolution definitively answers whether a wallet is
+// bound — i.e. it came back from GetWalletID as Bound or Unbound. Any other status
+// (Failed, or the zero-value WalletIDUnknown of a resolution built outside GetWalletID)
+// is non-authoritative: the binding is unknown and the caller MUST abort rather than
+// fall through to wallet creation. This is the guard the WalletIDUnknown zero value was
+// introduced to provide.
+func (r WalletIDResolution) authoritative() bool { return r.Bound() || r.Unbound() }
+
+// abortError returns the error a non-authoritative resolution must abort a wallet lookup
+// with. It preserves the storage cause for a WalletIDFailed and synthesizes one for a
+// zero-value / unknown resolution (whose Err is nil), so an unknown status can never
+// collapse into a nil error — via errors.WithMessagef(nil, ...) returning nil — and be
+// silently mistaken for a successful lookup. It must only be called once Bound and
+// Unbound have been ruled out (i.e. authoritative() is false).
+func (r WalletIDResolution) abortError(id driver.WalletLookupID) error {
+	cause := r.Err
+	if cause == nil {
+		cause = errors.Errorf("non-authoritative wallet id resolution status [%d]", r.Status)
+	}
+
+	return errors.WithMessagef(cause, "failed to lookup wallet [%s]", id)
+}
+
 // Registry manages wallets whose long-term identities have a given role.
 //
 // Concurrency and invariants:
@@ -108,11 +189,17 @@ func (r *Registry) Lookup(ctx context.Context, id driver.WalletLookupID) (driver
 		if ok {
 			r.Logger.DebugfContext(ctx, "lookup failed, check if there is a wallet for identity [%s]", passedIdentity)
 			// is this identity registered
-			wID, err := r.GetWalletID(ctx, passedIdentity)
-			if err == nil && len(wID) != 0 {
-				r.Logger.DebugfContext(ctx, "lookup failed, there is a wallet for identity [%s]: [%s]", passedIdentity, wID)
+			res := r.GetWalletID(ctx, passedIdentity)
+			if !res.authoritative() {
+				// A storage failure — or a resolution that never went through GetWalletID —
+				// leaves the binding unknown; it must not be treated as "not registered", or
+				// a transient blip would fall through to wallet creation and duplicate state.
+				return nil, nil, "", res.abortError(id)
+			}
+			if res.Bound() {
+				r.Logger.DebugfContext(ctx, "lookup failed, there is a wallet for identity [%s]: [%s]", passedIdentity, res.WalletID)
 				// we got a hit
-				walletID = wID
+				walletID = res.WalletID
 				ident = passedIdentity
 				fail = false
 			}
@@ -137,36 +224,53 @@ func (r *Registry) Lookup(ctx context.Context, id driver.WalletLookupID) (driver
 	if ok {
 		r.Logger.DebugfContext(ctx, "no wallet found, check if there is a wallet for identity [%s]", passedIdentity)
 		// is this identity registered
-		passedWalletID, err := r.GetWalletID(ctx, passedIdentity)
-		if err == nil && len(passedWalletID) != 0 {
-			r.Logger.DebugfContext(ctx, "no wallet found, there is a wallet for identity [%s]: [%s]", passedIdentity, passedWalletID)
+		res := r.GetWalletID(ctx, passedIdentity)
+		if res.Failed() {
+			// This probe is only an optimization: MapToIdentity already succeeded (or the
+			// fallback above recovered a binding), so wID is an authoritative candidate and
+			// is already in walletIdentifiers. A failed lookup here therefore costs at most
+			// a reuse opportunity, not correctness — log and continue with the mapped
+			// candidate rather than aborting the whole lookup on a transient blip. Failing
+			// closed belongs only at the branch above, where MapToIdentity failed and this
+			// probe is the sole signal for whether a wallet already exists (issue #2063).
+			r.Logger.Warnf("failed to check wallet binding for identity [%s], continuing with mapped wallet [%s]: %v", passedIdentity, wID, res.Err)
+		} else if res.Bound() {
+			r.Logger.DebugfContext(ctx, "no wallet found, there is a wallet for identity [%s]: [%s]", passedIdentity, res.WalletID)
 			// we got a hit
 			r.WalletMu.RLock()
-			walletEntry, ok = r.Wallets[passedWalletID]
+			walletEntry, ok = r.Wallets[res.WalletID]
 			r.WalletMu.RUnlock()
 			if ok {
-				return walletEntry, nil, passedWalletID, nil
+				return walletEntry, nil, res.WalletID, nil
 			}
-			r.Logger.DebugfContext(ctx, "no wallet found, there is a wallet for identity [%s]: [%s] but it has not been recreated yet", passedIdentity, passedWalletID)
+			r.Logger.DebugfContext(ctx, "no wallet found, there is a wallet for identity [%s]: [%s] but it has not been recreated yet", passedIdentity, res.WalletID)
+			// Only a Bound resolution carries a wallet id; an Unbound one has WalletID == ""
+			// and must not be appended (the consuming loop skips empties anyway).
+			walletIdentifiers = append(walletIdentifiers, res.WalletID)
 		}
-		walletIdentifiers = append(walletIdentifiers, passedWalletID)
 	}
 
 	r.Logger.DebugfContext(ctx, "no wallet found for [%s] at [%s]", passedIdentity, logging.Prefix(wID))
 	if len(ident) != 0 {
-		identityWID, err := r.GetWalletID(ctx, ident)
-		r.Logger.DebugfContext(ctx, "wallet for identity [%s] -> [%s:%s]", ident, identityWID, err)
-		if err == nil && len(identityWID) != 0 {
+		res := r.GetWalletID(ctx, ident)
+		r.Logger.DebugfContext(ctx, "wallet for identity [%s] -> [%s:%d]", ident, res.WalletID, res.Status)
+		if res.Failed() {
+			// Optimization probe only (see the probe above): ident came from an
+			// authoritative MapToIdentity, and its wallet id is already a candidate, so a
+			// failed lookup here is not decisive. Log and continue rather than aborting the
+			// lookup on a transient blip (issue #2063).
+			r.Logger.Warnf("failed to check wallet binding for identity [%s], continuing with mapped wallet [%s]: %v", ident, wID, res.Err)
+		} else if res.Bound() {
 			r.WalletMu.RLock()
-			w, ok := r.Wallets[identityWID]
+			w, ok := r.Wallets[res.WalletID]
 			r.WalletMu.RUnlock()
 			if ok {
-				r.Logger.DebugfContext(ctx, "found wallet [%s:%s:%s:%s]", ident, walletID, w.ID(), identityWID)
+				r.Logger.DebugfContext(ctx, "found wallet [%s:%s:%s:%s]", ident, walletID, w.ID(), res.WalletID)
 
-				return w, nil, identityWID, nil
+				return w, nil, res.WalletID, nil
 			}
+			walletIdentifiers = append(walletIdentifiers, res.WalletID)
 		}
-		walletIdentifiers = append(walletIdentifiers, identityWID)
 	}
 
 	for _, walletIdentifier := range walletIdentifiers {
@@ -259,16 +363,31 @@ func (r *Registry) GetIdentityMetadata(ctx context.Context, identity driver.Iden
 	return json.Unmarshal(raw, &meta)
 }
 
-// GetWalletID returns the wallet identifier bound to the passed identity
-func (r *Registry) GetWalletID(ctx context.Context, identity driver.Identity) (string, error) {
+// GetWalletID resolves the wallet identifier bound to the passed identity.
+//
+// It is the single point that translates the storage layer's (WalletID, error)
+// convention into an explicit WalletIDResolution, so no caller has to re-derive the
+// meaning of ("", nil) vs ("", err). The storage contract reports an unbound identity
+// as ("", nil); a non-nil error is a genuine storage failure (timeout, connection
+// reset, ...) whose result is therefore WalletIDFailed, never WalletIDUnbound. Keeping
+// the two apart here is what prevents a transient blip from looking like an
+// unregistered identity and triggering the creation of a duplicate wallet (issue #2063).
+func (r *Registry) GetWalletID(ctx context.Context, identity driver.Identity) WalletIDResolution {
 	wID, err := r.Storage.GetWalletID(ctx, identity, int(r.Role.ID()))
 	if err != nil {
-		//nolint:nilerr
-		return "", nil
+		return WalletIDResolution{
+			Status: WalletIDFailed,
+			Err:    errors.Wrapf(err, "failed to get wallet id for identity [%s]", identity),
+		}
+	}
+	if len(wID) == 0 {
+		r.Logger.DebugfContext(ctx, "no wallet bound to identity [%s]", identity)
+
+		return WalletIDResolution{Status: WalletIDUnbound}
 	}
 	r.Logger.DebugfContext(ctx, "wallet [%s] is bound to identity [%s]", wID, identity)
 
-	return wID, nil
+	return WalletIDResolution{Status: WalletIDBound, WalletID: wID}
 }
 
 // WalletByID returns the wallet bound to the passed lookup id, creating and registering it

--- a/token/services/identity/role/registry_test.go
+++ b/token/services/identity/role/registry_test.go
@@ -135,17 +135,153 @@ func TestBindIdentityAndContainsAndMetadataAndGetWalletID(t *testing.T) {
 	require.NoError(t, reg.GetIdentityMetadata(ctx, []byte("id"), "w", &meta))
 	require.Equal(t, "v", meta["k"])
 
-	// GetWalletID when storage returns value
+	// GetWalletID when storage returns a bound wallet id.
 	storage.GetWalletIDReturns("w", nil)
-	wid, err := reg.GetWalletID(ctx, []byte("id"))
-	require.NoError(t, err)
-	require.Equal(t, "w", wid)
+	res := reg.GetWalletID(ctx, []byte("id"))
+	require.Equal(t, role.WalletIDBound, res.Status)
+	require.True(t, res.Bound())
+	require.NoError(t, res.Err)
+	require.Equal(t, "w", res.WalletID)
 
-	// GetWalletID when storage returns error -> suppressed to empty string
+	// GetWalletID when storage authoritatively reports no binding -> WalletIDUnbound,
+	// a clean miss with no error and no wallet id.
+	storage.GetWalletIDReturns("", nil)
+	resUnbound := reg.GetWalletID(ctx, []byte("id"))
+	require.Equal(t, role.WalletIDUnbound, resUnbound.Status)
+	require.False(t, resUnbound.Bound())
+	require.True(t, resUnbound.Unbound())
+	require.False(t, resUnbound.Failed())
+	require.NoError(t, resUnbound.Err)
+	require.Empty(t, resUnbound.WalletID)
+
+	// GetWalletID when storage fails -> WalletIDFailed with the error preserved, so a
+	// transient storage blip cannot masquerade as "no binding".
 	storage.GetWalletIDReturns("", errors.New("boom"))
-	wid2, err2 := reg.GetWalletID(ctx, []byte("id"))
-	require.NoError(t, err2)
-	require.Empty(t, wid2)
+	resFailed := reg.GetWalletID(ctx, []byte("id"))
+	require.Equal(t, role.WalletIDFailed, resFailed.Status)
+	require.True(t, resFailed.Failed())
+	require.False(t, resFailed.Bound())
+	require.False(t, resFailed.Unbound())
+	require.Error(t, resFailed.Err)
+	require.Empty(t, resFailed.WalletID)
+}
+
+// TestWalletIDResolution_ZeroValueIsNotAuthoritative guards the WalletIDUnknown zero
+// value: a WalletIDResolution built without going through GetWalletID (a mock, or a
+// future constructor that forgets to set Status) must be indistinguishable from a
+// failure at every call site, never from an authoritative "unbound" miss. Callers act
+// on a fallthrough only when a resolution is Bound or Unbound, so the zero value —
+// being neither — is treated as a lookup failure rather than a safe "create a wallet".
+func TestWalletIDResolution_ZeroValueIsNotAuthoritative(t *testing.T) {
+	var zero role.WalletIDResolution
+
+	require.Equal(t, role.WalletIDUnknown, zero.Status)
+	require.False(t, zero.Bound(), "zero value must not read as a bound wallet id")
+	require.False(t, zero.Unbound(), "zero value must not read as an authoritative miss")
+	require.False(t, zero.Failed(), "zero value carries no storage error")
+	require.NoError(t, zero.Err)
+	require.Empty(t, zero.WalletID)
+}
+
+// TestLookup_StorageErrorDoesNotFallThrough pins the fix for #2063: when
+// MapToIdentity fails, the identity->wallet storage probe is the sole signal for
+// whether a wallet already exists, so a transient storage error there must abort
+// Lookup rather than be swallowed as "no binding". Otherwise the fallback chain
+// would fall through to wallet creation and persist a duplicate wallet for an
+// identity that already has one.
+func TestLookup_StorageErrorDoesNotFallThrough(t *testing.T) {
+	// Lookup never reaches the wallet factory (only WalletByID does, at
+	// registry.go:412), so NewWalletCallCount() would be 0 here even with the old
+	// swallow-and-fall-through bug restored — it cannot guard the regression. The
+	// real check is that the transient storage error aborts Lookup: a non-nil error
+	// and an otherwise empty result, rather than a resolved wallet id that would let
+	// the caller fall through to creation. WalletByID coverage of the
+	// no-duplicate-wallet guarantee lives in
+	// TestWalletByID_StorageErrorDoesNotCreateDuplicate.
+	reg, storage, role, _ := newRegistryWithFakes()
+	ctx := t.Context()
+
+	role.MapToIdentityReturns(nil, "", errors.New("no mapping"))
+	storage.GetWalletIDReturns("", errors.New("transient DB blip"))
+
+	wallet, idInfo, wID, err := reg.Lookup(ctx, []byte("id-with-binding"))
+	require.Error(t, err)
+	require.Nil(t, wallet)
+	require.Nil(t, idInfo)
+	require.Empty(t, wID)
+}
+
+// TestLookup_MappedWalletIDSurvivesProbeFailure is the complement of the #2063
+// guard: once MapToIdentity has *succeeded*, its wallet id is an authoritative
+// candidate and the later identity->wallet probes are only a cache-reuse
+// optimization. A transient storage error at those probes must NOT abort Lookup —
+// it must fall through to the mapped wallet id, so a storage blip never denies a
+// caller the wallet the role already resolved.
+func TestLookup_MappedWalletIDSurvivesProbeFailure(t *testing.T) {
+	reg, storage, role, _ := newRegistryWithFakes()
+	ctx := t.Context()
+
+	// mapping resolves to a wallet id that is not in the cache, so Lookup falls
+	// through to the identity->wallet storage probes, which fail transiently.
+	role.MapToIdentityReturns([]byte("id-with-binding"), "w-not-cached", nil)
+	storage.GetWalletIDReturns("", errors.New("transient DB blip"))
+	// the mapped wallet id still resolves to identity info, so Lookup returns it
+	// rather than aborting on the probe failure.
+	role.GetIdentityInfoReturns(&mockIdentityInfo{id: "w-not-cached"}, nil)
+
+	wallet, idInfo, wID, err := reg.Lookup(ctx, []byte("id-with-binding"))
+	require.NoError(t, err)
+	require.Nil(t, wallet)
+	require.NotNil(t, idInfo)
+	require.Equal(t, "w-not-cached", wID)
+}
+
+// TestWalletByID_StorageErrorDoesNotCreateDuplicate ensures that when MapToIdentity
+// fails and the identity->wallet storage probe (the sole remaining signal for an
+// existing binding) fails transiently, WalletByID surfaces the error instead of
+// creating a brand-new wallet (the duplicate-wallet bug of #2063).
+func TestWalletByID_StorageErrorDoesNotCreateDuplicate(t *testing.T) {
+	reg, storage, role, wf := newRegistryWithFakes()
+	ctx := t.Context()
+
+	role.MapToIdentityReturns(nil, "", errors.New("no mapping"))
+	storage.GetWalletIDReturns("", errors.New("transient DB blip"))
+
+	w, err := reg.WalletByID(ctx, 0, []byte("id-with-binding"))
+	require.Error(t, err)
+	require.Nil(t, w)
+	require.Equal(t, 0, wf.NewWalletCallCount())
+}
+
+// TestWalletByID_CreatesWalletForMappedIDWhenProbeFails is the complement of the
+// #2063 guard on the WalletByID path: when MapToIdentity has *succeeded*, the later
+// identity->wallet probes are only a cache-reuse optimization, so a transient
+// storage error there must not abort. WalletByID must fall through and create the
+// wallet under the *authoritative mapped id* — not a duplicate, and not nothing.
+func TestWalletByID_CreatesWalletForMappedIDWhenProbeFails(t *testing.T) {
+	reg, storage, role, wf := newRegistryWithFakes()
+	ctx := t.Context()
+
+	// The role resolves the identity to a wallet id that is not yet cached, so
+	// WalletByID falls through to the identity->wallet storage probes, which fail
+	// transiently. Since the mapped id is authoritative, the failure is logged and
+	// the wallet is created for that mapped id.
+	role.MapToIdentityReturns([]byte("id-with-binding"), "w-not-cached", nil)
+	storage.GetWalletIDReturns("", errors.New("transient DB blip"))
+	role.GetIdentityInfoReturns(&mockIdentityInfo{id: "w-not-cached"}, nil)
+	created := &mock2.Wallet{}
+	created.IDReturns("w-not-cached")
+	wf.NewWalletReturns(created, nil)
+
+	w, err := reg.WalletByID(ctx, 0, []byte("id-with-binding"))
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	require.Equal(t, "w-not-cached", w.ID())
+	// exactly one wallet created, and for the mapped id — not a duplicate under a
+	// phantom id.
+	require.Equal(t, 1, wf.NewWalletCallCount())
+	_, gotID, _, _, _ := wf.NewWalletArgsForCall(0)
+	require.Equal(t, "w-not-cached", gotID)
 }
 
 func TestWalletIDs_MergesRoleAndStorage(t *testing.T) {

--- a/token/services/storage/db/kvs/walletdb.go
+++ b/token/services/storage/db/kvs/walletdb.go
@@ -9,6 +9,7 @@ package kvs
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/LFDT-Panurus/panurus/token"
 	driver2 "github.com/LFDT-Panurus/panurus/token/driver"
@@ -85,12 +86,40 @@ func (s *WalletStore) GetWalletID(ctx context.Context, identity driver2.Identity
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create key")
 	}
+	// The WalletStoreService contract requires that "no binding" be reported as ("", nil)
+	// so callers can tell it apart from a transient storage error (see issue #2063). We must
+	// NOT probe with kvs.Exists first: FSC implements Exists as len(GetExisting(...)) > 0, and
+	// GetExisting drops the underlying store error and returns an empty result, so a genuine
+	// failure (timeout, connection reset, ...) would masquerade as "not found" and let a
+	// transient blip create a duplicate wallet — the exact #2063 failure mode.
+	//
+	// kvs.Get is the only method on the KVS surface that propagates the store error, but it
+	// reports a missing key as an error too. Until FSC exposes a proper absence sentinel (an
+	// error-returning Exists/GetIfExists or kvs.ErrNotFound), we call Get and classify only the
+	// "not found" case as an authoritative miss, propagating every other error.
+	// TODO(#2063): replace isNotFoundErr message-matching with the FSC sentinel once it lands.
 	var wID storage.WalletID
 	if err := s.kvs.Get(ctx, k, &wID); err != nil {
-		return "", err
+		if isNotFoundErr(err) {
+			return "", nil
+		}
+
+		return "", errors.Wrapf(err, "failed to get wallet id for identity [%v]", idHash)
 	}
 
 	return wID, nil
+}
+
+// isNotFoundErr reports whether err is a KVS "key not found" error, as opposed to a real
+// store failure. FSC has no absence sentinel yet, so both the memory/sql KVS
+// (errors.Errorf("state [%s,%s] does not exist", ...)) and the hashicorp vault KVS
+// (errors.Errorf("state of id [%s] does not exist", ...)) signal absence only through their
+// error message. Matching the shared "does not exist" substring is deliberately conservative:
+// a store failure surfaces as a "failed retrieving state ..." wrap and is therefore
+// propagated, never mistaken for a miss. This is fragile by nature — see the TODO in
+// GetWalletID and issue #2063 — and must be replaced once FSC exposes a typed sentinel.
+func isNotFoundErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "does not exist")
 }
 
 func (s *WalletStore) GetWalletIDs(ctx context.Context, roleID int) ([]storage.WalletID, error) {

--- a/token/services/storage/db/kvs/walletdb_test.go
+++ b/token/services/storage/db/kvs/walletdb_test.go
@@ -7,9 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package kvs
 
 import (
+	"context"
 	"testing"
 
 	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,6 +49,67 @@ func TestWalletStoreGetConfID(t *testing.T) {
 
 	// a different identity never bound in this TMS still misses cleanly
 	got, err = db.GetConfID(ctx, []byte("frank"))
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestWalletStoreGetWalletID asserts the not-found contract that the role Registry relies on to
+// tell a transient storage error apart from "this identity has no binding": an unbound identity
+// must resolve to ("", nil), and a bound identity must round-trip its wallet id. If GetWalletID
+// returned an error for a missing key (as kvs.Get does), the registry would abort every lookup
+// for a genuinely-unregistered identity instead of creating its wallet.
+func TestWalletStoreGetWalletID(t *testing.T) {
+	backend, err := NewInMemory()
+	require.NoError(t, err)
+	// NewInMemory shares a global in-memory backing store across the package's tests, so use a
+	// tmsID and identities unique to this test to stay isolated from any other stored bindings.
+	tmsID := token.TMSID{Network: "getwalletid", Channel: "getwalletid", Namespace: "getwalletid"}
+	db := NewWalletStore(backend, tmsID)
+	ctx := t.Context()
+
+	// miss: never bound -> ("", nil), NOT an error
+	got, err := db.GetWalletID(ctx, []byte("gwid-grace"), 0)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	// bound under role 0 -> round-trips the wallet id
+	require.NoError(t, db.StoreIdentity(ctx, []byte("gwid-grace"), "eID", "grace_wallet", 0, nil, "conf-1"))
+	got, err = db.GetWalletID(ctx, []byte("gwid-grace"), 0)
+	require.NoError(t, err)
+	assert.Equal(t, "grace_wallet", got)
+
+	// the same identity under a different role is still an independent miss
+	got, err = db.GetWalletID(ctx, []byte("gwid-grace"), 1)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// failingKVS is a KVS whose Get always returns getErr. It lets a test drive GetWalletID's
+// error classification directly, without depending on the real backend's internals.
+type failingKVS struct {
+	KVS
+	getErr error
+}
+
+func (k *failingKVS) Get(context.Context, string, any) error { return k.getErr }
+
+// TestWalletStoreGetWalletIDStoreFailurePropagates is the regression guard for #2063: a genuine
+// storage failure must NOT collapse into the ("", nil) "no binding" answer, or the role Registry
+// would treat a transient DB blip as an unregistered identity and create a duplicate wallet. Only
+// a "does not exist" error is an authoritative miss; every other error must propagate.
+func TestWalletStoreGetWalletIDStoreFailurePropagates(t *testing.T) {
+	tmsID := token.TMSID{Network: "fail", Channel: "fail", Namespace: "fail"}
+	ctx := context.Background()
+
+	// A real store failure (timeout, connection reset, ...) must surface as an error.
+	failing := &failingKVS{getErr: errors.Errorf("failed retrieving state [ns,id]: connection reset")}
+	got, err := NewWalletStore(failing, tmsID).GetWalletID(ctx, []byte("erin"), 0)
+	require.Error(t, err)
+	assert.Empty(t, got)
+
+	// A "not found" error is an authoritative miss: ("", nil).
+	notFound := &failingKVS{getErr: errors.Errorf("state [ns,id] does not exist")}
+	got, err = NewWalletStore(notFound, tmsID).GetWalletID(ctx, []byte("erin"), 0)
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }

--- a/token/services/storage/db/sql/common/wallet_test_utils.go
+++ b/token/services/storage/db/sql/common/wallet_test_utils.go
@@ -37,6 +37,28 @@ func TestGetWalletID(t *testing.T, store walletStoreConstructor) {
 	gomega.Expect(actualWalletID).To(gomega.Equal(output))
 }
 
+// TestGetWalletIDNotFound pins the not-found contract of the WalletStoreService: an identity with
+// no stored binding resolves to ("", nil), never an error. The role Registry relies on this to tell
+// a transient storage failure apart from "this identity was never registered" (issue #2063).
+func TestGetWalletIDNotFound(t *testing.T, store walletStoreConstructor) {
+	gomega.RegisterTestingT(t)
+	db, mockDB, err := sqlmock.New()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	tokenID := token.Identity([]byte("1234"))
+	roleID := 5
+	mockDB.
+		ExpectQuery("SELECT wallet_id FROM WALLETS WHERE \\(identity_hash = \\$1\\) AND \\(role_id = \\$2\\)").
+		WithArgs(tokenID.UniqueID(), roleID).
+		WillReturnError(sql.ErrNoRows)
+
+	actualWalletID, err := store(db).GetWalletID(t.Context(), tokenID, roleID)
+
+	gomega.Expect(mockDB.ExpectationsWereMet()).To(gomega.Succeed())
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Expect(actualWalletID).To(gomega.BeEmpty())
+}
+
 func TestGetWalletIDs(t *testing.T, store walletStoreConstructor) {
 	gomega.RegisterTestingT(t)
 	db, mockDB, err := sqlmock.New()

--- a/token/services/storage/db/sql/postgres/wallet_test.go
+++ b/token/services/storage/db/sql/postgres/wallet_test.go
@@ -24,6 +24,10 @@ func TestGetWalletID(t *testing.T) {
 	common2.TestGetWalletID(t, mockWalletStore)
 }
 
+func TestGetWalletIDNotFound(t *testing.T) {
+	common2.TestGetWalletIDNotFound(t, mockWalletStore)
+}
+
 func TestGetWalletIDs(t *testing.T) {
 	common2.TestGetWalletIDs(t, mockWalletStore)
 }

--- a/token/services/storage/db/sql/sqlite/wallet_test.go
+++ b/token/services/storage/db/sql/sqlite/wallet_test.go
@@ -24,6 +24,10 @@ func TestGetWalletID(t *testing.T) {
 	common2.TestGetWalletID(t, mockWalletStore)
 }
 
+func TestGetWalletIDNotFound(t *testing.T) {
+	common2.TestGetWalletIDNotFound(t, mockWalletStore)
+}
+
 func TestGetWalletIDs(t *testing.T) {
 	common2.TestGetWalletIDs(t, mockWalletStore)
 }


### PR DESCRIPTION
Fixes #2063

### Summary

`Registry.GetWalletID` swallows every storage error and returns `("", nil)`, which its callers treat
identically to "no wallet is bound to this identity." A transient storage error (DB blip, timeout)
therefore looks exactly like "not registered yet," and the wallet-lookup fallback chain in `Lookup`
creates a brand-new wallet and a second identity binding for an identity that already has one.

### Where

`token/services/identity/role/registry.go:237-246`:

```go
func (r *Registry) GetWalletID(ctx context.Context, identity driver.Identity) (string, error) {
	wID, err := r.Storage.GetWalletID(ctx, identity, int(r.Role.ID()))
	if err != nil {
		//nolint:nilerr
		return "", nil
	}
	...
	return wID, nil
}
```

All three call sites treat `err == nil && len(wID) == 0` as "not found, try the next fallback":
`registry.go:85-92`, `registry.go:114-117`, `registry.go:131-133`.

### Impact

`Lookup` (`registry.go:72-166`) is the fallback path used by `WalletByID` (`registry.go:271-281`)
whenever the in-memory cache misses. If the storage-level `GetWalletID` call fails transiently (not
"no row found," but an actual error — timeout, connection reset, etc.), the registry cannot
distinguish that from "this identity has never been registered." It falls through to
`WalletFactory.NewWallet` (`registry.go:293`), creating a second wallet and a second identity→wallet
binding for the same identity. This duplicates wallet state and, depending on the wallet
implementation, can duplicate key material bookkeeping.

### Reproduction

Not yet committed. Mock `idriver.WalletStoreService.GetWalletID` to return a non-nil error (e.g. a
simulated transient DB error) on the first call for an identity that has a real binding, and a
successful lookup on a second, independent call. Assert `Registry.GetWalletID` propagates the error
rather than returning `("", nil)`, and that `WalletByID` does not create a duplicate wallet when the
underlying storage error is transient.

### Suggested fix

Propagate the error and let callers decide:

```go
func (r *Registry) GetWalletID(ctx context.Context, identity driver.Identity) (string, error) {
	wID, err := r.Storage.GetWalletID(ctx, identity, int(r.Role.ID()))
	if err != nil {
		return "", errors.Wrapf(err, "failed to get wallet id for identity [%s]", identity)
	}
	...
	return wID, nil
}
```

This requires updating the three call sites in `Lookup` to distinguish "storage error" (abort/retry)
from "no row found" (continue to the next fallback) — today they're merged into one case. This
should land together with #8 (`WalletByID` write-lock scope), since both touch the same
creation path and fixing one without the other leaves the duplicate-wallet risk only partially
addressed.

### Severity

MEDIUM — requires a transient storage failure to trigger, but results in persisted duplicate wallet
state, which is hard to reconcile after the fact.