### PR TITLE
network-driver: QuerySpentTokens/deleteTokens: unvalidated response length drives an unguarded index and panics

### DIFF
--- a/token/services/network/fabric/tokenfetcher.go
+++ b/token/services/network/fabric/tokenfetcher.go
@@ -127,6 +127,9 @@ func (f *spentTokenFetcher) QuerySpentTokens(ctx context.Context, namespace stri
 	if err := json.Unmarshal(payloadBoxed, &spent); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal esponse")
 	}
+	if len(spent) != len(IDs) {
+		return nil, errors.Errorf("unexpected number of spent flags: got [%d], expected [%d]", len(spent), len(IDs))
+	}
 
 	return spent, nil
 }

--- a/token/services/network/fabricx/qe/qe.go
+++ b/token/services/network/fabricx/qe/qe.go
@@ -158,9 +158,16 @@ func (e *Executor) QuerySpentTokens(_ context.Context, namespace driver.Namespac
 	}
 
 	// This operation depends on the driver.
-	// Let's assume for now that the driver is non-graph hiding
+	// Let's assume for now that the driver is non-graph hiding.
+	//
+	// The returned slice is positionally aligned with ids: spentFlags[i]
+	// corresponds to ids[i], so its length always equals len(ids). Callers
+	// (e.g. tokens.Service.deleteTokens, htlc.OwnerWallet.deleteTokens) index
+	// the result by token position, so a shorter slice would panic. A nil id
+	// carries no ledger key and is reported as not spent.
 	keys := make([]driver.PKey, 0, len(ids))
