### PR TITLE
identity: secret material (PKCS11 PIN, idemix Sk) and unbounded attacker bytes reach error strings and logs

### DIFF
--- a/token/services/identity/idemix/crypto/config.go
+++ b/token/services/identity/idemix/crypto/config.go
@@ -173,7 +173,7 @@ func NewFabricCAIdemixConfig(issuerPublicKey []byte, dir string) (*Config, error
 func NewConfigFromRaw(issuerPublicKey []byte, configRaw []byte) (*Config, error) {
 	config := &config.IdemixConfig{}
 	if err := proto.Unmarshal(configRaw, config); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal idemix config at [%s]", string(configRaw))
+		return nil, errors.Wrapf(err, "failed to unmarshal idemix config of PK [%s]", utils.Hashable(issuerPublicKey))
 	}
 	// match public keys
 	if !bytes.Equal(issuerPublicKey, config.Ipk) {

--- a/token/services/identity/idemix/crypto/deserializer.go
+++ b/token/services/identity/idemix/crypto/deserializer.go
@@ -11,6 +11,7 @@ import (
 
 	bccsp "github.com/IBM/idemix/bccsp/types"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/idemix/schema"
+	"github.com/LFDT-Panurus/panurus/token/services/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 )
@@ -112,7 +113,7 @@ func (d *Deserializer) DeserializeAgainstNymEID(identity []byte, nymEID []byte) 
 func (d *Deserializer) DeserializeAuditInfo(_ context.Context, raw []byte) (*AuditInfo, error) {
 	ai, err := DeserializeAuditInfo(raw)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed deserializing audit info [%s]", string(raw))
+		return nil, errors.Wrapf(err, "failed deserializing audit info [%s]", utils.Hashable(raw))
 	}
 	ai.Csp = d.Csp
 	ai.IssuerPublicKey = d.IssuerPublicKey

--- a/token/services/identity/idemix/deserializer.go
+++ b/token/services/identity/idemix/deserializer.go
@@ -181,7 +181,7 @@ type AuditInfoDeserializer struct{}
 func (c *AuditInfoDeserializer) DeserializeAuditInfo(ctx context.Context, identity driver.Identity, raw []byte) (driver2.AuditInfo, error) {
 	ai, err := crypto2.DeserializeAuditInfo(raw)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed deserializing audit info [%s]", string(raw))
+		return nil, errors.Wrapf(err, "failed deserializing audit info [%s]", utils.Hashable(raw))
 	}
 
 	return ai, nil

--- a/token/services/identity/idemixnym/deserializer.go
+++ b/token/services/identity/idemixnym/deserializer.go
@@ -14,6 +14,7 @@ import (
 	driver2 "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/idemix"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/idemixnym/nym"
+	"github.com/LFDT-Panurus/panurus/token/services/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
@@ -103,7 +104,7 @@ type AuditInfoDeserializer struct{}
 func (c *AuditInfoDeserializer) DeserializeAuditInfo(ctx context.Context, identity driver.Identity, raw []byte) (driver2.AuditInfo, error) {
 	ai, err := nym.DeserializeAuditInfo(raw)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed deserializing audit info [%s]", string(raw))
+		return nil, errors.Wrapf(err, "failed deserializing audit info [%s]", utils.Hashable(raw))
 	}
 
 	return ai, nil

--- a/token/services/identity/interop/htlc/deserializer.go
+++ b/token/services/identity/interop/htlc/deserializer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	idriver "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
+	"github.com/LFDT-Panurus/panurus/token/services/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
@@ -182,14 +183,14 @@ func (a *AuditDeserializer) DeserializeAuditInfo(ctx context.Context, identity d
 	si := &ScriptInfo{}
 	err = json.Unmarshal(raw, si)
 	if err != nil || (len(si.Sender) == 0 && len(si.Recipient) == 0) {
-		return nil, errors.Errorf("invalid audit info, failed unmarshal [%s][%d][%d]", string(raw), len(si.Sender), len(si.Recipient))
+		return nil, errors.Errorf("invalid audit info, failed unmarshal [%s][%d][%d]", utils.Hashable(raw), len(si.Sender), len(si.Recipient))
 	}
 	if len(si.Recipient) == 0 {
 		return nil, errors.Errorf("no recipient defined")
 	}
 	ai, err := a.AuditInfoDeserializer.DeserializeAuditInfo(ctx, script.Recipient, si.Recipient)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed unmarshalling audit info [%s]", raw)
+		return nil, errors.Wrapf(err, "failed unmarshalling audit info [%s]", utils.Hashable(raw))
 	}
 
 	return ai, nil

--- a/token/services/identity/interop/htlc/validator.go
+++ b/token/services/identity/interop/htlc/validator.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
+	"github.com/LFDT-Panurus/panurus/token/services/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
@@ -87,7 +88,7 @@ func MetadataClaimKeyCheck(action Action, script *htlc.Script, op OperationType,
 	// Unmarshal signature to ClaimSignature
 	claim := &htlc.ClaimSignature{}
 	if err := json.Unmarshal(sig, claim); err != nil {
-		return "", errors.Wrapf(err, "failed unmarshalling claim signature [%s]", string(sig))
+		return "", errors.Wrapf(err, "failed unmarshalling claim signature [%s]", utils.Hashable(sig))
 	}
 	// Check that it is well-formed
 	if len(claim.Preimage) == 0 || len(claim.RecipientSignature) == 0 {

--- a/token/services/identity/x509/crypto/config.go
+++ b/token/services/identity/x509/crypto/config.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package crypto
 
 import (
+	"fmt"
+
 	"github.com/LFDT-Panurus/panurus/token/services/identity/x509/crypto/pkcs11"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/x509/crypto/protos-go/v1/config"
 	"github.com/go-viper/mapstructure/v2"
@@ -73,6 +75,20 @@ type PKCS11 struct {
 type KeyIDMapping struct {
 	SKI string `yaml:"SKI,omitempty"`
 	ID  string `yaml:"ID,omitempty"`
+}
+
+// String renders the PKCS11 configuration for logging with the PIN redacted, so
+// the secret can never reach a log line or error string, even when a *PKCS11 is
+// interpolated directly or as a field of a *BCCSP. It is nil-safe.
+func (p *PKCS11) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+
+	return fmt.Sprintf(
+		"{Security:%d Hash:%s Library:%s Label:%s Pin:[REDACTED] SoftwareVerify:%t Immutable:%t AltID:%s KeyIDs:%v SessionCacheSize:%d}",
+		p.Security, p.Hash, p.Library, p.Label, p.SoftwareVerify, p.Immutable, p.AltID, p.KeyIDs, p.SessionCacheSize,
+	)
 }
 
 // ToBCCSPOpts converts the passed opts to `config.BCCSP`

--- a/token/services/identity/x509/crypto/msp.go
+++ b/token/services/identity/x509/crypto/msp.go
@@ -12,6 +12,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 
+	"github.com/LFDT-Panurus/panurus/token/services/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger/fabric-lib-go/bccsp"
 )
@@ -242,7 +243,7 @@ func (f *IdentityFactory) getCertFromPem(idBytes []byte) (*x509.Certificate, err
 	// Decode the pem bytes
 	pemCert, _ := pem.Decode(idBytes)
 	if pemCert == nil {
-		return nil, errors.Errorf("could not decode pem bytes [%v]", idBytes)
+		return nil, errors.Errorf("could not decode pem bytes [%v]", utils.Hashable(idBytes))
 	}
 
 	// get a cert

--- a/token/services/identity/x509/crypto/pkcs11/disabled.go
+++ b/token/services/identity/x509/crypto/pkcs11/disabled.go
@@ -9,6 +9,8 @@ SPDX-License-Identifier: Apache-2.0
 package pkcs11
 
 import (
+	"fmt"
+
 	"github.com/hyperledger/fabric-lib-go/bccsp"
 )
 
@@ -31,6 +33,15 @@ type PKCS11Opts struct {
 	AltID            string         `yaml:"AltId,omitempty"`
 	KeyIDs           []KeyIDMapping `mapstructure:"KeyIds"             yaml:"KeyIds,omitempty"`
 	SessionCacheSize uint           `yaml:"SessionCacheSize,omitempty"`
+}
+
+// String renders the PKCS11 With redacted Pin,
+// So interpolated (with %v/%s/%+v) doesn't reach a log line.
+func (o PKCS11Opts) String() string {
+	return fmt.Sprintf(
+		"{Security:%d Hash:%s Library:%s Label:%s Pin:[REDACTED] SoftwareVerify:%t Immutable:%t AltID:%s KeyIDs:%v SessionCacheSize:%d}",
+		o.Security, o.Hash, o.Library, o.Label, o.SoftwareVerify, o.Immutable, o.AltID, o.KeyIDs, o.SessionCacheSize,
+	)
 }
 
 func NewProvider(opts any, ks bccsp.KeyStore, mapper func(ski []byte) []byte) (bccsp.BCCSP, error) {

--- a/token/services/identity/x509/crypto/pkcs11/pkcs11.go
+++ b/token/services/identity/x509/crypto/pkcs11/pkcs11.go
@@ -9,6 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package pkcs11
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
@@ -24,15 +25,27 @@ const (
 )
 
 type (
-	PKCS11Opts   = pkcs11.PKCS11Opts
+	// PKCS11Opts is a defined type (not an alias) over the fabric-lib PKCS11
+	// options so it can carry a redacting String().
+	PKCS11Opts   pkcs11.PKCS11Opts
 	KeyIDMapping = pkcs11.KeyIDMapping
 )
 
+// String renders the PKCS11 With redacted Pin,
+// So interpolated (with %v/%s/%+v) doesn't reach a log line.
+func (o PKCS11Opts) String() string {
+	return fmt.Sprintf(
+		"{Security:%d Hash:%s Library:%s Label:%s Pin:[REDACTED] SoftwareVerify:%t Immutable:%t AltID:%s KeyIDs:%v SessionCacheSize:%d}",
+		o.Security, o.Hash, o.Library, o.Label, o.SoftwareVerify, o.Immutable, o.AltID, o.KeyIDs, o.SessionCacheSize,
+	)
+}
+
 // NewProvider returns a pkcs11 provider
 func NewProvider(opts PKCS11Opts, ks bccsp.KeyStore, mapper func(ski []byte) []byte) (*pkcs11.Provider, error) {
-	csp, err := pkcs11.New(opts, ks, pkcs11.WithKeyMapper(mapper))
+	csp, err := pkcs11.New(pkcs11.PKCS11Opts(opts), ks, pkcs11.WithKeyMapper(mapper))
 	if err != nil {
-		return nil, errors.WithMessagef(err, "Failed initializing PKCS11 library with config [%+v]", opts)
+		// opts.String() redacts the PIN, so the secret never reaches the error string.
+		return nil, errors.WithMessagef(err, "Failed initializing PKCS11 library with config [%v]", opts)
 	}
 	return csp, nil
 }

--- a/token/services/identity/x509/crypto/redact_test.go
+++ b/token/services/identity/x509/crypto/redact_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package crypto
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/fabric-lib-go/bccsp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testPIN = "s3cr3t-pin-9999"
+
+// PKCS11.String must redact the PIN and never emit it verbatim, whether the
+// *PKCS11 is logged directly or as a field of a *BCCSP.
+func TestPKCS11_String_RedactsPin(t *testing.T) {
+	p := &PKCS11{Library: "/usr/lib/libpkcs11.so", Label: "tok", Pin: testPIN}
+
+	s := p.String()
+	assert.Contains(t, s, "[REDACTED]")
+	assert.NotContains(t, s, testPIN)
+	// Non-secret fields remain visible for debugging.
+	assert.Contains(t, s, "/usr/lib/libpkcs11.so")
+	assert.Contains(t, s, "tok")
+
+	// %v / %s go through the Stringer as well.
+	assert.NotContains(t, fmt.Sprintf("%s", p), testPIN) //nolint:staticcheck // Explicitly checking fmt.Sprintf
+	assert.NotContains(t, fmt.Sprintf("%+v", p), testPIN)
+}
+
+// A nil *PKCS11 must format without panicking (SW-only configs have a nil PKCS11).
+func TestPKCS11_String_Nil(t *testing.T) {
+	var p *PKCS11
+	assert.NotPanics(t, func() { _ = p.String() })
+	assert.Equal(t, "<nil>", p.String())
+	assert.NotPanics(t, func() { _ = fmt.Sprintf("%v", p) })
+}
+
+// Formatting a *BCCSP (as setup.go and kmp.go do) must redact the nested PKCS11 PIN,
+// and must not panic when the PKCS11 field is nil.
+func TestBCCSP_Format_RedactsPin(t *testing.T) {
+	t.Run("WithPKCS11", func(t *testing.T) {
+		cfg := &BCCSP{Default: "PKCS11", PKCS11: &PKCS11{Label: "tok", Pin: testPIN}}
+		out := fmt.Sprintf("%v", cfg)
+		assert.Contains(t, out, "[REDACTED]")
+		assert.NotContains(t, out, testPIN)
+	})
+	t.Run("NilPKCS11", func(t *testing.T) {
+		cfg := &BCCSP{Default: "SW", SW: &SoftwareProvider{Hash: "SHA2", Security: 256}}
+		assert.NotPanics(t, func() { _ = fmt.Sprintf("%v", cfg) })
+	})
+	t.Run("NilBCCSP", func(t *testing.T) {
+		var cfg *BCCSP
+		assert.NotPanics(t, func() { _ = fmt.Sprintf("%v", cfg) })
+	})
+}
+
+// getIdentityFactory must never mutate the caller's live config and must never panic,
+// across the nil, SW-only, and error paths. Regression test for the pointer-aliasing
+// redaction bug (Issue #2069) that overwrote the real PIN and dereferenced nil.
+func TestGetIdentityFactory_NoMutationNoPanic(t *testing.T) {
+	conf := &Config{CryptoConfig: &CryptoConfig{SignatureHashFamily: bccsp.SHA2}}
+
+	t.Run("NilBccspConfig", func(t *testing.T) {
+		// Default SW provider; nil bccspConfig is a supported, common path.
+		assert.NotPanics(t, func() {
+			_, err := getIdentityFactory(conf, nil, nil)
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("SWOnlyConfigLeavesPinUntouched", func(t *testing.T) {
+		bccspConfig := &BCCSP{
+			Default: "SW",
+			SW:      &SoftwareProvider{Hash: "SHA2", Security: 256},
+			// A PIN may be present even on the SW path; it must survive verbatim.
+			PKCS11: &PKCS11{Label: "tok", Pin: testPIN},
+		}
+
+		_, err := getIdentityFactory(conf, bccspConfig, nil)
+		require.NoError(t, err)
+		assert.Equal(t, testPIN, bccspConfig.PKCS11.Pin, "the caller's live PIN must not be mutated")
+	})
+
+	t.Run("ErrorPathRedactsWithoutMutating", func(t *testing.T) {
+		bccspConfig := &BCCSP{
+			Default: "does-not-exist", // forces GetBCCSPFromConf to return an error
+			PKCS11:  &PKCS11{Label: "tok", Pin: testPIN},
+		}
+
+		_, err := getIdentityFactory(conf, bccspConfig, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "[REDACTED]", "error must show redaction marker")
+		assert.NotContains(t, err.Error(), testPIN, "error must not leak the PIN")
+		assert.Equal(t, testPIN, bccspConfig.PKCS11.Pin, "the caller's live PIN must not be mutated")
+	})
+}


### PR DESCRIPTION
Fixes #2069

### Summary

Several code paths in the identity stack put secret material (PKCS11 PINs, idemix user secret keys)
into error strings or debug logs, and several others echo unbounded attacker-controlled bytes
directly into log/error messages instead of hashing or truncating them — both are logging-hygiene
issues that this tree otherwise avoids (it already uses `utils.Hashable(...)` in several places for
exactly this reason).

### Where

Secret material in errors/logs:
- `token/services/identity/idemix/crypto/config.go:176` — wraps an error with `string(configRaw)`,
  the full serialized `IdemixConfig`, whose `Signer.Sk` field is the idemix user secret key.
- `token/services/identity/x509/crypto/pkcs11/pkcs11.go:35` — logs `opts` directly, where
  `PKCS11Opts` contains a `Pin` field.
- `token/services/identity/x509/crypto/setup.go:64` — logs `bccspConfig`, which embeds `*PKCS11`
  (same `Pin` field).
- `token/services/identity/x509/kmp.go:89` — logs `opts.PKCS11` twice at debug level.

Unbounded attacker-byte echo into logs/errors (should use `utils.Hashable(raw)` or lengths, as done
elsewhere in this tree):
- `token/services/identity/interop/htlc/deserializer.go:172`
- `token/services/identity/interop/htlc/validator.go:90`
- `token/services/identity/idemix/crypto/deserializer.go:115`
- `token/services/identity/idemix/deserializer.go:184`
- `token/services/identity/idemixnym/deserializer.go:106`
- `token/services/identity/x509/crypto/msp.go:245`

### Impact

- PIN/secret-key exposure: if `LogLevel` is set to debug in a deployment (a plausible operational
  choice for troubleshooting), the idemix user secret key or the PKCS11 PIN can land in log files,
  which are frequently shipped to less-trusted aggregation systems than the node itself, or retained
  longer than the credential's intended lifetime.
- Unbounded byte echo: logs/error messages become arbitrarily large under attacker control (a crafted
  large or adversarial identity blob), and error strings containing raw untrusted bytes can pollute
  structured-logging pipelines or make log injection easier.

### Reproduction

Not yet committed. For the secret-exposure items: set debug logging, trigger the corresponding error
path (e.g. malformed idemix config, PKCS11 setup with a bad slot), and grep the resulting log output
for the PIN/secret-key value. For the byte-echo items: pass an oversized or binary-garbage identity
through the affected deserializer/validator and confirm the raw bytes appear verbatim in the emitted
log/error.

### Suggested fix

- For secret-bearing structs, add a custom `String()`/`MarshalLogObject` that redacts `Sk`/`Pin`
  before it's ever passed to a logger or error constructor, or explicitly select only the
  non-secret fields to log (e.g. log `opts.PKCS11.Label`/`.Slot` but never `.Pin`).
- For attacker-controlled byte fields, replace direct interpolation with
  `utils.Hashable(raw)` (already imported and used for this exact purpose elsewhere in this package,
  e.g. `wallet/service.go:115,118`) or log only `len(raw)`.

### Severity

MEDIUM — secret exposure requires debug logging to be enabled; byte-echo is a hygiene/DoS-adjacent
issue rather than directly exploitable, but both are inconsistent with the pattern already used
elsewhere in this codebase.