### PR TITLE
fix(auditor): attribute empty-EID inputs to their own token owner

### DIFF
--- a/docs/services/auditor.md
+++ b/docs/services/auditor.md
@@ -52,6 +52,23 @@ Auditors use specialized wallets (Auditor Wallets) managed by the **Identity Ser
 
 The service provides the `AuditApproveView`, which auditors use to respond to incoming audit requests. This view automates the verification and signing process, ensuring that the auditor only approves transactions that are fully compliant with the system's public parameters.
 
+## Input Attribution
+
+An audit record pairs every input and output with an enrollment ID. Inputs do not always carry one, so those left empty are resolved before the record is stored; the rest are untouched.
+
+Each such input is resolved from its own spent token:
+
+1. The spent token is read from the vault, yielding its owner, type, and quantity.
+2. The owner is resolved to an enrollment ID and revocation handle through `WalletManager.GetEIDAndRH`, using the audit info attached to the input: the locally stored audit info of the spent token's owner where present, the one carried by the request metadata otherwise — a counterparty's audit info is not necessarily present locally. An owner the identity layer cannot decode counts as resolving to nothing; any other resolution failure — a storage error, a canceled context — fails the audit.
+
+Across the built-in drivers, a **token upgrade** is the action whose metadata describes no sender for its inputs, and whose pre-upgrade owner often resolves to nothing: that identity predates the current driver and the request carries no audit info for it. Since an upgrade re-issues the spent tokens to the same party under a fresh identity, such an input takes the enrollment ID of the outputs issued by **its own action**, when every one of them resolves to the same party. The revocation handle comes from the same output, and is dropped when the outputs carry more than one. Without this the upgraded amount would be credited to the owner without ever being debited, doubling the holding. A composite owner issues one output row per member, all under one output index: members resolving to one enrollment ID attribute the input to it, while members spanning enrollment IDs fail the audit — a record keeps a single sender per action, and an unattributed input would credit the members without debiting anyone. Issued outputs that only partly resolve fail the audit for the same reason; when none resolve, nothing is credited and the input stays unattributed.
+
+An owner that maps to no single enrollment ID — a composite owner such as a multisig, or one whose audit info is not available to, or not decodable by, this auditor — leaves its input **unattributed**, with an empty enrollment ID. Amount aggregations skip empty enrollment IDs, so an unattributed input is counted for nobody. Guessing instead, for instance from the first output, would in a payment attribute the payer's spending to the recipient and silently corrupt both balances.
+
+An action whose inputs attribute to **more than one** enrollment ID — reachable when the tokens to spend are passed explicitly, since they are not constrained to a single wallet — fails the audit with an error naming the cause: a transaction record keeps a single sender per action, so the store cannot represent it. Representing multi-sender actions is tracked separately.
+
+Attribution runs in `Audit`, before the enrollment IDs are collected, so the EID locking described below covers the enrollment ID each input is finally booked under. `Append` reuses the record `Audit` attributed and stores it as it stands; it attributes the record itself only when called without a preceding `Audit`. An input left unattributed by `Audit` therefore stays unattributed, and no enrollment ID outside the locked set can reach the store.
+
 ## Distributed EID Locking
 
 When multiple auditor replicas share the same AuditDB (PostgreSQL), concurrent processing of the same enrollment IDs (EIDs) must be serialized. The **auditor locker** (`token/services/storage/auditdb/locker`) coordinates exclusive access to EIDs during audit record writes.

--- a/token/services/auditor/auditor.go
+++ b/token/services/auditor/auditor.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token"
 	"github.com/LFDT-Panurus/panurus/token/core/common/metrics"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	"github.com/LFDT-Panurus/panurus/token/services/network"
 	"github.com/LFDT-Panurus/panurus/token/services/network/driver"
