### PR TITLE
Audit-token cache fast-fail fallback for recently-audited outputs

### DIFF
--- a/token/core/common/auditor.go
+++ b/token/core/common/auditor.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"time"
 
+	cdriver "github.com/LFDT-Panurus/panurus/token/core/common/driver"
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1/request"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
@@ -286,6 +287,11 @@ func ExtractTokenIDsAndCheckDuplicates(
 // numRetries and retryDelay control the tolerance for the pending-transaction
 // read-timing race (see DefaultAuditTokensNumRetries / DefaultAuditTokensRetryDelay).
 // A numRetries <= 0 is clamped to a single attempt.
+//
+// cache is an optional (nil-safe) requests-cache fast-fail gate. When wired, a
+// lookup miss for which none of the producing transactions are cached fails
+// immediately instead of spending the retry/backoff budget (see
+// listAuditTokensWithRetry). Passing nil preserves the IsPending-only behaviour.
 func RetrieveAuditTokens(
 	ctx context.Context,
 	logger logging.Logger,
@@ -294,6 +300,7 @@ func RetrieveAuditTokens(
 	anchor driver.TokenRequestAnchor,
 	numRetries int,
 	retryDelay time.Duration,
+	cache cdriver.RequestsCache,
 ) (map[string]*token.Token, error) {
 	if logger == nil {
 		return nil, errors.Errorf("logger cannot be nil for tx [%s]", anchor)
@@ -307,7 +314,7 @@ func RetrieveAuditTokens(
 	}
 
 	logger.DebugfContext(ctx, "[%s] retrieving [%d] audit tokens...", anchor, len(tokenIDs))
-	tokens, err := listAuditTokensWithRetry(ctx, logger, queryEngine, tokenIDs, anchor, numRetries, retryDelay)
+	tokens, err := listAuditTokensWithRetry(ctx, logger, queryEngine, tokenIDs, anchor, numRetries, retryDelay, cache)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to retrieve audit tokens for tx [%s]", anchor)
 	}
@@ -338,6 +345,21 @@ func RetrieveAuditTokens(
 // immediately instead of pinning a goroutine for the full grace window. A genuine
 // (non-pending) lookup failure, or a failure to determine pending status, is
 // returned rather than retried and never masked as "still pending".
+//
+// When a requests cache is wired (cache != nil), it is consulted on a miss as a
+// fast-fail gate: id.TxId is the producing transaction of a referenced input, and
+// its token request is held in the in-memory cache from audit-approval time until
+// it is persisted. If none of the producing transactions are cached, this node has
+// nothing pending to wait for, so the lookup fails immediately without spending the
+// backoff budget. A cache hit does not bypass the IsPending gate: retries still
+// require the producing transaction to be pending, so both gates apply. When no
+// cache is wired the behaviour is unchanged (IsPending-only gating).
+//
+// NOTE: the requests cache is per-process, so the gate assumes audit-approval and
+// this audit check run on the same node. In a multi-replica auditor topology a
+// producing transaction approved on another replica is absent here and the gate
+// fails fast rather than waiting; deployments that chain transactions across auditor
+// replicas should leave the cache unwired (see docs/services/auditor.md).
 func listAuditTokensWithRetry(
 	ctx context.Context,
 	logger logging.Logger,
@@ -346,6 +368,7 @@ func listAuditTokensWithRetry(
 	anchor driver.TokenRequestAnchor,
 	numRetries int,
 	retryDelay time.Duration,
+	cache cdriver.RequestsCache,
 ) ([]*token.Token, error) {
 	attempts := max(1, numRetries)
 
@@ -356,6 +379,16 @@ func listAuditTokensWithRetry(
 		tokens, err = queryEngine.ListAuditTokens(ctx, tokenIDs...)
 		if err == nil {
 			return tokens, nil
+		}
+
+		// Fast-fail gate: when a requests cache is wired, use membership as a
+		// short-circuit. If none of the producing transactions are cached there is
+		// nothing this node is waiting to persist, so retrying cannot help -- fail
+		// immediately instead of paying the backoff.
+		if cache != nil && !anyRequestCached(cache, tokenIDs) {
+			logger.Warnf("[%s] audit token lookup failed and none of the producing transactions are cached, failing fast: %v", anchor, err)
+
+			return nil, err
 		}
 
 		// The lookup failed. Check whether any requested token belongs to a

--- a/token/core/common/driver/driver.go
+++ b/token/core/common/driver/driver.go
@@ -62,3 +62,20 @@ type VaultProvider interface {
 	// Vault returns the vault instance for the given network, channel, and namespace.
 	Vault(network, channel, namespace string) (driver.Vault, error)
 }
+
+// RequestsCache is the minimal, nil-safe view onto the per-TMS in-memory requests
+// cache that the audit-token lookup needs. Membership is keyed by the producing
+// transaction ID: a transaction is present iff its token request was cached at
+// audit-approval time (before commit) and not yet evicted after persistence.
+type RequestsCache interface {
+	// IsRequestCached reports whether a token request for the given transaction ID
+	// is currently held in the in-memory cache.
+	IsRequestCached(txID string) bool
+}
+
+// RequestsCacheProvider yields the RequestsCache for a TMS. It is optional: when no
+// provider is wired, the audit-token lookup falls back to IsPending-only gating.
+type RequestsCacheProvider interface {
+	// RequestsCache returns the RequestsCache for the given TMS.
+	RequestsCache(tmsID driver.TMSID) (RequestsCache, error)
+}


### PR DESCRIPTION
Fixes #2176

## Problem

Auditor-side transaction validation (`AuditorCheck` →
`common.RetrieveAuditTokens`, `token/core/common/auditor.go`) can spuriously
fail when a transaction references — as inputs — outputs of a very
recently-audited transaction. The SQL-backed token store returns a hard
`"token not found for key [...]"` the moment a requested output row is
missing, and those rows are only written asynchronously by the finality
listener (`token/services/ttx/finality/listener.go`) once the network reports
the referenced transaction as final. A closely-following transaction can
therefore reach audit validation before those rows are persisted.

See parent issue #2105 for the full analysis of the race.

## Scope of this issue

This tracks **only the cache fast-fail solution** (Suggestion 2 in #2105,
refined in the review on #2140), *not* the retry/backoff mitigation that
landed in #2140.

The idea: `tokens.Service` already maintains an in-memory `RequestsCache`,
populated at audit-approval time (`AuditApproveView.Call`,
`token/services/ttx/auditor.go`, via `CacheRequest`) and removed in
`AppendValid` (`token/services/tokens/tokens.go`). Its lifetime lines up
exactly with the race window, and the cached value is byte-identical to what
the DB read returns (`owner_raw`, `token_type`, `quantity`). Consulting this
cache on a DB miss lets audit validation resolve the in-flight token
**immediately** — fast — instead of relying on a multi-second backoff window
that is unbounded under load and only shrinks (never removes) the failure
probability.

Proposed shape:
- DB read first; consult the `tokens.Service` cache only on a miss.
- Replicate the `auditor = true` filter (`Flags.Auditor`) so a cached entry
  is only used where the DB read would have qualified.
- `token/core/common` cannot import `token/services/tokens` directly, so this
  needs a consumer-side interface plus an adapter wired in the SDK, and
  `tokens.Service` (or a narrow view of it) plumbed into `AuditorService`
  construction for both the fabtoken and zkatdlog drivers — a dependency that
  does not exist in either construction chain today.

## Known limits

The cache is in-process and best-effort (Ristretto's `Set` result is
discarded), so a process restart or a second auditor replica falls straight
through it. This is why the cache is a complement to the backoff, not a
replacement: the backoff remains the outer net for whatever the cache does
not cover.

## Impact

Removes the multi-second latency the backoff adds to the common case (a
just-audited output referenced on the same node), turning a slow retry into
an immediate cache hit, while further reducing the spurious-failure rate for
quickly-chained transactions.