### PR TITLE
zkatdlog: transfer validator missing the owner-verifier cache that fabtoken already has

### DIFF
--- a/token/core/zkatdlog/nogh/v1/validator/validator_test.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_test.go
@@ -14,12 +14,15 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/benchmark"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
 	testing2 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/testutils"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/validator"
 	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/driver/mock"
 	benchmark2 "github.com/LFDT-Panurus/panurus/token/services/benchmark"
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/idemix"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/idemixnym"
 	"github.com/hyperledger-labs/fabric-smart-client/node/start/profile"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -104,6 +107,83 @@ func TestValidator(t *testing.T) {
 			})
 		}
 	}
+}
+
+// TestVerifierCache verifies that VerifierCache deserializes each distinct owner
+// at most once (issue #2074): repeated lookups of the same owner reuse the
+// cached verifier, distinct owners are deserialized independently, and a
+// deserialization error is propagated without being cached so a later lookup
+// can retry.
+func TestVerifierCache(t *testing.T) {
+	ctx := context.Background()
+	ownerA := driver.Identity("owner-A")
+	ownerB := driver.Identity("owner-B")
+
+	t.Run("same owner is deserialized only once", func(t *testing.T) {
+		des := &mock.Deserializer{}
+		verifier := &mock.Verifier{}
+		des.GetOwnerVerifierReturns(verifier, nil)
+
+		cache := validator.NewVerifierCache(des)
+
+		first, err := cache.Get(ctx, ownerA)
+		require.NoError(t, err)
+		require.Same(t, verifier, first)
+
+		second, err := cache.Get(ctx, ownerA)
+		require.NoError(t, err)
+		require.Same(t, verifier, second)
+
+		require.Equal(t, 1, des.GetOwnerVerifierCallCount(), "owner should be deserialized exactly once")
+	})
+
+	t.Run("distinct owners are deserialized separately", func(t *testing.T) {
+		des := &mock.Deserializer{}
+		verifiers := map[string]driver.Verifier{
+			string(ownerA): &mock.Verifier{},
+			string(ownerB): &mock.Verifier{},
+		}
+		des.GetOwnerVerifierStub = func(_ context.Context, id driver.Identity) (driver.Verifier, error) {
+			return verifiers[string(id)], nil
+		}
+
+		cache := validator.NewVerifierCache(des)
+
+		gotA, err := cache.Get(ctx, ownerA)
+		require.NoError(t, err)
+		require.Same(t, verifiers[string(ownerA)], gotA)
+
+		gotB, err := cache.Get(ctx, ownerB)
+		require.NoError(t, err)
+		require.Same(t, verifiers[string(ownerB)], gotB)
+
+		// re-fetch the first owner: it is served from the cache, not re-deserialized.
+		gotAAgain, err := cache.Get(ctx, ownerA)
+		require.NoError(t, err)
+		require.Same(t, gotA, gotAAgain)
+
+		require.Equal(t, 2, des.GetOwnerVerifierCallCount(), "each distinct owner should be deserialized once")
+	})
+
+	t.Run("deserialization error propagates and is not cached", func(t *testing.T) {
+		des := &mock.Deserializer{}
+		boom := errors.New("boom")
+		verifier := &mock.Verifier{}
+		des.GetOwnerVerifierReturnsOnCall(0, nil, boom)
+		des.GetOwnerVerifierReturnsOnCall(1, verifier, nil)
+
+		cache := validator.NewVerifierCache(des)
+
+		_, err := cache.Get(ctx, ownerA)
+		require.ErrorIs(t, err, boom)
+
+		// The failed lookup was not cached, so a subsequent call retries and succeeds.
+		got, err := cache.Get(ctx, ownerA)
+		require.NoError(t, err)
+		require.Same(t, verifier, got)
+
+		require.Equal(t, 2, des.GetOwnerVerifierCallCount(), "a failed lookup must not be cached")
+	})
 }
 
 func BenchmarkValidatorTransfer(b *testing.B) {

--- a/token/core/zkatdlog/nogh/v1/validator/validator_transfer.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_transfer.go
@@ -29,6 +29,45 @@ func TransferActionValidate(c context.Context, ctx *Context) error {
 	return ctx.TransferAction.Validate()
 }
 
+// VerifierCache memoizes owner signature verifiers for the lifetime of a single
+// transfer validation. deserializing an owner verifier is expensive so,
+//
+// # VerifierCache deserializes each distinct owner at most once, so the cost
+//
+// scales with the number of distinct owners rather than with the number of inputs.
+//
+// A VerifierCache is discarded when validation invocation ends,
+// so it holds no cross-transaction state
+type VerifierCache struct {
+	deserializer driver.Deserializer
+	cache        map[string]driver.Verifier
+}
+
+// NewVerifierCache returns an empty VerifierCache that deserializes owner
+// verifiers through the given deserializer.
+func NewVerifierCache(deserializer driver.Deserializer) *VerifierCache {
+	return &VerifierCache{
+		deserializer: deserializer,
+		cache:        make(map[string]driver.Verifier),
+	}
+}
+
+// Get returns the signature verifier for owner, deserializing it on first
+// request only.
+func (c *VerifierCache) Get(ctx context.Context, owner driver.Identity) (driver.Verifier, error) {
+	key := string(owner)
+	if verifier, ok := c.cache[key]; ok {
+		return verifier, nil
+	}
+	verifier, err := c.deserializer.GetOwnerVerifier(ctx, owner)
+	if err != nil {
+		return nil, err
+	}
+	c.cache[key] = verifier
+
+	return verifier, nil
+}
+
 // TransferSignatureValidate validates the signatures of the transfer action.
 // It assumes TransferActionValidate has been called first; however it also
 // performs its own nil guards so that it cannot panic even when called in
@@ -49,6 +88,8 @@ func TransferSignatureValidate(c context.Context, ctx *Context) error {
 
 	var isRedeem bool
 	var inputToken []*token.Token
+
+	verifierCache := NewVerifierCache(ctx.Deserializer)
 	for i, in := range ctx.TransferAction.Inputs {
 		// Guard against a nil ActionInput or a nil Token inside it so that
 		// this function cannot panic even if TransferActionValidate was skipped.
@@ -61,7 +102,7 @@ func TransferSignatureValidate(c context.Context, ctx *Context) error {
 		// check sender signature
 		uniqueID := driver.Identity(tok.Owner).UniqueID()
 		ctx.Logger.Debugf("check sender [%d][%s]", i, uniqueID)
-		verifier, err := ctx.Deserializer.GetOwnerVerifier(c, tok.Owner)
+		verifier, err := verifierCache.Get(c, tok.Owner)
 		if err != nil {
 			return errors.Wrapf(err, "failed deserializing owner [%d][%s]", i, uniqueID)
 		}


### PR DESCRIPTION
Fixes #2074

### Summary

The zkatdlog transfer validator re-deserializes the owner verifier from scratch for every input
token, while the fabtoken transfer validator already caches verifiers per-invocation. Each
zkatdlog deserialization is an ASN.1 unmarshal plus a linear scan over the registered deserializers
plus full cryptographic key reconstruction, and the multiplex registers one idemix deserializer per
issuer public key — so a transaction spending N tokens under the same owner identity pays N×M
instead of M (M = number of registered deserializers scanned per call).

### Where

`token/core/fabtoken/v1/validator/validator_transfer.go:36,45,52` — the existing pattern to follow:

```go
verifierCache := make(map[string]driver.Verifier)
...
if v, ok := verifierCache[key]; ok { ... }
...
verifierCache[key] = v
```

`token/core/zkatdlog/nogh/v1/validator/validator_transfer.go:64` — calls
`ctx.Deserializer.GetOwnerVerifier(c, tok.Owner)` unconditionally per input token, with no equivalent
cache.

The cost per miss is amplified by `token/core/zkatdlog/nogh/v1/driver/deserializer.go:38-44`, which
registers one idemix deserializer per configured issuer public key — the linear scan grows with the
number of issuers.

### Impact

For any transaction where one owner identity spends multiple input tokens (a common pattern), the
zkatdlog validator repeats the full verifier-reconstruction cost once per input instead of once per
distinct owner. This is a straightforward, measurable hot spot on the validation path with a
well-established fix already implemented next door in the fabtoken validator.

Because the cache is scoped to a single validator invocation (constructed fresh per call, discarded
at return), there's no cross-transaction cache-poisoning surface to worry about — this mirrors
fabtoken's existing cache exactly.

### Reproduction

Not yet committed. A benchmark constructing a transfer with a fixed owner spending an increasing
number of input tokens (e.g. 1, 5, 20) would show `GetOwnerVerifier` call count and cumulative time
scaling linearly with input count in zkatdlog today, flat (after the first call) once cached.

### Suggested fix

Add a `verifierCache := make(map[string]driver.Verifier)` local to the zkatdlog transfer validator
function, following the exact fabtoken pattern. Key on the raw `string(tok.Owner)` bytes (as fabtoken
does), **not** on `tok.Owner.UniqueID()` — `UniqueID()` does a sha256 + base64 encode per call, which
would add back a chunk of the cost this change is meant to remove, for no benefit over the raw string
as a map key.

### Severity

MEDIUM — clear, measurable per-token hot spot on the block-validation path, with a low-risk fix
already proven in the equivalent fabtoken code path.