### PR TITLE
fabtoken: audit path never applies configured resource limits, always falls back to defaults

### DIFF
--- a/token/core/fabtoken/v1/audit/auditor.go
+++ b/token/core/fabtoken/v1/audit/auditor.go
@@ -28,7 +28,11 @@ type ValidateTransferAuditFunc = common.ValidateTransferAuditFunc[*setup.PublicP
 type AuditContext = common.AuditContext[*setup.PublicParams, *actions.IssueAction, *actions.TransferAction, driver.Deserializer]
 
 // ActionDeserializer deserializes fabtoken actions.
-type ActionDeserializer struct{}
+type ActionDeserializer struct {
+	// Limits are the configured resource limits stamped onto each action before
+	// deserialization, so the audit path enforces the same policy as the validator.
+	Limits driver.ResourceLimits
+}
 
 // DeserializeActions deserializes issue and transfer actions from a token request.
 func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*actions.IssueAction, []*actions.TransferAction, error) {
@@ -36,6 +40,7 @@ func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*act
 	issueActions := make([]*actions.IssueAction, len(issues))
 	for i := range issues {
 		ia := &actions.IssueAction{}
+		ia.SetLimits(a.Limits)
 		if err := ia.Deserialize(issues[i]); err != nil {
 			return nil, nil, err
 		}
@@ -46,6 +51,7 @@ func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*act
 	transferActions := make([]*actions.TransferAction, len(transfers))
 	for i := range transfers {
 		ta := &actions.TransferAction{}
+		ta.SetLimits(a.Limits)
 		if err := ta.Deserialize(transfers[i]); err != nil {
 			return nil, nil, err
 		}
@@ -59,7 +65,11 @@ func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*act
 type Auditor = common.Auditor[*setup.PublicParams, *actions.IssueAction, *actions.TransferAction, driver.Deserializer]
 
 // NewAuditor creates a new Auditor for fabtoken validation.
-func NewAuditor(logger logging.Logger, tracer trace.Tracer, deserializer driver.Deserializer, pp *setup.PublicParams, precision uint64) *Auditor {
+//
+// limits are the configured resource limits; they are threaded into the
+// ActionDeserializer and applied to each action before deserialization so the
+// audit path enforces the same policy as the validator (see validator.go).
+func NewAuditor(logger logging.Logger, tracer trace.Tracer, deserializer driver.Deserializer, pp *setup.PublicParams, precision uint64, limits driver.ResourceLimits) *Auditor {
 	issueValidators := []ValidateIssueAuditFunc{
 		IssueAuditValidate(precision),
 	}
@@ -73,7 +83,7 @@ func NewAuditor(logger logging.Logger, tracer trace.Tracer, deserializer driver.
 		tracer,
 		pp,
 		deserializer,
-		&ActionDeserializer{},
+		&ActionDeserializer{Limits: limits},
 		issueValidators,
 		transferValidators,
 	)

--- a/token/core/fabtoken/v1/audit/auditor_limits_test.go
+++ b/token/core/fabtoken/v1/audit/auditor_limits_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package audit
+
+import (
+	"testing"
+
+	protoactions "github.com/LFDT-Panurus/panurus/token/core/fabtoken/protos-go/v1/actions"
+	"github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/actions"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1/request"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/stretchr/testify/require"
+)
+
+// marshalIssueAction builds a serialized fabtoken issue action with the given
+// number of outputs.
+func marshalIssueAction(t *testing.T, outputs int) []byte {
+	t.Helper()
+	ia := &protoactions.IssueAction{
+		Version: actions.ProtocolV1,
+		Issuer:  nil,
+	}
+	for range outputs {
+		ia.Outputs = append(ia.Outputs, &protoactions.IssueActionOutput{Token: &protoactions.Token{Owner: []byte("o"), Type: "TYPE", Quantity: "0x1"}})
+	}
+	raw, err := proto.Marshal(ia)
+	require.NoError(t, err)
+
+	return raw
+}
+
+// marshalTransferAction builds a serialized fabtoken transfer action with the
+// given number of inputs and outputs.
+func marshalTransferAction(t *testing.T, inputs, outputs int) []byte {
+	t.Helper()
+	ta := &protoactions.TransferAction{
+		Version: actions.ProtocolV1,
+	}
+	for range inputs {
+		ta.Inputs = append(ta.Inputs, &protoactions.TransferActionInput{Input: &protoactions.Token{Owner: []byte("o"), Type: "TYPE", Quantity: "0x1"}})
+	}
+	for range outputs {
+		ta.Outputs = append(ta.Outputs, &protoactions.TransferActionOutput{Token: &protoactions.Token{Owner: []byte("o"), Type: "TYPE", Quantity: "0x1"}})
+	}
+	raw, err := proto.Marshal(ta)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func issueRequest(raw []byte) *driver.TokenRequest {
+	return &driver.TokenRequest{
+		Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: raw}},
+	}
+}
+
+func transferRequest(raw []byte) *driver.TokenRequest {
+	return &driver.TokenRequest{
+		Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}},
+	}
+}
+
+// TestActionDeserializer_AppliesConfiguredLimits is a regression test for issue
+// #2028: the audit path must enforce the operator-configured resource limits,
+// not silently fall back to driver.DefaultResourceLimits(). It exercises a limit
+// tighter than the defaults so that a missing SetLimits call (the original bug)
+// would let the oversized action through and fail the test.
+func TestActionDeserializer_AppliesConfiguredLimits(t *testing.T) {
+	custom := driver.DefaultResourceLimits()
+	custom.MaxOutputs = 2
+	custom.MaxInputs = 2
+	d := &ActionDeserializer{Limits: custom}
+
+	t.Run("issue within limit", func(t *testing.T) {
+		_, _, err := d.DeserializeActions(issueRequest(marshalIssueAction(t, 2)))
+		require.NoError(t, err)
+	})
+	t.Run("issue exceeds configured limit", func(t *testing.T) {
+		_, _, err := d.DeserializeActions(issueRequest(marshalIssueAction(t, 3)))
+		require.ErrorIs(t, err, actions.ErrTooManyOutputs)
+	})
+
+	t.Run("transfer within limit", func(t *testing.T) {
+		_, _, err := d.DeserializeActions(transferRequest(marshalTransferAction(t, 2, 2)))
+		require.NoError(t, err)
+	})
+	t.Run("transfer exceeds configured input limit", func(t *testing.T) {
+		_, _, err := d.DeserializeActions(transferRequest(marshalTransferAction(t, 3, 1)))
+		require.ErrorIs(t, err, actions.ErrTooManyInputs)
+	})
+	t.Run("transfer exceeds configured output limit", func(t *testing.T) {
+		_, _, err := d.DeserializeActions(transferRequest(marshalTransferAction(t, 1, 3)))
+		require.ErrorIs(t, err, actions.ErrTooManyOutputs)
+	})
+}

--- a/token/core/fabtoken/v1/auditor.go
+++ b/token/core/fabtoken/v1/auditor.go
@@ -28,6 +28,10 @@ type AuditorService struct {
 	QueryEngine             driver.QueryEngine
 	tracer                  trace.Tracer
 
+	// Limits are the configured resource limits threaded into the auditor so the
+	// audit path enforces the same policy as the validator (issue #2028).
+	Limits driver.ResourceLimits
+
 	// AuditTokensNumRetries and AuditTokensRetryDelay control how AuditorCheck's
 	// token lookup tolerates the pending-transaction read-timing race (issue #2105).
 	// They default to common.DefaultAuditTokensNumRetries / DefaultAuditTokensRetryDelay
@@ -41,6 +45,9 @@ type AuditorService struct {
 // retryConfig sets the audit-token retry/backoff behavior of AuditorCheck; pass
 // common.DefaultAuditRetryConfig() for the built-in defaults or
 // common.LoadAuditRetryConfig(tmsConfig) to honor the per-TMS configuration file.
+//
+// limits are the configured resource limits; they are threaded into the auditor
+// so the audit path enforces the same policy as the validator (issue #2028).
 func NewAuditorService(
 	logger logging.Logger,
 	publicParametersManager common.PublicParametersManager[*setup.PublicParams],
@@ -48,6 +55,7 @@ func NewAuditorService(
 	queryEngine driver.QueryEngine,
 	tracerProvider trace.TracerProvider,
 	retryConfig common.AuditRetryConfig,
+	limits driver.ResourceLimits,
 ) *AuditorService {
 	return &AuditorService{
 		Logger:                  logger,
@@ -57,6 +65,7 @@ func NewAuditorService(
 		tracer:                  tracerProvider.Tracer("auditor_service", tracing.WithMetricsOpts(tracing.MetricsOpts{})),
 		AuditTokensNumRetries:   retryConfig.NumRetries,
 		AuditTokensRetryDelay:   retryConfig.RetryDelay,
+		Limits:                  limits,
 	}
 }
 
@@ -79,7 +88,7 @@ func (s *AuditorService) AuditorCheck(ctx context.Context, request *driver.Token
 	}
 
 	pp := s.PublicParametersManager.PublicParams()
-	auditor := audit.NewAuditor(s.Logger, s.tracer, s.Deserializer, pp, pp.Precision())
+	auditor := audit.NewAuditor(s.Logger, s.tracer, s.Deserializer, pp, pp.Precision(), s.Limits)
 	s.Logger.DebugfContext(ctx, "Start auditor check")
 	err = auditor.Check(
 		ctx,

--- a/token/core/fabtoken/v1/auditor_test.go
+++ b/token/core/fabtoken/v1/auditor_test.go
@@ -112,7 +112,7 @@ func newAuditEnv(benchmarkCase *benchmark2.Case) (*auditEnv, error) {
 	queryEngine := &mockQueryEngine{}
 	tracerProvider := noop.NewTracerProvider()
 
-	as := v1.NewAuditorService(logger, publicParamsManager, deserializer, queryEngine, tracerProvider, common.DefaultAuditRetryConfig())
+	as := v1.NewAuditorService(logger, publicParamsManager, deserializer, queryEngine, tracerProvider, common.DefaultAuditRetryConfig(), driver.DefaultResourceLimits())
 
 	// Create test data structures
 	issueAction := &actions.IssueAction{

--- a/token/core/fabtoken/v1/driver/driver.go
+++ b/token/core/fabtoken/v1/driver/driver.go
@@ -182,7 +182,7 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 		tmsConfig,
 		metrics.NewIssueService(v1.NewIssueService(publicParamsManager, ws, deserializer), metricsProvider),
 		metrics.NewTransferService(v1.NewTransferService(logger, publicParamsManager, ws, common.NewVaultTokenLoader(qe), deserializer), metricsProvider),
-		metrics.NewAuditorService(v1.NewAuditorService(logger, publicParamsManager, deserializer, qe, d.tracerProvider, common.LoadAuditRetryConfig(tmsConfig)), metricsProvider),
+		metrics.NewAuditorService(v1.NewAuditorService(logger, publicParamsManager, deserializer, qe, d.tracerProvider, common.LoadAuditRetryConfig(tmsConfig), limits), metricsProvider),
 		metrics.NewTokensService(tokensService, metricsProvider),
 		metrics.NewTokensUpgradeService(&v1.TokensUpgradeService{}, metricsProvider),
 		authorization,


### PR DESCRIPTION
Fixes #2028

### Summary

The main fabtoken validator applies deployment-configured resource limits (`MaxInputs`, `MaxOutputs`, metadata size caps, etc.) to deserialized actions via `SetLimits(...)` before calling `Deserialize()`. The audit-path deserializer does not — it always falls back to `driver.DefaultResourceLimits()` regardless of what limits the deployment actually configured. This is an inconsistency between the validate and audit code paths: an action that the validator would reject for exceeding configured limits could still be processed by the audit path using looser defaults.

### Where

Main validator wires limits through before deserializing (`token/core/fabtoken/v1/validator/validator.go:32,43`):
```go
ia.SetLimits(a.Limits)
...
ta.SetLimits(a.Limits)
```

The audit path's `ActionDeserializer` never does this (`token/core/fabtoken/v1/audit/auditor.go:34-56`):
```go
func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*actions.IssueAction, []*actions.TransferAction, error) {
	issues := tr.GetIssues()
	issueActions := make([]*actions.IssueAction, len(issues))
	for i := range issues {
		ia := &actions.IssueAction{}
		if err := ia.Deserialize(issues[i]); err != nil {   // no ia.SetLimits(...) call before this
			return nil, nil, err
		}
		issueActions[i] = ia
	}

	transfers := tr.GetTransfers()
	transferActions := make([]*actions.TransferAction, len(transfers))
	for i := range transfers {
		ta := &actions.TransferAction{}
		if err := ta.Deserialize(transfers[i]); err != nil {  // no ta.SetLimits(...) call before this
			return nil, nil, err
		}
		transferActions[i] = ta
	}

	return issueActions, transferActions, nil
}
```

Since `TransferAction.effectiveLimits()`/`IssueAction.effectiveLimits()` fall back to `driver.DefaultResourceLimits()` whenever `SetLimits` was never called, the audit path always enforces the hardcoded defaults, never the deployment's actual configured limits.

### Impact

Wherever the audit path is expected to reject the same class of oversized/abusive actions the validator rejects (excess inputs/outputs, oversized metadata), it currently enforces a different (and potentially looser or stricter) policy than the one operators actually configured — a DoS-protection inconsistency between validation and audit.

### Suggested fix

Thread the configured `driver.ResourceLimits` into `audit.NewAuditor`/`ActionDeserializer` (the same way `validator.go` receives and applies `a.Limits`), and call `ia.SetLimits(...)`/`ta.SetLimits(...)` before `Deserialize()` in `DeserializeActions`.

### Severity

MEDIUM — inconsistent enforcement between validate and audit paths, not itself an authentication/validity bypass.