@@ -159,7 +160,13 @@ func (a *Service) Audit(ctx context.Context, tx Transaction) (*token.InputStream
 	start := time.Now()
 	logger.DebugfContext(ctx, "audit transaction [%s]....", tx.ID())
 	request := tx.Request()
-	record, err := request.AuditRecord(ctx)
+	tms, err := a.bindProviderTMS(request)
+	if err != nil {
+		return nil, nil, err
+	}
+	// the record is completed before the enrollment IDs are collected, so that
+	// the locks cover the enrollment ID every input is finally booked under
+	record, err := newRequestWrapper(request, tms).AuditRecord(ctx)
 	if err != nil {
 		return nil, nil, errors.WithMessagef(err, "failed getting transaction audit record")
 	}
@@ -217,7 +224,7 @@ func (a *Service) Append(ctx context.Context, tx Transaction) error {
 	defer func() { a.metrics.AppendDuration.Observe(time.Since(start).Seconds()) }()
 	defer a.Release(ctx, tx)
 
-	tms, err := a.tmsProvider.TokenManagementService(token.WithTMSID(a.tmsID))
+	tms, err := a.bindProviderTMS(tx.Request())
 	if err != nil {
 		return err
 	}
@@ -252,6 +259,22 @@ func (a *Service) Append(ctx context.Context, tx Transaction) error {
 	logger.DebugfContext(ctx, "append done for request [%s]", tx.ID())
 
 	return nil
+}
+
+// bindProviderTMS resolves the TMS for the service's TMS ID through the
+// provider and rebinds the request to it. The record computation runs through
+// request.TokenService, so this is what keeps the request from influencing
+// which TMS computes and attributes the record.
+func (a *Service) bindProviderTMS(request *token.Request) (dep.TokenManagementServiceWithExtensions, error) {
+	tms, err := a.tmsProvider.TokenManagementService(token.WithTMSID(a.tmsID))
+	if err != nil {
+		return nil, err
+	}
+	if err := tms.SetTokenManagementService(request); err != nil {
+		return nil, err
+	}
+
+	return tms, nil
 }
 
 // Release releases the lock acquired of the passed transaction and drops the
@@ -395,44 +418,93 @@ func (r *requestWrapper) PublicParamsHash() token.PPHash { return r.r.PublicPara
 
 // AuditRecord retrieves the audit record for the wrapped token request and completes any
 // inputs with missing enrollment IDs by querying the token vault.
-// The gap filling always runs, also on a cached record, because it depends on
-// the current vault state.
+// A record cached by Audit is returned as it stands: it was already attributed
+// there, and the locks were taken for the enrollment IDs it carries.
 func (r *requestWrapper) AuditRecord(ctx context.Context) (*token.AuditRecord, error) {
-	record := r.cached
-	if record == nil {
-		var err error
-		record, err = r.r.AuditRecord(ctx)
-		if err != nil {
-			return nil, err
-		}
+	// re-running the gap filling on a cached record could attribute an input
+	// Audit deliberately left empty, booking it under an enrollment ID that
+	// was never locked
+	if r.cached != nil {
+		return r.cached, nil
+	}
+
+	record, err := r.r.AuditRecord(ctx)
+	if err != nil {
+		return nil, err
 	}
 	if err := r.completeInputsWithEmptyEID(ctx, record); err != nil {
 		return nil, errors.WithMessagef(err, "failed filling gaps for request [%s]", r.r.Anchor)
+	}
+	if err := rejectMultiOwnerActions(record); err != nil {
+		return nil, err
 	}
 
 	return record, nil
 }
 
+// rejectMultiOwnerActions fails when one action spends tokens attributed to
+// more than one enrollment ID. A transaction record keeps a single sender per
+// action, so the store would reject such a record only at Append time, with
+// an error that does not name the cause. It mirrors the store's grouping:
+// unattributed inputs are skipped.
+func rejectMultiOwnerActions(record *token.AuditRecord) error {
+	firstEID := map[int]string{}
+	for _, in := range record.Inputs.Inputs() {
+		if in.EnrollmentID == "" {
+			continue
+		}
+		eID, ok := firstEID[in.ActionIndex]
+		if !ok {
+			firstEID[in.ActionIndex] = in.EnrollmentID
+
+			continue
+		}
+		if eID != in.EnrollmentID {
+			return errors.Errorf("action [%d] of request [%s] spends tokens of multiple enrollment IDs ([%s] and [%s]): a transaction record keeps a single sender per action", in.ActionIndex, record.Anchor, eID, in.EnrollmentID)
+		}
+	}
+
+	return nil
+}
+
 // completeInputsWithEmptyEID fills in missing enrollment ID information for inputs in the audit record
 // by querying the token vault. This is necessary when inputs don't have enrollment IDs explicitly set.
-// It uses the first output's enrollment ID as the target and retrieves token details from the vault.
+// Each input is attributed to the enrollment ID resolved from its own token
+// owner and the audit info the input carries — the locally stored audit info
+// of the owner where present, the one carried by the request otherwise (see
+// Request.AuditRecord). An owner the identity layer cannot decode counts as
+// resolving to nothing; any other resolution failure — a storage error, a
+// canceled context — fails the audit. An input the request describes no sender for is an
+// upgrade input, and falls back to the enrollment ID the request issues to;
+// an upgrade issued to a composite owner spanning enrollment IDs fails the
+// audit (see issuedToEIDAndRH). An owner that maps to no single enrollment ID
+// leaves its input unattributed rather than booked under a guessed enrollment
+// ID, so a record keeping such an input is not fully attributed on return.
 func (r *requestWrapper) completeInputsWithEmptyEID(ctx context.Context, record *token.AuditRecord) error {
 	filter := record.Inputs.ByEnrollmentID("")
 	if filter.Count() == 0 {
 		return nil
 	}
-	// TODO: extract from the audit tokens
-	targetEID := record.Outputs.EnrollmentIDs()[0]
 
 	// fetch all the tokens
 	tokens, err := r.tms.Vault().NewQueryEngine().ListAuditTokens(ctx, filter.IDs()...)
 	if err != nil {
 		return errors.WithMessagef(err, "failed listing tokens for [%s]", filter.IDs())
 	}
+	if filter.Count() != len(tokens) {
+		return errors.Errorf("expected %d audit tokens, got %d", filter.Count(), len(tokens))
+	}
 	precision := r.tms.PublicParametersManager().PublicParameters().Precision()
+	wm := r.tms.WalletManager()
 	for i := range filter.Count() {
 		item := filter.At(i)
-		item.EnrollmentID = targetEID
+		if tokens[i] == nil {
+			return errors.Errorf("failed to audit inputs: nil input at [%d]th input", i)
+		}
+		// an input the request describes no sender for: extractIssueInputs fills
+		// only the token id, so across the built-in drivers this is an upgrade
+		upgraded := len(item.Owner) == 0
+
 		item.Owner = tokens[i].Owner
 		item.Type = tokens[i].Type
 		q, err := token2.ToQuantity(tokens[i].Quantity, precision)
@@ -440,9 +512,101 @@ func (r *requestWrapper) completeInputsWithEmptyEID(ctx context.Context, record 
 			return errors.WithMessagef(err, "failed converting token quantity [%s]", tokens[i].Quantity)
 		}
 		item.Quantity = q
+
+		eID, rID, err := wm.GetEIDAndRH(ctx, item.Owner, item.OwnerAuditInfo)
+		if err != nil {
+			// only a decoding failure counts as "this owner does not resolve";
+			// anything else — a storage failure, a canceled context — fails the
+			// audit rather than silently leaving the input unattributed
+			if ctx.Err() != nil || !errors.Is(err, identity.ErrUnresolvableIdentity) {
+				return errors.WithMessagef(err, "failed resolving enrollment id for input [%v]", item.Id)
+			}
+			logger.DebugfContext(ctx, "owner of input [%v] does not resolve, treating it as unresolved: %v", item.Id, err)
+			eID, rID = "", ""
+		}
+		if eID == "" && upgraded {
+			// an upgrade re-issues the spent tokens to their owner under a fresh
+			// identity, so the outputs of the very same action carry the
+			// enrollment ID the input belongs to. The pre-upgrade identity
+			// itself often resolves to nothing here: it predates the current
+			// driver and the request metadata carries no audit info for it.
+			eID, rID, err = issuedToEIDAndRH(record.Outputs, item.ActionIndex)
+			if err != nil {
+				return err
+			}
+		}
+		if eID == "" {
+			// the owner maps to no single enrollment ID — a composite owner,
+			// or one whose audit info is unavailable. Leave the input
+			// unattributed: amount aggregations skip an empty enrollment ID,
+			// whereas a guessed one would be charged to the wrong party.
+			continue
+		}
+		item.EnrollmentID = eID
+		item.RevocationHandler = rID
 	}
 
 	return nil
+}
+
+// issuedToEIDAndRH returns the enrollment ID and revocation handle the given issue
+// action issues to, and empty values when it does not issue to exactly one party.
+// An issued output carries both an issuer and an owner; a redeem output carries an
+// issuer but no owner. Every issued output of the action must resolve to the same
+// enrollment ID. The handle is kept only while it stays paired with that ID.
+//
+// A composite owner issues one output row per member, all under one output index.
+// Members resolving to distinct enrollment IDs leave no single enrollment ID to
+// book the input under, and an unattributed input would credit the members
+// without debiting anyone: such an action fails the audit instead. Outputs that
+// only partly resolve fail the audit for the same reason; when none resolve,
+// nothing is credited and the input may stay unattributed.
+func issuedToEIDAndRH(outputs *token.OutputStream, actionIndex int) (string, string, error) {
+	issued := outputs.Filter(func(o *token.Output) bool {
+		return o.ActionIndex == actionIndex && len(o.Issuer) != 0 && len(o.Owner) != 0
+	}).Outputs()
+	if len(issued) == 0 {
+		return "", "", nil
+	}
+
+	unresolved := 0
+	eIDByIndex := map[uint64]string{}
+	for _, output := range issued {
+		if output.EnrollmentID == "" {
+			unresolved++
+
+			continue
+		}
+		if eID, ok := eIDByIndex[output.Index]; ok && eID != output.EnrollmentID {
+			return "", "", errors.Errorf(
+				"output [%d] of action [%d] is issued to a composite owner whose members span enrollment IDs ([%s] and [%s]): no single enrollment ID to attribute its input to",
+				output.Index, actionIndex, eID, output.EnrollmentID,
+			)
+		}
+		eIDByIndex[output.Index] = output.EnrollmentID
+	}
+	if unresolved == len(issued) {
+		// nothing is credited to anybody, so nothing needs debiting
+		return "", "", nil
+	}
+	if unresolved > 0 {
+		return "", "", errors.Errorf(
+			"action [%d] issues [%d] of [%d] outputs to owners resolving to no enrollment ID: crediting the resolved ones would leave the input undebited",
+			actionIndex, unresolved, len(issued),
+		)
+	}
+
+	eID, rH := issued[0].EnrollmentID, issued[0].RevocationHandler
+	for _, output := range issued[1:] {
+		if output.EnrollmentID != eID {
+			return "", "", nil
+		}
+		if output.RevocationHandler != rH {
+			rH = ""
+		}
+	}
+
+	return eID, rH, nil
 }
 
 // String returns a string representation of the wrapped token request.

--- a/token/services/auditor/auditor_internal_test.go
+++ b/token/services/auditor/auditor_internal_test.go
@@ -18,7 +18,9 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/core/common/metrics"
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	drivermock "github.com/LFDT-Panurus/panurus/token/driver/mock"
+	"github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1/request"
 	tokenmock "github.com/LFDT-Panurus/panurus/token/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	"github.com/LFDT-Panurus/panurus/token/services/network"
 	networkdriver "github.com/LFDT-Panurus/panurus/token/services/network/driver"
@@ -216,7 +218,7 @@ func TestMetricsProviderCall(t *testing.T) {
 // newInternalTestTMS builds a ManagementService backed by driver mocks whose
 // query engine returns toks; the query engine is also returned so tests can
 // count vault accesses.
-func newInternalTestTMS(t *testing.T, toks []*token2.Token) (*token.ManagementService, *drivermock.QueryEngine) {
+func newInternalTestTMS(t *testing.T, toks []*token2.Token) (*token.ManagementService, *drivermock.QueryEngine, *drivermock.WalletService) {
 	t.Helper()
 	mockTMS := &drivermock.TokenManagerService{}
 	mockVP := &tokenmock.VaultProvider{}
@@ -228,9 +230,10 @@ func newInternalTestTMS(t *testing.T, toks []*token2.Token) (*token.ManagementSe
 	mockPP.PrecisionReturns(64)
 	mockPPM.PublicParametersReturns(mockPP)
 
+	mockWS := &drivermock.WalletService{}
 	mockTMS.PublicParamsManagerReturns(mockPPM)
 	mockTMS.TokensServiceReturns(&drivermock.TokensService{})
-	mockTMS.WalletServiceReturns(&drivermock.WalletService{})
+	mockTMS.WalletServiceReturns(mockWS)
 	mockTMS.IssueServiceReturns(&drivermock.IssueService{})
 	mockTMS.TransferServiceReturns(&drivermock.TransferService{})
 
@@ -251,21 +254,21 @@ func newInternalTestTMS(t *testing.T, toks []*token2.Token) (*token.ManagementSe
 	require.NoError(t, err)
 	require.NotNil(t, tms)
 
-	return tms, mockQE
+	return tms, mockQE, mockWS
 }
 
 func newInternalTestManagementService(t *testing.T) *token.ManagementService {
 	t.Helper()
-	tms, _ := newInternalTestTMS(t, []*token2.Token{})
+	tms, _, _ := newInternalTestTMS(t, []*token2.Token{})
 
 	return tms
 }
 
-func newInternalTestManagementServiceWithTokens(t *testing.T, toks []*token2.Token) *token.ManagementService {
+func newInternalTestManagementServiceWithTokens(t *testing.T, toks []*token2.Token) (*token.ManagementService, *drivermock.WalletService) {
 	t.Helper()
-	tms, _ := newInternalTestTMS(t, toks)
+	tms, _, ws := newInternalTestTMS(t, toks)
 
-	return tms
+	return tms, ws
 }
 
 func TestRequestWrapper_PublicParamsHash(t *testing.T) {
@@ -288,9 +291,11 @@ func TestRequestWrapper_CompleteInputsWithEmptyEID_Shortcut(t *testing.T) {
 }
 
 func TestRequestWrapper_CompleteInputsWithEmptyEID_WithInputs(t *testing.T) {
-	tmsWithToken := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
 		{Type: "USD", Quantity: "100", Owner: []byte("owner1")},
 	})
+	ws.GetAuditInfoReturns([]byte("owner1-audit-info"), nil)
+	ws.GetEIDAndRHReturns("owner1-eid", "owner1-rh", nil)
 	rw := newRequestWrapper(
 		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-cid2")), tmsWithToken,
 	)
@@ -299,7 +304,505 @@ func TestRequestWrapper_CompleteInputsWithEmptyEID_WithInputs(t *testing.T) {
 		Outputs: token.NewOutputStream([]*token.Output{{EnrollmentID: "target"}}, 0),
 	}
 	err := rw.completeInputsWithEmptyEID(context.Background(), recordWithInputs)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+
+	// the input is attributed to its own token's owner, never to the
+	// first output's enrollment ID
+	in := recordWithInputs.Inputs.At(0)
+	assert.Equal(t, "owner1-eid", in.EnrollmentID)
+	assert.Equal(t, "owner1-rh", in.RevocationHandler)
+	assert.Equal(t, token2.Type("USD"), in.Type)
+	assert.Equal(t, "100", in.Quantity.Decimal())
+}
+
+func TestRequestWrapper_CompleteInputsWithEmptyEID_UsesRecordAuditInfo(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("owner1")},
+	})
+	ws.GetEIDAndRHReturns("owner1-eid", "owner1-rh", nil)
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-cid3")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs: token.NewInputStream(nil, []*token.Input{
+			{Id: &token2.ID{TxId: "123"}, OwnerAuditInfo: []byte("carried-audit-info")},
+		}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{{EnrollmentID: "target"}}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.NoError(t, err)
+
+	// the record-carried audit info is used directly: no local lookup
+	assert.Equal(t, 0, ws.GetAuditInfoCallCount())
+	_, _, auditInfo := ws.GetEIDAndRHArgsForCall(0)
+	assert.Equal(t, []byte("carried-audit-info"), auditInfo)
+	assert.Equal(t, "owner1-eid", record.Inputs.At(0).EnrollmentID)
+}
+
+// An owner that maps to no single enrollment ID — a composite owner, as in a
+// multisig transfer — leaves the input unattributed rather than failing the
+// record or borrowing the first output's enrollment ID.
+func TestCompleteInputsWithEmptyEID_CompositeOwnerStaysUnattributed(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("owner1")},
+	})
+	ws.GetAuditInfoReturns([]byte("owner1-audit-info"), nil)
+	ws.GetEIDAndRHReturns("", "", nil)
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-unres")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs:  token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{{EnrollmentID: "target"}}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.NoError(t, err)
+
+	in := record.Inputs.At(0)
+	assert.Empty(t, in.EnrollmentID)
+	assert.Empty(t, in.RevocationHandler)
+	// the remaining fields are still filled in from the spent token
+	assert.Equal(t, token2.Type("USD"), in.Type)
+	assert.Equal(t, "100", in.Quantity.Decimal())
+	// and an unattributed input reaches no eid-keyed aggregation
+	assert.Empty(t, record.Inputs.EnrollmentIDs())
+}
+
+// Neither the record nor the local store carries audit info for the owner:
+// resolution is not attempted with empty audit info, and with nothing issued by
+// the request to fall back on the input stays unattributed.
+func TestCompleteInputsWithEmptyEID_MissingAuditInfoStaysUnattributed(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("owner1")},
+	})
+	ws.GetAuditInfoReturns(nil, nil)
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-no-audit-info")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs:  token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{{EnrollmentID: "target"}}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.NoError(t, err)
+
+	assert.Empty(t, record.Inputs.At(0).EnrollmentID)
+	assert.Equal(t, 0, ws.GetEIDAndRHCallCount())
+}
+
+// A token upgrade spends tokens the request describes no sender for, and their
+// pre-upgrade owner resolves to nothing here. The tokens are re-issued to the
+// same party, so the input is attributed to what the request issues to —
+// otherwise the upgraded amount is credited without ever being debited.
+func TestCompleteInputsWithEmptyEID_UpgradeInputTakesIssuedEID(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("pre-upgrade-owner")},
+	})
+	ws.GetAuditInfoReturns(nil, nil)
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-upgrade")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		// no owner: the issue metadata of an upgrade holds only the token id
+		Inputs: token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{{
+			Issuer:            driver.Identity("issuer"),
+			Owner:             []byte("post-upgrade-owner"),
+			EnrollmentID:      "alice",
+			RevocationHandler: "alice-rh",
+		}}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.NoError(t, err)
+
+	in := record.Inputs.At(0)
+	assert.Equal(t, "alice", in.EnrollmentID)
+	assert.Equal(t, "alice-rh", in.RevocationHandler)
+}
+
+// The fallback is confined to upgrade inputs: a transfer input whose owner maps
+// to no enrollment ID keeps none, even when the same request issues tokens.
+func TestCompleteInputsWithEmptyEID_TransferInputIgnoresIssuedEID(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("composite-owner")},
+	})
+	ws.GetEIDAndRHReturns("", "", nil)
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-mixed")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs: token.NewInputStream(nil, []*token.Input{{
+			Id:             &token2.ID{TxId: "123"},
+			Owner:          []byte("composite-owner"),
+			OwnerAuditInfo: []byte("composite-audit-info"),
+		}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{{
+			Issuer:       driver.Identity("issuer"),
+			Owner:        []byte("bob"),
+			EnrollmentID: "bob",
+		}}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.NoError(t, err)
+
+	assert.Empty(t, record.Inputs.At(0).EnrollmentID)
+}
+
+// Issuing to more than one party — two outputs, each with its own index — leaves
+// the upgrade input unattributed: there is no single enrollment ID to charge it to.
+func TestCompleteInputsWithEmptyEID_AmbiguousIssuedEIDStaysUnattributed(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("pre-upgrade-owner")},
+	})
+	ws.GetAuditInfoReturns(nil, nil)
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-two-receivers")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs: token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{
+			{Index: 0, Issuer: driver.Identity("issuer"), Owner: []byte("alice"), EnrollmentID: "alice"},
+			{Index: 1, Issuer: driver.Identity("issuer"), Owner: []byte("bob"), EnrollmentID: "bob"},
+		}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.NoError(t, err)
+
+	assert.Empty(t, record.Inputs.At(0).EnrollmentID)
+}
+
+// An upgrade issued back to a composite owner emits one output row per member,
+// all under one output index. Members resolving to one enrollment ID attribute
+// the input to it; their distinct revocation handles drop the handle.
+func TestCompleteInputsWithEmptyEID_CompositeUpgradeSharedEIDAttributed(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("pre-upgrade-composite")},
+	})
+	ws.GetAuditInfoReturns(nil, nil)
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-composite-upgrade")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs: token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{
+			{Index: 0, Issuer: driver.Identity("issuer"), Owner: []byte("member-0"), EnrollmentID: "alice", RevocationHandler: "rh-0"},
+			{Index: 0, Issuer: driver.Identity("issuer"), Owner: []byte("member-1"), EnrollmentID: "alice", RevocationHandler: "rh-1"},
+		}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.NoError(t, err)
+
+	in := record.Inputs.At(0)
+	assert.Equal(t, "alice", in.EnrollmentID)
+	assert.Empty(t, in.RevocationHandler)
+}
+
+// Members spanning enrollment IDs leave no single enrollment ID to book the
+// input under, and leaving it unattributed would credit the members without
+// debiting anyone: the audit fails, naming the enrollment IDs.
+func TestCompleteInputsWithEmptyEID_CompositeUpgradeSpanningEIDsFailsAudit(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("pre-upgrade-composite")},
+	})
+	ws.GetAuditInfoReturns(nil, nil)
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-composite-span")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs: token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{
+			{Index: 0, Issuer: driver.Identity("issuer"), Owner: []byte("member-0"), EnrollmentID: "alice"},
+			{Index: 0, Issuer: driver.Identity("issuer"), Owner: []byte("member-1"), EnrollmentID: "bob"},
+		}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "composite owner")
+	assert.Contains(t, err.Error(), "alice")
+	assert.Contains(t, err.Error(), "bob")
+}
+
+// Issued outputs that only partly resolve fail the audit: here a composite
+// owner with one member resolving to alice and one member resolving to
+// nothing — alice's row would be credited while the input, left unattributed,
+// debits nobody.
+func TestCompleteInputsWithEmptyEID_PartlyResolvedIssuedOutputsFailAudit(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("pre-upgrade-owner")},
+	})
+	ws.GetAuditInfoReturns(nil, nil)
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-unresolved-output")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs: token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{
+			{Index: 0, Issuer: driver.Identity("issuer"), Owner: []byte("member-0"), EnrollmentID: "alice", RevocationHandler: "alice-rh"},
+			{Index: 0, Issuer: driver.Identity("issuer"), Owner: []byte("member-1"), EnrollmentID: ""},
+		}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolving to no enrollment ID")
+}
+
+// When no issued output resolves, nothing is credited to anybody: the input
+// stays unattributed and nothing is imbalanced.
+func TestCompleteInputsWithEmptyEID_NoResolvedIssuedOutputStaysUnattributed(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("pre-upgrade-owner")},
+	})
+	ws.GetAuditInfoReturns(nil, nil)
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-all-unresolved")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs: token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{
+			{Index: 0, Issuer: driver.Identity("issuer"), Owner: []byte("unknown-0"), EnrollmentID: ""},
+			{Index: 1, Issuer: driver.Identity("issuer"), Owner: []byte("unknown-1"), EnrollmentID: ""},
+		}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.NoError(t, err)
+
+	assert.Empty(t, record.Inputs.At(0).EnrollmentID)
+}
+
+// The enrollment ID and the revocation handle come from the same output: two
+// handles under one enrollment ID keep the ID and drop the handle rather than
+// pair the ID with a handle no output carries next to it.
+func TestCompleteInputsWithEmptyEID_MixedRevocationHandlesDropTheHandle(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("pre-upgrade-owner")},
+	})
+	ws.GetAuditInfoReturns(nil, nil)
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-mixed-rh")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs: token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{
+			{Issuer: driver.Identity("issuer"), Owner: []byte("alice"), EnrollmentID: "alice", RevocationHandler: ""},
+			{Issuer: driver.Identity("issuer"), Owner: []byte("alice2"), EnrollmentID: "alice", RevocationHandler: "other-rh"},
+		}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.NoError(t, err)
+
+	in := record.Inputs.At(0)
+	assert.Equal(t, "alice", in.EnrollmentID)
+	assert.Empty(t, in.RevocationHandler)
+}
+
+// The fallback looks at the outputs of the input's own action: a second issue
+// action to another party neither suppresses this attribution nor lends its
+// enrollment ID to it.
+func TestCompleteInputsWithEmptyEID_UpgradeFallbackIsActionScoped(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("alice-pre-upgrade")},
+		{Type: "USD", Quantity: "50", Owner: []byte("carol-pre-upgrade")},
+	})
+	ws.GetAuditInfoReturns(nil, nil)
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-two-actions")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs: token.NewInputStream(nil, []*token.Input{
+			{ActionIndex: 0, Id: &token2.ID{TxId: "123"}},
+			{ActionIndex: 1, Id: &token2.ID{TxId: "456"}},
+		}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{
+			{ActionIndex: 0, Issuer: driver.Identity("issuer"), Owner: []byte("alice"), EnrollmentID: "alice", RevocationHandler: "alice-rh"},
+			{ActionIndex: 1, Issuer: driver.Identity("issuer"), Owner: []byte("bob"), EnrollmentID: "bob", RevocationHandler: "bob-rh"},
+		}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.NoError(t, err)
+
+	assert.Equal(t, "alice", record.Inputs.At(0).EnrollmentID)
+	assert.Equal(t, "alice-rh", record.Inputs.At(0).RevocationHandler)
+	assert.Equal(t, "bob", record.Inputs.At(1).EnrollmentID)
+	assert.Equal(t, "bob-rh", record.Inputs.At(1).RevocationHandler)
+}
+
+// The vault answering with fewer tokens than were asked for must not be indexed
+// past: this runs on the approval path, where a panic would take the audit down.
+func TestCompleteInputsWithEmptyEID_ShortVaultResultErrors(t *testing.T) {
+	tmsWithToken, _ := newInternalTestManagementServiceWithTokens(t, []*token2.Token{})
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-short")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs:  token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{{EnrollmentID: "target"}}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected 1 audit tokens, got 0")
+}
+
+func TestCompleteInputsWithEmptyEID_NilVaultTokenErrors(t *testing.T) {
+	tmsWithToken, _ := newInternalTestManagementServiceWithTokens(t, []*token2.Token{nil})
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-nil-token")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs:  token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{{EnrollmentID: "target"}}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil input at [0]th input")
+}
+
+// The identity layer signals an owner it cannot decode by returning an error —
+// an unknown identity type, a missing deserializer, undecodable audit info.
+// Such an owner is unresolvable, not a failure: the input stays unattributed
+// instead of failing the whole audit.
+func TestCompleteInputsWithEmptyEID_OwnerResolutionErrorLeavesUnattributed(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("owner1")},
+	})
+	ws.GetEIDAndRHReturns("", "", errors.Join(identity.ErrUnresolvableIdentity, errors.New("no deserializer found for [legacy]")))
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-res-err")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs: token.NewInputStream(nil, []*token.Input{{
+			Id:             &token2.ID{TxId: "123"},
+			Owner:          []byte("owner1"),
+			OwnerAuditInfo: []byte("legacy-audit-info"),
+		}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{{EnrollmentID: "target"}}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.NoError(t, err)
+
+	in := record.Inputs.At(0)
+	assert.Empty(t, in.EnrollmentID)
+	assert.Empty(t, in.RevocationHandler)
+	// the remaining fields are still filled in from the spent token
+	assert.Equal(t, token2.Type("USD"), in.Type)
+	assert.Equal(t, "100", in.Quantity.Decimal())
+}
+
+// A failure of the local audit-info storage is not an unresolvable owner:
+// the error fails the audit instead of silently leaving the input unattributed.
+func TestCompleteInputsWithEmptyEID_AuditInfoStorageErrorFailsAudit(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("owner1")},
+	})
+	ws.GetAuditInfoReturns(nil, errors.New("storage failure"))
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-storage-err")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs:  token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{{EnrollmentID: "target"}}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storage failure")
+}
+
+// A resolution error under a canceled context is cancellation, not an
+// unresolvable owner: it propagates.
+func TestCompleteInputsWithEmptyEID_ContextCancellationPropagates(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("owner1")},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	ws.GetAuditInfoReturns([]byte("audit-info"), nil)
+	ws.GetEIDAndRHStub = func(context.Context, driver.Identity, []byte) (string, string, error) {
+		cancel()
+
+		return "", "", ctx.Err()
+	}
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-ctx-cancel")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs:  token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{{EnrollmentID: "target"}}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(ctx, record)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// A pre-upgrade owner from an older driver carries audit info the identity
+// layer cannot deserialize: GetEIDAndRH errors. The upgrade fallback still
+// runs, so the input takes the issued enrollment ID instead of the resolution
+// error blocking the upgrade forever.
+func TestCompleteInputsWithEmptyEID_UpgradeOwnerResolutionErrorTakesIssuedEID(t *testing.T) {
+	tmsWithToken, ws := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("pre-upgrade-owner")},
+	})
+	ws.GetAuditInfoReturns([]byte("legacy-audit-info"), nil)
+	ws.GetEIDAndRHReturns("", "", errors.Join(identity.ErrUnresolvableIdentity, errors.New("no deserializer found for [legacy]")))
+	rw := newRequestWrapper(
+		token.NewRequest(tmsWithToken, token.RequestAnchor("tx-upgrade-res-err")), tmsWithToken,
+	)
+	record := &token.AuditRecord{
+		Inputs: token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{{
+			Issuer:            driver.Identity("issuer"),
+			Owner:             []byte("post-upgrade-owner"),
+			EnrollmentID:      "alice",
+			RevocationHandler: "alice-rh",
+		}}, 0),
+	}
+	err := rw.completeInputsWithEmptyEID(context.Background(), record)
+	require.NoError(t, err)
+
+	in := record.Inputs.At(0)
+	assert.Equal(t, "alice", in.EnrollmentID)
+	assert.Equal(t, "alice-rh", in.RevocationHandler)
+}
+
+func TestRejectMultiOwnerActions(t *testing.T) {
+	t.Run("one action spending tokens of two enrollment IDs is rejected", func(t *testing.T) {
+		record := &token.AuditRecord{
+			Anchor: "tx-multi",
+			Inputs: token.NewInputStream(nil, []*token.Input{
+				{ActionIndex: 0, EnrollmentID: "alice"},
+				{ActionIndex: 0, EnrollmentID: "bob"},
+			}, 0),
+		}
+		err := rejectMultiOwnerActions(record)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spends tokens of multiple enrollment IDs")
+		assert.Contains(t, err.Error(), "alice")
+		assert.Contains(t, err.Error(), "bob")
+		assert.Contains(t, err.Error(), "action [0]")
+	})
+	t.Run("composite members sharing an enrollment ID pass", func(t *testing.T) {
+		record := &token.AuditRecord{
+			Inputs: token.NewInputStream(nil, []*token.Input{
+				{ActionIndex: 0, EnrollmentID: "alice"},
+				{ActionIndex: 0, EnrollmentID: "alice"},
+			}, 0),
+		}
+		require.NoError(t, rejectMultiOwnerActions(record))
+	})
+	t.Run("different actions with different enrollment IDs pass", func(t *testing.T) {
+		record := &token.AuditRecord{
+			Inputs: token.NewInputStream(nil, []*token.Input{
+				{ActionIndex: 0, EnrollmentID: "alice"},
+				{ActionIndex: 1, EnrollmentID: "bob"},
+			}, 0),
+		}
+		require.NoError(t, rejectMultiOwnerActions(record))
+	})
+	t.Run("an unattributed input does not count as a second owner", func(t *testing.T) {
+		record := &token.AuditRecord{
+			Inputs: token.NewInputStream(nil, []*token.Input{
+				{ActionIndex: 0, EnrollmentID: "alice"},
+				{ActionIndex: 0, EnrollmentID: ""},
+			}, 0),
+		}
+		require.NoError(t, rejectMultiOwnerActions(record))
+	})
 }
 
 func TestRequestWrapper_AuditRecord(t *testing.T) {
@@ -378,10 +881,13 @@ func TestCompleteInputsWithEmptyEID_ToQuantityError(t *testing.T) {
 	mockPP := &drivermock.PublicParameters{}
 	mockPP.PrecisionReturns(64)
 	mockPPM.PublicParametersReturns(mockPP)
+	mockWS := &drivermock.WalletService{}
+	mockWS.GetAuditInfoReturns([]byte("owner1-audit-info"), nil)
+	mockWS.GetEIDAndRHReturns("owner1-eid", "owner1-rh", nil)
 	mockTMS.PublicParamsManagerReturns(mockPPM)
 	mockTMS.ValidatorReturns(&drivermock.Validator{}, nil)
 	mockTMS.TokensServiceReturns(&drivermock.TokensService{})
-	mockTMS.WalletServiceReturns(&drivermock.WalletService{})
+	mockTMS.WalletServiceReturns(mockWS)
 	mockTMS.IssueServiceReturns(&drivermock.IssueService{})
 	mockTMS.TransferServiceReturns(&drivermock.TransferService{})
 
@@ -425,10 +931,16 @@ func TestRequestWrapper_AuditRecord_ReusesCached(t *testing.T) {
 	assert.Same(t, cached, record)
 }
 
-func TestRequestWrapper_AuditRecord_CachedStillFillsGaps(t *testing.T) {
-	tms := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+// Audit attributes the record and takes the locks for the enrollment IDs it
+// ends up carrying, so an input it deliberately left unattributed must stay
+// that way here — even though this wallet service would now resolve it. Filling
+// it in would book the input under an enrollment ID that was never locked.
+func TestRequestWrapper_AuditRecord_CachedKeepsUnattributedInput(t *testing.T) {
+	tms, qe, ws := newInternalTestTMS(t, []*token2.Token{
 		{Type: "USD", Quantity: "100", Owner: []byte("owner1")},
 	})
+	ws.GetAuditInfoReturns([]byte("owner1-audit-info"), nil)
+	ws.GetEIDAndRHReturns("owner1-eid", "owner1-rh", nil)
 	rw := newRequestWrapper(token.NewRequest(tms, token.RequestAnchor("tx-cache-gaps")), tms)
 	rw.cached = &token.AuditRecord{
 		Inputs:  token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
@@ -437,9 +949,10 @@ func TestRequestWrapper_AuditRecord_CachedStillFillsGaps(t *testing.T) {
 
 	record, err := rw.AuditRecord(context.Background())
 	require.NoError(t, err)
-	in := record.Inputs.At(0)
-	assert.Equal(t, "target", in.EnrollmentID)
-	assert.Equal(t, token2.Type("USD"), in.Type)
+	assert.Empty(t, record.Inputs.At(0).EnrollmentID)
+	// neither the vault nor the identity store was consulted again
+	assert.Equal(t, 0, qe.ListAuditTokensCallCount())
+	assert.Equal(t, 0, ws.GetEIDAndRHCallCount())
 }
 
 func TestService_AuditRecordCache(t *testing.T) {
@@ -508,16 +1021,35 @@ func (s *stubNetworkDriver) AddFinalityListener(string, string, networkdriver.Fi
 	return nil
 }
 
-// stubTMSWithExtensions is never invoked in these tests: the wrapped TMS is
-// only consulted for gap filling, which short-circuits on records without
-// empty enrollment IDs.
+// stubTMSWithExtensions leaves the request's own TMS in place and is otherwise
+// never consulted: gap filling short-circuits on records without empty
+// enrollment IDs.
 type stubTMSWithExtensions struct {
 	dep.TokenManagementServiceWithExtensions
 }
 
-type stubTMSProvider struct{}
+func (*stubTMSWithExtensions) SetTokenManagementService(*token.Request) error { return nil }
+
+// tmsExt adapts a ManagementService to the type the TMS provider returns,
+// rebinding requests to it the way the production wrapper does.
+type tmsExt struct{ *token.ManagementService }
+
+func (t tmsExt) SetTokenManagementService(req *token.Request) error {
+	req.SetTokenService(t.ManagementService)
+
+	return nil
+}
+
+// stubTMSProvider returns tms when set, an inert stub otherwise.
+type stubTMSProvider struct {
+	tms dep.TokenManagementServiceWithExtensions
+}
 
 func (s *stubTMSProvider) TokenManagementService(...token.ServiceOption) (dep.TokenManagementServiceWithExtensions, error) {
+	if s.tms != nil {
+		return s.tms, nil
+	}
+
 	return &stubTMSWithExtensions{}, nil
 }
 
@@ -527,7 +1059,7 @@ func (s *stubTMSProvider) TokenManagementService(...token.ServiceOption) (dep.To
 // accesses performed to compute an audit record.
 func newAuditTestService(t *testing.T) (*Service, *drivermock.QueryEngine, *token.ManagementService) {
 	t.Helper()
-	tms, qe := newInternalTestTMS(t, []*token2.Token{})
+	tms, qe, _ := newInternalTestTMS(t, []*token2.Token{})
 
 	auditDB, err := auditdb.NewStoreService(&stubAuditStore{})
 	require.NoError(t, err)
@@ -544,7 +1076,7 @@ func newAuditTestService(t *testing.T) (*Service, *drivermock.QueryEngine, *toke
 }
 
 func TestSnapshotAuditRecord_IsolatedFromOriginal(t *testing.T) {
-	tms, _ := newInternalTestTMS(t, []*token2.Token{})
+	tms, _, _ := newInternalTestTMS(t, []*token2.Token{})
 	req := token.NewRequest(tms, "tx-snapshot")
 	quantity, err := token2.ToQuantity("100", 64)
 	require.NoError(t, err)
@@ -642,4 +1174,364 @@ func TestService_AuditThenRelease_DropsCachedRecord(t *testing.T) {
 
 	svc.Release(context.Background(), tx)
 	assert.Nil(t, svc.cachedAuditRecord(tx.req))
+}
+
+// ---------------------------------------------------------------------------
+// Empty-EID input attribution across the Audit -> Append lifecycle
+// ---------------------------------------------------------------------------
+
+// stubTransferAction is a minimal driver.TransferAction. TransferMetadata.Match
+// only checks the input/output counts, the extra signers and the issuer, so
+// every other method can be inert.
+type stubTransferAction struct {
+	inputs  []*token2.ID
+	outputs []driver.Output
+}
+
+func (a *stubTransferAction) Validate() error                         { return nil }
+func (a *stubTransferAction) NumInputs() int                          { return len(a.inputs) }
+func (a *stubTransferAction) GetInputs() []*token2.ID                 { return a.inputs }
+func (a *stubTransferAction) GetSerializedInputs() ([][]byte, error)  { return nil, nil }
+func (a *stubTransferAction) GetSerialNumbers() []string              { return nil }
+func (a *stubTransferAction) IsGraphHiding() bool                     { return false }
+func (a *stubTransferAction) GetMetadata() map[string][]byte          { return nil }
+func (a *stubTransferAction) ExtraSigners() []driver.Identity         { return nil }
+func (a *stubTransferAction) Serialize() ([]byte, error)              { return nil, nil }
+func (a *stubTransferAction) NumOutputs() int                         { return len(a.outputs) }
+func (a *stubTransferAction) GetSerializedOutputs() ([][]byte, error) { return nil, nil }
+func (a *stubTransferAction) GetOutputs() []driver.Output             { return a.outputs }
+func (a *stubTransferAction) IsRedeemAt(int) bool                     { return false }
+func (a *stubTransferAction) SerializeOutputAt(int) ([]byte, error)   { return nil, nil }
+func (a *stubTransferAction) GetIssuer() driver.Identity              { return nil }
+
+type stubTransferOutput struct{ owner []byte }
+
+func (o *stubTransferOutput) Serialize() ([]byte, error) { return []byte("ledger-output"), nil }
+func (o *stubTransferOutput) IsRedeem() bool             { return false }
+func (o *stubTransferOutput) GetOwner() []byte           { return o.owner }
+
+// capturingLocker records the enrollment IDs every AcquireLocks call is given.
+type capturingLocker struct{ acquired [][]string }
+
+func (l *capturingLocker) AcquireLocks(_ context.Context, _ string, eIDs ...string) error {
+	l.acquired = append(l.acquired, append([]string(nil), eIDs...))
+
+	return nil
+}
+func (l *capturingLocker) ReleaseLocks(context.Context, string)          {}
+func (l *capturingLocker) AssertLocksHeld(context.Context, string) error { return nil }
+
+// exactSpendTestContext holds the service under test together with the mocks
+// behind it, so tests can assert on what Audit and Append did with them.
+type exactSpendTestContext struct {
+	svc    *Service
+	tx     *stubTransaction
+	qe     *drivermock.QueryEngine
+	ws     *drivermock.WalletService
+	locker *capturingLocker
+}
+
+// newExactSpendTMS builds the TMS an exact-spend request runs over: a transfer
+// spending one token owned by payer into a single output for recipient. The
+// wallet service resolves the spent token's owner to payerEID, the recipient
+// to recipientEID, and leaves the transfer's sender unresolved.
+func newExactSpendTMS(t *testing.T, payer, recipient driver.Identity, payerEID, recipientEID string) (*token.ManagementService, *drivermock.QueryEngine, *drivermock.WalletService) {
+	t.Helper()
+	spent := &token2.ID{TxId: "prev-tx", Index: 0}
+
+	mockWS := &drivermock.WalletService{}
+	mockWS.GetEIDAndRHStub = func(_ context.Context, id driver.Identity, _ []byte) (string, string, error) {
+		switch {
+		case id.Equal(payer):
+			return payerEID, payerEID + "-rh", nil
+		case id.Equal(recipient):
+			return recipientEID, recipientEID + "-rh", nil
+		}
+
+		// the transfer's sender is not known locally: the input reaches the
+		// record with an empty enrollment ID
+		return "", "", nil
+	}
+
+	mockQE := &drivermock.QueryEngine{}
+	mockQE.ListAuditTokensReturns([]*token2.Token{
+		{Type: "USD", Quantity: "40", Owner: payer},
+	}, nil)
+	mockV := &drivermock.Vault{}
+	mockV.QueryEngineReturns(mockQE)
+	mockVP := &tokenmock.VaultProvider{}
+	mockVP.VaultReturns(mockV, nil)
+
+	mockPP := &drivermock.PublicParameters{}
+	mockPP.PrecisionReturns(64)
+	mockPPM := &drivermock.PublicParamsManager{}
+	mockPPM.PublicParametersReturns(mockPP)
+
+	mockTS := &drivermock.TokensService{}
+	mockTS.DeobfuscateReturns(
+		&token2.Token{Owner: recipient, Type: "USD", Quantity: "40"},
+		nil, []driver.Identity{recipient}, "format", nil,
+	)
+
+	mockTransfers := &drivermock.TransferService{}
+	mockTransfers.DeserializeTransferActionReturns(&stubTransferAction{
+		inputs:  []*token2.ID{spent},
+		outputs: []driver.Output{&stubTransferOutput{owner: recipient}},
+	}, nil)
+
+	mockTMS := &drivermock.TokenManagerService{}
+	mockTMS.PublicParamsManagerReturns(mockPPM)
+	mockTMS.WalletServiceReturns(mockWS)
+	mockTMS.TokensServiceReturns(mockTS)
+	mockTMS.TransferServiceReturns(mockTransfers)
+	mockTMS.IssueServiceReturns(&drivermock.IssueService{})
+	mockTMS.ValidatorReturns(&drivermock.Validator{}, nil)
+
+	tms, err := token.NewManagementService(
+		token.TMSID{}, mockTMS, logging.MustGetLogger("test"), mockVP, nil, nil,
+	)
+	require.NoError(t, err)
+
+	return tms, mockQE, mockWS
+}
+
+// newExactSpendTestContext builds a Service over an exact-spend request (see
+// newExactSpendTMS): the payer owns no change output, and the unresolved
+// sender is what makes the input reach the audit record with an empty
+// enrollment ID.
+func newExactSpendTestContext(t *testing.T, payer, recipient driver.Identity, payerEID string) *exactSpendTestContext {
+	t.Helper()
+	spent := &token2.ID{TxId: "prev-tx", Index: 0}
+	tms, mockQE, mockWS := newExactSpendTMS(t, payer, recipient, payerEID, "recipient-eid")
+
+	req := token.NewRequest(tms, "tx-exact-spend")
+	req.Actions.Actions = []*driver.TypedAction{{
+		Type: request.ActionType_ACTION_TYPE_TRANSFER,
+		Raw:  []byte("transfer-action"),
+	}}
+	req.Metadata.Actions = []*driver.ActionMetadataEntry{{
+		TransferMetadata: &driver.TransferMetadata{
+			Inputs: []*driver.TransferInputMetadata{{
+				TokenID: spent,
+				Senders: []*driver.AuditableIdentity{{Identity: driver.Identity("sender"), AuditInfo: []byte("sender-audit-info")}},
+			}},
+			Outputs: []*driver.TransferOutputMetadata{{
+				OutputMetadata:  []byte("output-metadata"),
+				OutputAuditInfo: []byte("output-audit-info"),
+				Receivers:       []*driver.AuditableIdentity{{Identity: recipient, AuditInfo: []byte("recipient-audit-info")}},
+			}},
+		},
+	}}
+
+	locker := &capturingLocker{}
+	auditDB, err := auditdb.NewStoreService(&stubAuditStore{}, auditdb.WithLocker(locker))
+	require.NoError(t, err)
+
+	svc := &Service{
+		networkProvider: &stubNetworkProvider{net: network.NewNetwork(&stubNetworkDriver{}, nil)},
+		auditDB:         auditDB,
+		// the gap filling resolves through the provider-returned TMS, so the
+		// provider hands out the same TMS the request is built over
+		tmsProvider: &stubTMSProvider{tms: tmsExt{tms}},
+		metrics:     newMetrics(nil),
+		lockConfig:  DefaultLockConfig(),
+	}
+
+	return &exactSpendTestContext{
+		svc:    svc,
+		tx:     &stubTransaction{req: req},
+		qe:     mockQE,
+		ws:     mockWS,
+		locker: locker,
+	}
+}
+
+// TestService_Audit_AttributesAndLocksEmptyEIDInput pins the lifecycle: the
+// input is attributed before the enrollment IDs are collected, so the payer
+// the record is finally booked against is among the locked IDs. Moving the
+// gap filling back after lock acquisition fails this test.
+func TestService_Audit_AttributesAndLocksEmptyEIDInput(t *testing.T) {
+	payer := driver.Identity("payer-owner")
+	recipient := driver.Identity("recipient-owner")
+	c := newExactSpendTestContext(t, payer, recipient, "payer-eid")
+
+	inputs, outputs, err := c.svc.Audit(context.Background(), c.tx)
+	require.NoError(t, err)
+
+	// Audit returns the resolved payer, not an empty enrollment ID
+	require.Equal(t, 1, inputs.Count())
+	in := inputs.At(0)
+	require.Equal(t, "payer-eid", in.EnrollmentID)
+	assert.Equal(t, "payer-eid-rh", in.RevocationHandler)
+	assert.Equal(t, "40", in.Quantity.Decimal())
+
+	// exact spend: the payer owns no output, so the only output is the recipient
+	require.Equal(t, 1, outputs.Count())
+	assert.Equal(t, "recipient-eid", outputs.At(0).EnrollmentID)
+
+	// the locks cover the payer the record is booked against, and no empty ID
+	require.Len(t, c.locker.acquired, 1)
+	require.Contains(t, c.locker.acquired[0], "payer-eid")
+	assert.Contains(t, c.locker.acquired[0], "recipient-eid")
+	assert.NotContains(t, c.locker.acquired[0], "")
+
+	// Append reuses the attributed record: no second vault or identity lookup
+	vaultReads := c.qe.ListAuditTokensCallCount()
+	eidLookups := c.ws.GetEIDAndRHCallCount()
+	require.NoError(t, c.svc.Append(context.Background(), c.tx))
+	assert.Equal(t, vaultReads, c.qe.ListAuditTokensCallCount())
+	assert.Equal(t, eidLookups, c.ws.GetEIDAndRHCallCount())
+}
+
+// Audit rebinds the request to the provider-resolved TMS before the record is
+// computed, so the whole computation — extraction included — runs through the
+// provider's wallet service and the request's own TokenService cannot
+// influence what the record is booked and locked under.
+func TestService_Audit_ProviderTMSAttributesTheRecord(t *testing.T) {
+	payer := driver.Identity("payer-owner")
+	recipient := driver.Identity("recipient-owner")
+	c := newExactSpendTestContext(t, payer, recipient, "request-eid")
+	providerTMS, _, _ := newExactSpendTMS(t, payer, recipient, "provider-eid", "provider-recipient-eid")
+	c.svc.tmsProvider = &stubTMSProvider{tms: tmsExt{providerTMS}}
+
+	inputs, outputs, err := c.svc.Audit(context.Background(), c.tx)
+	require.NoError(t, err)
+
+	// the extraction resolved the recipient through the provider TMS
+	require.Equal(t, 1, outputs.Count())
+	assert.Equal(t, "provider-recipient-eid", outputs.At(0).EnrollmentID)
+	// the gap filling resolved the payer through the provider TMS
+	require.Equal(t, 1, inputs.Count())
+	assert.Equal(t, "provider-eid", inputs.At(0).EnrollmentID)
+	// the locks cover what the record is booked under, nothing request-resolved
+	require.Len(t, c.locker.acquired, 1)
+	assert.Contains(t, c.locker.acquired[0], "provider-eid")
+	assert.Contains(t, c.locker.acquired[0], "provider-recipient-eid")
+	assert.NotContains(t, c.locker.acquired[0], "request-eid")
+	assert.NotContains(t, c.locker.acquired[0], "recipient-eid")
+}
+
+// Append without a preceding Audit recomputes the record; the recomputation
+// too runs through the provider-resolved TMS, not the request's own.
+func TestService_Append_WithoutAudit_ProviderTMSAttributesTheRecord(t *testing.T) {
+	payer := driver.Identity("payer-owner")
+	recipient := driver.Identity("recipient-owner")
+	c := newExactSpendTestContext(t, payer, recipient, "request-eid")
+	providerTMS, providerQE, providerWS := newExactSpendTMS(t, payer, recipient, "provider-eid", "provider-recipient-eid")
+	c.svc.tmsProvider = &stubTMSProvider{tms: tmsExt{providerTMS}}
+
+	require.NoError(t, c.svc.Append(context.Background(), c.tx))
+
+	// the record was computed over the provider TMS; the request's own TMS
+	// was never consulted
+	assert.Positive(t, providerQE.ListAuditTokensCallCount())
+	assert.Positive(t, providerWS.GetEIDAndRHCallCount())
+	assert.Equal(t, 0, c.qe.ListAuditTokensCallCount())
+	assert.Equal(t, 0, c.ws.GetEIDAndRHCallCount())
+}
+
+// newUpgradeTestRequest builds an upgrade-shaped request: one issue action
+// spending a token owned by an identity that resolves to nothing here, and
+// issuing to receiver. It goes through the real Request.AuditRecord pipeline,
+// so extractIssueInputs and extractIssueOutputs decide what the record carries.
+func newUpgradeTestRequest(t *testing.T, preUpgradeOwner, receiver driver.Identity) *requestWrapper {
+	t.Helper()
+	upgraded := &token2.ID{TxId: "pre-upgrade-tx", Index: 0}
+	issuer := driver.Identity("issuer")
+
+	mockWS := &drivermock.WalletService{}
+	mockWS.GetEIDAndRHStub = func(_ context.Context, id driver.Identity, _ []byte) (string, string, error) {
+		if id.Equal(receiver) {
+			return "alice", "alice-rh", nil
+		}
+
+		return "", "", nil
+	}
+
+	mockQE := &drivermock.QueryEngine{}
+	mockQE.ListAuditTokensReturns([]*token2.Token{
+		{Type: "USD", Quantity: "110", Owner: preUpgradeOwner},
+	}, nil)
+	mockV := &drivermock.Vault{}
+	mockV.QueryEngineReturns(mockQE)
+	mockVP := &tokenmock.VaultProvider{}
+	mockVP.VaultReturns(mockV, nil)
+
+	mockPP := &drivermock.PublicParameters{}
+	mockPP.PrecisionReturns(64)
+	mockPPM := &drivermock.PublicParamsManager{}
+	mockPPM.PublicParametersReturns(mockPP)
+
+	mockTS := &drivermock.TokensService{}
+	mockTS.DeobfuscateReturns(
+		&token2.Token{Owner: receiver, Type: "USD", Quantity: "110"},
+		issuer, []driver.Identity{receiver}, "format", nil,
+	)
+
+	action := &drivermock.IssueAction{}
+	action.NumInputsReturns(1)
+	action.NumOutputsReturns(1)
+	action.GetIssuerReturns(issuer)
+	action.GetOutputsReturns([]driver.Output{&stubTransferOutput{owner: receiver}})
+	mockIssues := &drivermock.IssueService{}
+	mockIssues.DeserializeIssueActionReturns(action, nil)
+
+	mockTMS := &drivermock.TokenManagerService{}
+	mockTMS.PublicParamsManagerReturns(mockPPM)
+	mockTMS.WalletServiceReturns(mockWS)
+	mockTMS.TokensServiceReturns(mockTS)
+	mockTMS.IssueServiceReturns(mockIssues)
+	mockTMS.TransferServiceReturns(&drivermock.TransferService{})
+	mockTMS.ValidatorReturns(&drivermock.Validator{}, nil)
+
+	tms, err := token.NewManagementService(
+		token.TMSID{}, mockTMS, logging.MustGetLogger("test"), mockVP, nil, nil,
+	)
+	require.NoError(t, err)
+
+	req := token.NewRequest(tms, "tx-upgrade")
+	req.Actions.Actions = []*driver.TypedAction{{
+		Type: request.ActionType_ACTION_TYPE_ISSUE,
+		Raw:  []byte("issue-action"),
+	}}
+	req.Metadata.Actions = []*driver.ActionMetadataEntry{{
+		IssueMetadata: &driver.IssueMetadata{
+			Issuer: driver.AuditableIdentity{Identity: issuer},
+			// an upgrade input: the token id and nothing else
+			Inputs: []*driver.IssueInputMetadata{{TokenID: upgraded}},
+			Outputs: []*driver.IssueOutputMetadata{{
+				OutputMetadata:  []byte("output-metadata"),
+				OutputAuditInfo: []byte("output-audit-info"),
+				Receivers: []*driver.AuditableIdentity{
+					{Identity: receiver, AuditInfo: []byte("receiver-audit-info")},
+				},
+			}},
+		},
+	}}
+
+	return newRequestWrapper(req, tms)
+}
+
+// The upgrade fallback over the real record-building pipeline: nothing about the
+// record is hand-written, so the assumptions it rests on — the input reaching the
+// record without an owner, the issued output carrying issuer, owner and
+// enrollment ID, both under the same action index — are exercised rather than
+// asserted.
+func TestRequestWrapper_AuditRecord_UpgradeInputAttributedToReceiver(t *testing.T) {
+	receiver := driver.Identity("post-upgrade-receiver")
+	rw := newUpgradeTestRequest(t, driver.Identity("pre-upgrade-owner"), receiver)
+
+	record, err := rw.AuditRecord(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, 1, record.Inputs.Count())
+	in := record.Inputs.At(0)
+	assert.Equal(t, "alice", in.EnrollmentID)
+	assert.Equal(t, "alice-rh", in.RevocationHandler)
+	assert.Equal(t, "110", in.Quantity.Decimal())
+
+	// what the upgrade credits is what it debits: the holding does not move
+	require.Equal(t, 1, record.Outputs.Count())
+	assert.Equal(t, "alice", record.Outputs.At(0).EnrollmentID)
+	assert.Equal(t, 0, record.Outputs.Sum().Cmp(record.Inputs.Sum()))
 }

--- a/token/services/auditor/auditor_test.go
+++ b/token/services/auditor/auditor_test.go
@@ -122,14 +122,38 @@ func newFakeStore() *auditmock.AuditTransactionStore {
 	return fakeStore
 }
 
-// newTestService creates a Service with the given auditDB and checkService for testing.
-func newTestService(auditDB *auditdb.StoreService, checkService auditor.CheckService) *auditor.Service {
+// tmsWithExtensions adapts a ManagementService to the type the TMS provider
+// returns, rebinding requests to it the way the production wrapper does.
+type tmsWithExtensions struct{ *token.ManagementService }
+
+func (t tmsWithExtensions) SetTokenManagementService(req *token.Request) error {
+	req.SetTokenService(t.ManagementService)
+
+	return nil
+}
+
+// newTestTMSProvider returns a provider handing out a working TMS.
+func newTestTMSProvider(t *testing.T) *depmock.TokenManagementServiceProvider {
+	t.Helper()
+	tmsProv := &depmock.TokenManagementServiceProvider{}
+	tmsProv.TokenManagementServiceReturns(tmsWithExtensions{newTestManagementService(t)}, nil)
+
+	return tmsProv
+}
+
+// newTestService creates a Service with the given auditDB and checkService for
+// testing. Audit and Append resolve the TMS through the provider, so a working
+// one is always wired in.
+func newTestService(t *testing.T, auditDB *auditdb.StoreService, checkService auditor.CheckService) *auditor.Service {
+	t.Helper()
+	tmsProv := newTestTMSProvider(t)
+
 	return auditor.NewService(
 		token.TMSID{},
 		nil, // networkProvider
 		auditDB,
 		nil, // tokenDB
-		nil, // tmsProvider
+		tmsProv,
 		nil, // finalityTracer
 		nil, // metricsProvider
 		checkService,
@@ -149,7 +173,7 @@ func newStubNetwork() *network.Network {
 func TestService_Check_ReturnsIssues(t *testing.T) {
 	cs := &auditmock.CheckService{}
 	cs.CheckReturns([]string{"tx-aaa", "tx-bbb"}, nil)
-	svc := newTestService(newTestStoreService(t, newFakeStore()), cs)
+	svc := newTestService(t, newTestStoreService(t, newFakeStore()), cs)
 	got, err := svc.Check(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"tx-aaa", "tx-bbb"}, got)
@@ -159,7 +183,7 @@ func TestService_Check_ReturnsError(t *testing.T) {
 	expectedErr := errors.New("check failed")
 	cs := &auditmock.CheckService{}
 	cs.CheckReturns(nil, expectedErr)
-	svc := newTestService(newTestStoreService(t, newFakeStore()), cs)
+	svc := newTestService(t, newTestStoreService(t, newFakeStore()), cs)
 	_, err := svc.Check(context.Background())
 	assert.ErrorIs(t, err, expectedErr)
 }
@@ -167,7 +191,7 @@ func TestService_Check_ReturnsError(t *testing.T) {
 func TestService_Check_EmptyIssues(t *testing.T) {
 	cs := &auditmock.CheckService{}
 	cs.CheckReturns([]string{}, nil)
-	svc := newTestService(newTestStoreService(t, newFakeStore()), cs)
+	svc := newTestService(t, newTestStoreService(t, newFakeStore()), cs)
 	got, err := svc.Check(context.Background())
 	require.NoError(t, err)
 	assert.Empty(t, got)
@@ -194,7 +218,7 @@ func TestGetByTMSID_GetServiceError_ReturnsNil(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestService_Release_IncrementsCounter(t *testing.T) {
-	svc := newTestService(newTestStoreService(t, newFakeStore()), nil)
+	svc := newTestService(t, newTestStoreService(t, newFakeStore()), nil)
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-release")
 	tx.RequestReturns(&token.Request{Anchor: "tx-release"})
@@ -204,7 +228,7 @@ func TestService_Release_IncrementsCounter(t *testing.T) {
 }
 
 func TestService_SetStatus_Success(t *testing.T) {
-	svc := newTestService(newTestStoreService(t, newFakeStore()), nil)
+	svc := newTestService(t, newTestStoreService(t, newFakeStore()), nil)
 	err := svc.SetStatus(context.Background(), "tx-set", auditdb.Confirmed, "ok")
 	assert.NoError(t, err)
 }
@@ -213,7 +237,7 @@ func TestService_SetStatus_Error(t *testing.T) {
 	expectedErr := errors.New("db write error")
 	fakeStore := newFakeStore()
 	fakeStore.SetStatusReturns(expectedErr)
-	svc := newTestService(newTestStoreService(t, fakeStore), nil)
+	svc := newTestService(t, newTestStoreService(t, fakeStore), nil)
 	err := svc.SetStatus(context.Background(), "tx-set", auditdb.Confirmed, "ok")
 	assert.ErrorIs(t, err, expectedErr)
 }
@@ -221,7 +245,7 @@ func TestService_SetStatus_Error(t *testing.T) {
 func TestService_GetStatus_Success(t *testing.T) {
 	fakeStore := newFakeStore()
 	fakeStore.GetStatusReturns(auditdb.Confirmed, "done", nil)
-	svc := newTestService(newTestStoreService(t, fakeStore), nil)
+	svc := newTestService(t, newTestStoreService(t, fakeStore), nil)
 	status, msg, err := svc.GetStatus(context.Background(), "tx-get")
 	require.NoError(t, err)
 	assert.Equal(t, auditdb.Confirmed, status)
@@ -232,7 +256,7 @@ func TestService_GetStatus_Error(t *testing.T) {
 	expectedErr := errors.New("db read error")
 	fakeStore := newFakeStore()
 	fakeStore.GetStatusReturns(0, "", expectedErr)
-	svc := newTestService(newTestStoreService(t, fakeStore), nil)
+	svc := newTestService(t, newTestStoreService(t, fakeStore), nil)
 	_, _, err := svc.GetStatus(context.Background(), "tx-get")
 	assert.ErrorIs(t, err, expectedErr)
 }
@@ -241,7 +265,7 @@ func TestService_GetTokenRequest_Success(t *testing.T) {
 	data := []byte("raw-token-request")
 	fakeStore := newFakeStore()
 	fakeStore.GetTokenRequestReturns(data, nil)
-	svc := newTestService(newTestStoreService(t, fakeStore), nil)
+	svc := newTestService(t, newTestStoreService(t, fakeStore), nil)
 	got, err := svc.GetTokenRequest(context.Background(), "tx-tok")
 	require.NoError(t, err)
 	assert.Equal(t, data, got)
@@ -251,7 +275,7 @@ func TestService_GetTokenRequest_Error(t *testing.T) {
 	expectedErr := errors.New("not found")
 	fakeStore := newFakeStore()
 	fakeStore.GetTokenRequestReturns(nil, expectedErr)
-	svc := newTestService(newTestStoreService(t, fakeStore), nil)
+	svc := newTestService(t, newTestStoreService(t, fakeStore), nil)
 	_, err := svc.GetTokenRequest(context.Background(), "tx-tok")
 	assert.ErrorIs(t, err, expectedErr)
 }
@@ -261,7 +285,7 @@ func TestService_GetTokenRequest_Error(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestService_Validate(t *testing.T) {
-	svc := newTestService(nil, nil)
+	svc := newTestService(t, nil, nil)
 	assert.Panics(t, func() {
 		_ = svc.Validate(context.Background(), &token.Request{})
 	})
@@ -290,7 +314,15 @@ func TestService_Audit_AuditRecordError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	svc := newTestService(newTestStoreService(t, newFakeStore()), nil)
+	// the record is computed over the provider-resolved TMS, so the failing
+	// TMS is routed through the provider
+	tmsProv := &depmock.TokenManagementServiceProvider{}
+	tmsProv.TokenManagementServiceReturns(tmsWithExtensions{badTMS}, nil)
+	svc := auditor.NewService(
+		token.TMSID{}, nil,
+		newTestStoreService(t, newFakeStore()),
+		nil, tmsProv, nil, nil, nil, nil,
+	)
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-err")
 	tx.RequestReturns(token.NewRequest(badTMS, token.RequestAnchor("tx-err")))
@@ -301,7 +333,7 @@ func TestService_Audit_AuditRecordError(t *testing.T) {
 }
 
 func TestService_Audit_Success(t *testing.T) {
-	svc := newTestService(newTestStoreService(t, newFakeStore()), nil)
+	svc := newTestService(t, newTestStoreService(t, newFakeStore()), nil)
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-audit-ok")
 	tx.RequestReturns(token.NewRequest(newTestManagementService(t), token.RequestAnchor("tx-audit-ok")))
@@ -316,7 +348,7 @@ func TestService_Audit_DBCleanSuccess(t *testing.T) {
 	fakeStore := newFakeStore()
 	fakeStore.GetStatusReturns(0, "", errors.New("db status err"))
 
-	svc := newTestService(newTestStoreService(t, fakeStore), nil)
+	svc := newTestService(t, newTestStoreService(t, fakeStore), nil)
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-aud-err")
 	tx.RequestReturns(token.NewRequest(newTestManagementService(t), token.RequestAnchor("tx-aud-err")))
@@ -331,7 +363,7 @@ func TestService_Audit_NotUnknown(t *testing.T) {
 	fakeStore := newFakeStore()
 	fakeStore.GetStatusReturns(dbdriver.Pending, "", nil)
 
-	svc := newTestService(newTestStoreService(t, fakeStore), nil)
+	svc := newTestService(t, newTestStoreService(t, fakeStore), nil)
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-aud-not-unknown")
 	tx.RequestReturns(token.NewRequest(newTestManagementService(t), token.RequestAnchor("tx-aud-not-unknown")))
@@ -342,7 +374,10 @@ func TestService_Audit_NotUnknown(t *testing.T) {
 	assert.NotNil(t, outputs)
 }
 
-func TestService_Audit_TMSProviderIrrelevant(t *testing.T) {
+// Audit resolves the TMS through the provider, as Append does, so the request
+// cannot influence which wallet service attributes the record: a provider
+// error fails the audit.
+func TestService_Audit_TMSProviderError(t *testing.T) {
 	tmsProv := &depmock.TokenManagementServiceProvider{}
 	tmsProv.TokenManagementServiceReturns(nil, errors.New("tms err"))
 
@@ -355,10 +390,9 @@ func TestService_Audit_TMSProviderIrrelevant(t *testing.T) {
 	tx.IDReturns("tx-aud-tms-err")
 	tx.RequestReturns(token.NewRequest(newTestManagementService(t), token.RequestAnchor("tx-aud-tms-err")))
 
-	inputs, outputs, err := svc.Audit(context.Background(), tx)
-	require.NoError(t, err)
-	assert.NotNil(t, inputs)
-	assert.NotNil(t, outputs)
+	_, _, err := svc.Audit(context.Background(), tx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tms err")
 }
 
 // ---------------------------------------------------------------------------
@@ -390,7 +424,7 @@ func TestService_Append_GetNetworkError(t *testing.T) {
 	svc := auditor.NewService(
 		token.TMSID{}, netProvider,
 		newTestStoreService(t, newFakeStore()),
-		nil, &depmock.TokenManagementServiceProvider{}, nil, nil, nil, nil,
+		nil, newTestTMSProvider(t), nil, nil, nil, nil,
 	)
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-net-err")
@@ -411,7 +445,7 @@ func TestService_Append_Success(t *testing.T) {
 	svc := auditor.NewService(
 		token.TMSID{}, netProvider,
 		newTestStoreService(t, newFakeStore()),
-		nil, &depmock.TokenManagementServiceProvider{}, nil, nil, nil, nil,
+		nil, newTestTMSProvider(t), nil, nil, nil, nil,
 	)
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-app-success")
@@ -434,7 +468,7 @@ func TestService_Append_AddFinalityListenerError(t *testing.T) {
 	svc := auditor.NewService(
 		token.TMSID{}, netProvider,
 		newTestStoreService(t, newFakeStore()),
-		nil, &depmock.TokenManagementServiceProvider{}, nil, nil, nil, nil,
+		nil, newTestTMSProvider(t), nil, nil, nil, nil,
 	)
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-listener-err")
@@ -463,7 +497,7 @@ func TestService_Append_AuditError(t *testing.T) {
 	svc := auditor.NewService(
 		token.TMSID{}, netProvider,
 		newTestStoreService(t, fakeStore),
-		nil, &depmock.TokenManagementServiceProvider{}, nil, nil, nil, nil,
+		nil, newTestTMSProvider(t), nil, nil, nil, nil,
 	)
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-app-err")
@@ -702,7 +736,14 @@ func TestService_Audit_LocksReleasedOnAuditRecordError(t *testing.T) {
 	require.NoError(t, err)
 
 	storeService := newTestStoreService(t, newFakeStore())
-	svc := newTestService(storeService, nil)
+	// the record is computed over the provider-resolved TMS, so the failing
+	// TMS is routed through the provider
+	tmsProv := &depmock.TokenManagementServiceProvider{}
+	tmsProv.TokenManagementServiceReturns(tmsWithExtensions{badTMS}, nil)
+	svc := auditor.NewService(
+		token.TMSID{}, nil, storeService,
+		nil, tmsProv, nil, nil, nil, nil,
+	)
 
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-audit-record-err")
@@ -729,7 +770,7 @@ func TestService_Audit_LocksReleasedOnAuditRecordError(t *testing.T) {
 // Release() frees them, and Release() is idempotent (safe to call multiple times).
 func TestService_Audit_LocksAcquiredOnSuccess(t *testing.T) {
 	storeService := newTestStoreService(t, newFakeStore())
-	svc := newTestService(storeService, nil)
+	svc := newTestService(t, storeService, nil)
 
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-audit-success")
@@ -759,7 +800,7 @@ func TestService_Audit_LocksAcquiredOnSuccess(t *testing.T) {
 // Release() is always safe regardless of Audit() outcome.
 func TestService_Audit_ContextCancellationBeforeLockAcquisition(t *testing.T) {
 	storeService := newTestStoreService(t, newFakeStore())
-	svc := newTestService(storeService, nil)
+	svc := newTestService(t, storeService, nil)
 
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-ctx-cancel")
@@ -790,7 +831,7 @@ func TestService_Audit_ContextCancellationBeforeLockAcquisition(t *testing.T) {
 // first Audit() acquires locks, Release() frees them, second Audit() succeeds.
 func TestService_Audit_MultipleAuditsSequential(t *testing.T) {
 	storeService := newTestStoreService(t, newFakeStore())
-	svc := newTestService(storeService, nil)
+	svc := newTestService(t, storeService, nil)
 
 	ctx := context.Background()
 
@@ -825,7 +866,7 @@ func TestService_Audit_MultipleAuditsSequential(t *testing.T) {
 // multiple times safely without panics (handles error paths, defer, retry logic).
 func TestService_Audit_ReleaseIdempotency(t *testing.T) {
 	storeService := newTestStoreService(t, newFakeStore())
-	svc := newTestService(storeService, nil)
+	svc := newTestService(t, storeService, nil)
 
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-release-idempotent")
@@ -857,7 +898,7 @@ func TestService_Audit_ReleaseIdempotency(t *testing.T) {
 // prior Audit() (handles defer in error paths where Audit() never ran or failed early).
 func TestService_Audit_ReleaseWithoutAudit(t *testing.T) {
 	storeService := newTestStoreService(t, newFakeStore())
-	svc := newTestService(storeService, nil)
+	svc := newTestService(t, storeService, nil)
 
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-no-audit")
@@ -875,7 +916,7 @@ func TestService_Audit_ReleaseWithoutAudit(t *testing.T) {
 //	defer auditor.Release(ctx, tx)  // MUST be after error check
 func TestService_Audit_PanicRecoveryReleasesLocks(t *testing.T) {
 	storeService := newTestStoreService(t, newFakeStore())
-	svc := newTestService(storeService, nil)
+	svc := newTestService(t, storeService, nil)
 
 	tx := &auditmock.Transaction{}
 	tx.IDReturns("tx-panic-recovery")
@@ -964,13 +1005,16 @@ func newTestServiceWithMockLocker(t *testing.T, mockLocker *mockAuditLocker) *au
 	storeService, err := auditdb.NewStoreService(fakeStore, auditdb.WithLocker(mockLocker))
 	require.NoError(t, err)
 
+	tmsProv := &depmock.TokenManagementServiceProvider{}
+	tmsProv.TokenManagementServiceReturns(tmsWithExtensions{newTestManagementService(t)}, nil)
+
 	// Create the auditor service with the store that uses our mock locker
 	return auditor.NewService(
 		token.TMSID{},
 		nil, // networkProvider
 		storeService,
 		nil, // tokenDB
-		nil, // tmsProvider
+		tmsProv,
 		nil, // finalityTracer
 		nil, // metricsProvider
 		nil, // checkService

--- a/token/services/identity/deserializer/deserializer_test.go
+++ b/token/services/identity/deserializer/deserializer_test.go
@@ -186,7 +186,7 @@ func TestEIDRHDeserializer(t *testing.T) {
 		deserializer := NewEIDRHDeserializer()
 
 		_, err := deserializer.GetEnrollmentID(context.Background(), []byte("invalid"), []byte("audit-info"))
-		require.Error(t, err)
+		require.ErrorIs(t, err, identity.ErrUnresolvableIdentity)
 		assert.Contains(t, err.Error(), "failed to unmarshal to TypedIdentity")
 	})
 
@@ -197,24 +197,27 @@ func TestEIDRHDeserializer(t *testing.T) {
 		typedID := createTypedIdentity(t, identity.Type(98), []byte("raw-identity"))
 
 		_, err := deserializer.GetEnrollmentID(context.Background(), typedID, []byte("audit-info"))
-		require.Error(t, err)
+		require.ErrorIs(t, err, identity.ErrUnresolvableIdentity)
 		assert.Contains(t, err.Error(), "no deserializer found")
 	})
 
 	// test error when trying to deserialize and extract the EID
-	// when the NewEIDRHDeserializer returns with an arbitrary error
+	// when the NewEIDRHDeserializer returns with an arbitrary error;
+	// the error carries the unresolvable marker and keeps its cause
 	t.Run("DeserializeAuditInfoError", func(t *testing.T) {
 		deserializer := NewEIDRHDeserializer()
 
+		expectedErr := errors.New("deserialize error")
 		mockDeserializer := &identitydrivermock.AuditInfoDeserializer{}
-		mockDeserializer.DeserializeAuditInfoReturns(nil, errors.New("deserialize error"))
+		mockDeserializer.DeserializeAuditInfoReturns(nil, expectedErr)
 
 		deserializer.AddDeserializer(identity.Type(99), mockDeserializer)
 
 		typedID := createTypedIdentity(t, identity.Type(99), []byte("raw-identity"))
 		_, err := deserializer.GetEnrollmentID(context.Background(), typedID, []byte("audit-info"))
 
-		require.Error(t, err)
+		require.ErrorIs(t, err, identity.ErrUnresolvableIdentity)
+		require.ErrorIs(t, err, expectedErr)
 		assert.Contains(t, err.Error(), "failed to deserialize audit info")
 		assert.Equal(t, 1, mockDeserializer.DeserializeAuditInfoCallCount())
 	})

--- a/token/services/identity/deserializer/eidrh.go
+++ b/token/services/identity/deserializer/eidrh.go
@@ -64,6 +64,10 @@ func (e *EIDRHDeserializer) GetEIDAndRH(ctx context.Context, identity driver.Ide
 	return ai.EnrollmentID(), ai.RevocationHandle(), nil
 }
 
+// DeserializeAuditInfo decodes the audit info matched to the passed identity.
+// A decoding failure — an identity that does not unmarshal, a type with no
+// deserializer, audit info the deserializer rejects — carries
+// identity.ErrUnresolvableIdentity along with its cause.
 func (e *EIDRHDeserializer) DeserializeAuditInfo(ctx context.Context, id driver.Identity, auditInfo []byte) (driver2.AuditInfo, error) {
 	if len(auditInfo) == 0 {
 		return nil, errors.Errorf("nil audit info")
@@ -71,17 +75,17 @@ func (e *EIDRHDeserializer) DeserializeAuditInfo(ctx context.Context, id driver.
 
 	si, err := identity.UnmarshalTypedIdentity(id)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal to TypedIdentity")
+		return nil, errors.WithMessage(errors.Join(identity.ErrUnresolvableIdentity, err), "failed to unmarshal to TypedIdentity")
 	}
 	e.mutex.RLock()
 	d, ok := e.deserializers[si.Type]
 	e.mutex.RUnlock()
 	if !ok {
-		return nil, errors.Errorf("no deserializer found for [%v]", si.Type)
+		return nil, errors.Wrapf(identity.ErrUnresolvableIdentity, "no deserializer found for [%v]", si.Type)
 	}
 	res, err := d.DeserializeAuditInfo(ctx, si.Identity, auditInfo)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to deserialize audit info for identity type [%v]", si.Type)
+		return nil, errors.WithMessagef(errors.Join(identity.ErrUnresolvableIdentity, err), "failed to deserialize audit info for identity type [%v]", si.Type)
 	}
 
 	return res, nil

--- a/token/services/identity/typed.go
+++ b/token/services/identity/typed.go
@@ -20,6 +20,11 @@ type (
 	Identity = driver.Identity
 )
 
+// ErrUnresolvableIdentity marks an identity this identity layer cannot decode —
+// an unknown identity type, a missing deserializer, undecodable audit info.
+// Errors carrying it keep the underlying cause in their chain.
+var ErrUnresolvableIdentity = errors.New("identity does not resolve")
+
 // TypedIdentity encodes an identity with a type.
 type TypedIdentity struct {
 	// Type encodes the type of the identity

--- a/token/wallet.go
+++ b/token/wallet.go
@@ -162,6 +162,27 @@ func (wm *WalletManager) GetRevocationHandle(ctx context.Context, identity Ident
 	return wm.walletService.GetRevocationHandle(ctx, identity, auditInfo)
 }
 
+// GetEIDAndRH returns the enrollment ID and revocation handle bound to the
+// passed identity. When auditInfo is empty, the locally stored audit info of
+// the identity is used instead; when that is empty too, the identity carries
+// no audit info here and empty values are returned without an error. A
+// decoding failure carries identity.ErrUnresolvableIdentity, put there by the
+// identity layer; an audit-info storage failure does not.
+func (wm *WalletManager) GetEIDAndRH(ctx context.Context, identity Identity, auditInfo []byte) (string, string, error) {
+	if len(auditInfo) == 0 {
+		var err error
+		auditInfo, err = wm.walletService.GetAuditInfo(ctx, identity)
+		if err != nil {
+			return "", "", errors.WithMessagef(err, "failed to get audit info for identity %s", identity)
+		}
+		if len(auditInfo) == 0 {
+			return "", "", nil
+		}
+	}
+
+	return wm.walletService.GetEIDAndRH(ctx, identity, auditInfo)
+}
+
 // SpentIDs returns the spent keys corresponding to the passed token IDs
 func (wm *WalletManager) SpentIDs(ids []*token.ID) ([]string, error) {
 	return wm.walletService.SpendIDs(ids...)

--- a/token/wallet_test.go
+++ b/token/wallet_test.go
@@ -247,6 +247,35 @@ func TestWalletManager_GetRevocationHandle(t *testing.T) {
 	assert.Equal(t, "revocation-handle", rh)
 }
 
+// TestWalletManager_GetEIDAndRH_DecodeErrorPassedThrough verifies an identity
+// layer error keeps its chain: the auditor classifies it by errors.Is.
+func TestWalletManager_GetEIDAndRH_DecodeErrorPassedThrough(t *testing.T) {
+	mockWS := &mock.WalletService{}
+	wm := &WalletManager{walletService: mockWS}
+
+	expectedErr := errors.New("no deserializer found for [legacy]")
+	mockWS.GetEIDAndRHReturns("", "", expectedErr)
+
+	_, _, err := wm.GetEIDAndRH(context.Background(), Identity("alice"), []byte("audit"))
+
+	require.ErrorIs(t, err, expectedErr)
+}
+
+// TestWalletManager_GetEIDAndRH_StorageErrorKeepsChain verifies an audit-info
+// storage failure propagates with its chain intact.
+func TestWalletManager_GetEIDAndRH_StorageErrorKeepsChain(t *testing.T) {
+	mockWS := &mock.WalletService{}
+	wm := &WalletManager{walletService: mockWS}
+
+	expectedErr := errors.New("storage failure")
+	mockWS.GetAuditInfoReturns(nil, expectedErr)
+
+	_, _, err := wm.GetEIDAndRH(context.Background(), Identity("alice"), nil)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Contains(t, err.Error(), "failed to get audit info")
+}
+
 // TestWalletManager_SpentIDs verifies spent IDs retrieval
 func TestWalletManager_SpentIDs(t *testing.T) {
 	mockWS := &mock.WalletService{}


### PR DESCRIPTION
Fixes #2198

## What

- Attribute each input with an unresolved enrollment ID to its **own** spent token's owner, instead of to the first output's enrollment ID. The revocation handle is filled in from the same resolution.
- An owner that maps to no single enrollment ID — a composite owner such as a multisig — leaves its input **unattributed**, with an empty enrollment ID.
- A **token upgrade** is the exception: its issue metadata describes no sender for the inputs, and the pre-upgrade owner resolves to nothing here, so such an input takes the enrollment ID of the outputs issued by *its own action*, when every one of them resolves to the same party. The revocation handle comes from the same output.
- Add `WalletManager.GetEIDAndRH(ctx, identity, auditInfo)`, which resolves through the audit info attached to the input — the locally stored audit info of the spent token's owner where present (`Request.AuditRecord` fills it in), the request-carried one otherwise; when neither is available it returns empty values rather than an error.
- Run the gap filling in `Audit`, before the enrollment IDs are collected, so the locks cover the enrollment ID each input is finally booked under, and return a record cached by `Audit` from `Append` as it stands. `Append` still attributes the record when called without a preceding `Audit`.
- Guard the vault result the way `Request.AuditRecord` does — a length check plus a per-token nil check — since this code now runs on the audit approval path.

## Why

In a payment the first output is the recipient, so the old `targetEID := record.Outputs.EnrollmentIDs()[0]` recorded the payer's spend against the counterparty: the recipient is charged a spend it never made, and the payer's spend is never booked. Neither side errors or warns. The `TODO` above that line marked it as a placeholder.

Leaving an unattributable input empty rather than guessing is the point of the change: `EnrollmentIDs()` skips empty enrollment IDs, so such an input is counted for nobody, which is the honest outcome when the owner genuinely maps to no single enrollment ID. A multisig input is exactly that — several members, no single one to charge — so it is a normal state to represent, not a failure to raise.

The upgrade case is the one where the same guess was right, and dropping it showed up as a red `TokensUpgrade` integration test (alice's holding 220 instead of 110). `extractIssueInputs` fills only the token id, and the pre-upgrade owner predates the current driver, so nothing in the record resolves it. But an upgrade re-issues the spent tokens to their owner under a fresh identity, so what the request issues to *is* the input's enrollment ID — leaving it empty credits the upgraded amount without ever debiting it. The fallback is confined to inputs the request describes no sender for, and scoped to the outputs of the input's own action: a second issue action neither suppresses the attribution nor lends its enrollment ID to it. Every issued output of that action must resolve to the same party — one resolving to none cannot be shown to belong to the others — and the handle is kept only while it stays paired with that enrollment ID.

The lifecycle matters as much as the attribution. `Audit` collects the enrollment IDs it locks from the record and `Append` writes that record, so filling the gaps only in `Append` would leave the final record booked against a payer that was never locked — an exact spend has no change output, so the payer's enrollment ID appears nowhere in what `Audit` saw.

The same reasoning applies in reverse to the cached record: re-running the gap filling in `Append` could attribute an input that `Audit` deliberately left empty, storing it under an enrollment ID that was never locked. `Append` therefore returns the cached record as it stands. Together these keep the locked set and the stored record in agreement, and remove the second vault read for records carrying an unattributed input.

Resolving from the input's own owner also drops the `record.Outputs.EnrollmentIDs()[0]` index-out-of-range on a record with no outputs.

## Testing

- `token/services/auditor/auditor_internal_test.go`: attribution from the token owner; record-carried audit info preferred over a local lookup (asserting no local lookup happens); a composite owner and a missing-audit-info owner both staying unattributed without an error, with the remaining fields still filled from the spent token; a genuine resolution error still propagating; a short vault answer and a nil vault token each erroring instead of panicking.
- The upgrade fallback: an input with no sender and an unresolvable owner takes the issued enrollment ID and revocation handle; a transfer input whose owner maps to nothing keeps none even when the same request issues tokens; issuing to two parties, or to one party plus an output resolving to none, leaves the input unattributed; two handles under one enrollment ID keep the ID and drop the handle; a two-action record attributes each input from its own action.
- `TestRequestWrapper_AuditRecord_UpgradeInputAttributedToReceiver` runs an upgrade-shaped request through the real `Request.AuditRecord` pipeline rather than a hand-written record, so what `extractIssueInputs` and `extractIssueOutputs` actually produce — the input arriving without an owner, the issued output carrying issuer, owner and enrollment ID under the same action index — is exercised instead of assumed. It also asserts the record's inputs and outputs sum equal, which is the holding that went to 220 in `update-t1`.
- `TestRequestWrapper_AuditRecord_CachedKeepsUnattributedInput`: a record cached by `Audit` with an unattributed input is returned untouched even though the wallet service would now resolve it, with no further vault or identity lookup.
- `TestService_Audit_AttributesAndLocksEmptyEIDInput` pins the lifecycle over an exact spend whose sender does not resolve locally: `Audit` returns the resolved payer enrollment ID and revocation handle, the acquired locks contain that payer and no empty ID, and `Append` reuses the record without a second vault read or identity lookup. Moving the gap filling back after lock acquisition fails this test.
- Verified locally on both modules: `gofmt`, `go build`, `go vet`, `go test -race`, and golangci-lint v2.12.2 with the repo config.

## Docs

`docs/services/auditor.md` gains an "Input Attribution" section: the per-input resolution order, the upgrade fallback, what happens to an owner with no single enrollment ID, and where in the `Audit`/`Append` lifecycle it runs relative to the EID locking documented just below it.



## Review rounds

- An action spending tokens of multiple enrollment IDs, a composite owner spanning enrollment IDs, and issued outputs that only partly resolve now fail the audit with errors naming the cause; representing multi-sender actions is #2242.
- The identity layer marks its decoding failures with `identity.ErrUnresolvableIdentity`, keeping the cause in the chain; the gap filling treats only that class as unresolvable, while storage failures and context cancellation fail the audit.
- `Audit` and `Append` rebind the request to the provider-resolved TMS before the record is computed, so the request cannot influence which TMS attributes the record.
- `docs/services/auditor.md` gained an Input Attribution section describing the behavior, including the audit-info preference order (the local store wins; flipping it is #2251).
- Follow-ups: #2249 (action-scoped output filter), #2250 (cache entry lifetime), #2251 (preference order).