-	for _, id := range ids {
+	keyIndex := make([]int, 0, len(ids))
+	for i, id := range ids {
 		if id == nil {
 			continue
 		}
@@ -169,9 +176,12 @@ func (e *Executor) QuerySpentTokens(_ context.Context, namespace driver.Namespac
 			return nil, errors.Wrapf(err, "error creating output id key [%s:%d]", id.TxId, id.Index)
 		}
 		keys = append(keys, outputID)
+		keyIndex = append(keyIndex, i)
 	}
+
+	spentFlags := make([]bool, len(ids))
 	if len(keys) == 0 {
-		return nil, nil
+		return spentFlags, nil
 	}
 
 	qs, err := e.qsProvider.Get(e.network, e.channel)
@@ -187,10 +197,9 @@ func (e *Executor) QuerySpentTokens(_ context.Context, namespace driver.Namespac
 
 	// map[driver.Namespace]map[driver.PKey]driver.VaultValue
 	ns := res[namespace]
-	spentFlags := make([]bool, len(keys))
-	for i, key := range keys {
+	for j, key := range keys {
 		value := ns[key]
-		spentFlags[i] = len(value.Raw) == 0
+		spentFlags[keyIndex[j]] = len(value.Raw) == 0
 	}
 
 	return spentFlags, nil

--- a/token/services/network/fabricx/qe/qe_test.go
+++ b/token/services/network/fabricx/qe/qe_test.go
@@ -338,6 +338,112 @@ func TestQuerySpentTokens_EmptyIDs(t *testing.T) {
 	e := newExecutor(qsp)
 	res, err := e.QuerySpentTokens(t.Context(), testNamespace, nil, nil)
 	require.NoError(t, err)
+	// Empty input returns nil without querying the provider. Contrast with
+	// TestQuerySpentTokens_AllNilIDs, which passes a non-empty slice of nil
+	// pointers and does exercise the query path.
 	require.Nil(t, res)
 	assert.Equal(t, 0, qsp.GetCallCount())
+}
+
+// TestQuerySpentTokens_NilIDPreservesAlignment is a regression guard: a nil id
+// must not shift the remaining flags or shorten the result. The returned slice
+// stays positionally aligned with ids (length == len(ids)); the nil position is
+// reported as not spent, and only the non-nil ids are looked up on the ledger.
+func TestQuerySpentTokens_NilIDPreservesAlignment(t *testing.T) {
+	ids := []*token.ID{nil, {TxId: "tx1", Index: 0}, {TxId: "tx2", Index: 1}}
+	k1 := outputKey(t, "tx1", 0)
+	k2 := outputKey(t, "tx2", 1)
+
+	qsp := &mock.QueryServiceProvider{}
+	qs := &mock.QueryService{}
+	qsp.GetReturns(qs, nil)
+	// tx1 is present (unspent) -> false; tx2 is missing (spent) -> true.
+	qs.GetStatesReturns(map[driver.Namespace]map[driver.PKey]driver.VaultValue{
+		testNamespace: {k1: {Raw: []byte("token1")}},
+	}, nil)
+
+	e := newExecutor(qsp)
+	res, err := e.QuerySpentTokens(t.Context(), testNamespace, ids, nil)
+	require.NoError(t, err)
+	// index 0 (nil) -> false, index 1 (tx1 present) -> false, index 2 (tx2 missing) -> true.
+	require.Equal(t, []bool{false, false, true}, res)
+
+	// Only the non-nil ids are queried on the ledger; the nil id is not.
+	queried := qs.GetStatesArgsForCall(0)
+	require.Equal(t, map[driver.Namespace][]driver.PKey{testNamespace: {k1, k2}}, queried)
+}
+
+// TestQuerySpentTokens_AllNilIDs is a regression guard: before the fix, an
+// all-nil ids slice returned (nil, nil) — length 0 — which made the callers'
+// spent[i] loop panic with index-out-of-range. It must now return a slice of
+// len(ids) with every position reported as not spent, without touching the
+// query service.
+func TestQuerySpentTokens_AllNilIDs(t *testing.T) {
+	ids := []*token.ID{nil, nil}
+
+	qsp := &mock.QueryServiceProvider{}
+
+	e := newExecutor(qsp)
+	res, err := e.QuerySpentTokens(t.Context(), testNamespace, ids, nil)
+	require.NoError(t, err)
+	require.Equal(t, []bool{false, false}, res)
+	assert.Equal(t, 0, qsp.GetCallCount())
+}
+
+// TestQuerySpentTokens_InteriorNilPreservesAlignment guards the index mapping
+// for a nil that sits between two non-nil ids (not just a leading nil): the
+// flag for each non-nil id must land at that id's original position, and the
+// nil slot stays not spent.
+func TestQuerySpentTokens_InteriorNilPreservesAlignment(t *testing.T) {
+	ids := []*token.ID{{TxId: "tx1", Index: 0}, nil, {TxId: "tx2", Index: 1}}
+	k1 := outputKey(t, "tx1", 0)
+	k2 := outputKey(t, "tx2", 1)
+
+	qsp := &mock.QueryServiceProvider{}
+	qs := &mock.QueryService{}
+	qsp.GetReturns(qs, nil)
+	// tx1 missing (spent) -> true; tx2 present (unspent) -> false.
+	qs.GetStatesReturns(map[driver.Namespace]map[driver.PKey]driver.VaultValue{
+		testNamespace: {k2: {Raw: []byte("token2")}},
+	}, nil)
+
+	e := newExecutor(qsp)
+	res, err := e.QuerySpentTokens(t.Context(), testNamespace, ids, nil)
+	require.NoError(t, err)
+	// index 0 (tx1 missing) -> true, index 1 (nil) -> false, index 2 (tx2 present) -> false.
+	require.Equal(t, []bool{true, false, false}, res)
+
+	// The nil id is not queried; only tx1 and tx2 are.
+	queried := qs.GetStatesArgsForCall(0)
+	require.Equal(t, map[driver.Namespace][]driver.PKey{testNamespace: {k1, k2}}, queried)
+}
+
+func TestQuerySpentTokens_ProviderError(t *testing.T) {
+	ids := []*token.ID{{TxId: "tx1", Index: 0}}
+
+	qsp := &mock.QueryServiceProvider{}
+	qsp.GetReturns(nil, errors.New("boom"))
+
+	e := newExecutor(qsp)
+	res, err := e.QuerySpentTokens(t.Context(), testNamespace, ids, nil)
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "failed getting qs")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestQuerySpentTokens_GetStatesError(t *testing.T) {
+	ids := []*token.ID{{TxId: "tx1", Index: 0}}
+
+	qsp := &mock.QueryServiceProvider{}
+	qs := &mock.QueryService{}
+	qsp.GetReturns(qs, nil)
+	qs.GetStatesReturns(nil, errors.New("rpc failed"))
+
+	e := newExecutor(qsp)
+	res, err := e.QuerySpentTokens(t.Context(), testNamespace, ids, nil)
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "failed getting states")
+	assert.Contains(t, err.Error(), "rpc failed")
 }


### PR DESCRIPTION
Fixes #2059

### Summary

`spentTokenFetcher.QuerySpentTokens` unmarshals the chaincode's `areTokensSpent` response directly into `[]bool` with no check that its length matches the number of ids requested. Its sole caller, `Service.deleteTokens`, then indexes the result positionally against its own input slice with no bounds check — an unguarded index driven entirely by an unvalidated response length from the network layer.

### Where

`token/services/network/fabric/tokenfetcher.go:94-132` (client):

```go
query := stdChannelChaincode.Query(AreTokensSpent, idsRaw)
payloadBoxed, err := query.Call()
...
var spent []bool
if err := json.Unmarshal(payloadBoxed, &spent); err != nil { ... }
return spent, nil   // tokenfetcher.go:126-131 — no length check against len(IDs)
```

`token/services/tokens/tokens.go:314-349` (consumer):

```go
spent, err := network.AreTokensSpent(ctx, tms.Namespace(), ids, meta)
...
for i, tok := range tokens {
    if spent[i] {   // tokens.go:337 — panics if len(spent) < len(tokens)
        toDelete = append(toDelete, &tok.Id)
    }
}
```

On the chaincode side, `Translator.AreTokensSpent` (`token/services/network/common/rws/translator/translator.go:170`) does build its result as `make([]bool, len(ids))` against the *ids it received* — so this is exploitable only if something between the client's request and the chaincode's response can desynchronize the two ids lists (e.g. a future refactor, an alternate driver/backend implementing the same interface less carefully, or a compromised/buggy peer returning a manipulated response), but nothing in the current code path structurally prevents that mismatch from reaching `deleteTokens` and panicking.

### Impact

Any response shorter than the caller's `tokens` slice (whether from a bug in an alternate chaincode/driver implementation, a malformed/truncated response, or a future change that decouples request/response ordering) panics `deleteTokens` on the very next token-vault cleanup pass — a client-side crash driven entirely by data returned from the network layer, with no defensive check at the trust boundary between "what the chaincode returned" and "what we assumed it returned."

### Reproduction

Reproduced locally with a unit test (not yet committed) exercising the full, real production call path — `Service.PruneInvalidUnspentTokens` → `Service.deleteTokens` → `*network.Network.AreTokensSpent` — with only the `driver.Network` boundary faked:

```go
fakeDriverNetwork := &tokensmock.FakeNetwork{}
fakeDriverNetwork.AreTokensSpentReturns([]bool{true}, nil)   // 1 bool for 2 requested tokens
net := network.NewNetwork(fakeDriverNetwork, nil)
...
svc := tokens.NewService(tmsID, tmsProvider, networkProvider, storage, nil)

require.Panics(t, func() {
    _, _ = svc.PruneInvalidUnspentTokens(context.Background())
}, "expected an index-out-of-range panic in deleteTokens when spent[] is shorter than the token batch")
```

A contrast test with a correctly-sized `spent` slice proves the panic is specifically caused by the length mismatch. Happy to include both in the fix PR.

### Suggested fix

Validate `len(spent) == len(IDs)` in `QuerySpentTokens` before returning (returning an error on mismatch instead of the raw unmarshaled slice), and/or add a defensive bounds check in `deleteTokens` before indexing `spent[i]`.

### Severity

HIGH