### PR TITLE
fix(tokengen): inject the public params into the chaincode package

### DIFF
--- a/cmd/tokengen/cobra/pp/cc/cc.go
+++ b/cmd/tokengen/cobra/pp/cc/cc.go
@@ -14,7 +14,9 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/tcc/ccpackage"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/packager"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/packager/replacer"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
@@ -33,21 +35,28 @@ func GeneratePackage(raw []byte, outputDir string) error {
 	}
 
 	err = packager.New().PackageChaincode(
-		"github.com/LFDT-Panurus/panurus/token/services/network/fabric/tcc/main",
+		ccpackage.ChaincodePath,
 		"golang",
 		"tcc",
 		filepath.Join(outputDir, "tcc.tar"),
-		func(s string, s2 string) (string, []byte) {
-			if strings.HasSuffix(s, "github.com/LFDT-Panurus/panurus/token/tcc/params.go") {
-				return "", paramsFile.Bytes()
-			}
-
-			return "", nil
-		},
+		paramsReplacer(paramsFile.Bytes()),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed creating chaincode package")
 	}
 
 	return nil
+}
+
+// paramsReplacer returns the replacer that swaps the public parameters file of
+// the token chaincode with params while it is packaged. The packager passes the
+// absolute path of each file it packages.
+func paramsReplacer(params []byte) replacer.Func {
+	return func(filePath string, fileName string) (string, []byte) {
+		if strings.HasSuffix(filePath, ccpackage.ParamsFileSuffix) {
+			return "", params
+		}
+
+		return "", nil
+	}
 }

--- a/cmd/tokengen/cobra/pp/cc/cc_test.go
+++ b/cmd/tokengen/cobra/pp/cc/cc_test.go
@@ -20,3 +20,27 @@ func TestGeneratePackage(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+// TestParamsReplacer checks that the replacer passed to the chaincode packager
+// swaps the public parameters file, and only that file. The packager hands out
+// the absolute path of each file it packages.
+func TestParamsReplacer(t *testing.T) {
+	params := []byte("package tcc\n\nvar Params = \"cGFyYW1z\"\n")
+	replace := paramsReplacer(params)
+
+	t.Run("replaces_the_params_file", func(t *testing.T) {
+		_, raw := replace(
+			"/home/user/panurus/token/services/network/fabric/tcc/params.go",
+			"src/token/services/network/fabric/tcc/params.go",
+		)
+		assert.Equal(t, params, raw)
+	})
+
+	t.Run("keeps_every_other_file", func(t *testing.T) {
+		_, raw := replace(
+			"/home/user/panurus/token/services/network/fabric/tcc/tcc.go",
+			"src/token/services/network/fabric/tcc/tcc.go",
+		)
+		assert.Nil(t, raw)
+	})
+}

--- a/cmd/tokengen/cobra/pp/cc/params.go
+++ b/cmd/tokengen/cobra/pp/cc/params.go
@@ -6,10 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package cc
 
+import "github.com/LFDT-Panurus/panurus/token/services/network/fabric/tcc/ccpackage"
+
 // DefaultParams defines the template for the public parameters burned into
 // the token chaincode.
-const DefaultParams = `
-package tcc
-
-var Params = "{{ Params }}"
-`
+const DefaultParams = ccpackage.ParamsTemplate

--- a/integration/nwo/token/fabric/cc/params.go
+++ b/integration/nwo/token/fabric/cc/params.go
@@ -6,10 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package cc
 
+import "github.com/LFDT-Panurus/panurus/token/services/network/fabric/tcc/ccpackage"
+
 // DefaultParams defines the template for the public parameters burned into
 // the token chaincode.
-const DefaultParams = `
-package tcc
-
-var Params = "{{ Params }}"
-`
+const DefaultParams = ccpackage.ParamsTemplate

--- a/integration/nwo/token/fabric/cc/tcc.go
+++ b/integration/nwo/token/fabric/cc/tcc.go
@@ -21,6 +21,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/integration/nwo/token/fabric"
 	topology3 "github.com/LFDT-Panurus/panurus/integration/nwo/token/topology"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/tcc/ccpackage"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/packager"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
 	"github.com/onsi/gomega"
@@ -29,8 +30,10 @@ import (
 const (
 	// DefaultTokenChaincode is the default path to the token chaincode.
 	// #nosec G101 no passwords here
-	DefaultTokenChaincode                    = "github.com/LFDT-Panurus/panurus/token/services/network/fabric/tcc/main"
-	DefaultTokenChaincodeParamsReplaceSuffix = "/token/services/network/fabric/tcc/params.go"
+	DefaultTokenChaincode = ccpackage.ChaincodePath
+	// DefaultTokenChaincodeParamsReplaceSuffix is the path suffix of the file
+	// holding the public parameters of the token chaincode.
+	DefaultTokenChaincodeParamsReplaceSuffix = ccpackage.ParamsFileSuffix
 )
 
 var logger = logging.MustGetLogger()

--- a/token/services/network/fabric/tcc/ccpackage/ccpackage.go
+++ b/token/services/network/fabric/tcc/ccpackage/ccpackage.go
@@ -1,0 +1,29 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package ccpackage describes how the public parameters are baked into the
+// token chaincode package. Everything that builds such a package (tokengen and
+// the integration test harness) shares these definitions, so that a move of the
+// chaincode sources cannot silently break one of them.
+package ccpackage
+
+const (
+	// ChaincodePath is the import path of the token chaincode.
+	ChaincodePath = "github.com/LFDT-Panurus/panurus/token/services/network/fabric/tcc/main"
+
+	// ParamsFileSuffix is the path suffix of the source file holding the public
+	// parameters. The packager passes the absolute path of every file it
+	// packages, so this must match the tail of the path of tcc/params.go.
+	ParamsFileSuffix = "/token/services/network/fabric/tcc/params.go"
+
+	// ParamsTemplate is the source of the file that replaces the file matched by
+	// ParamsFileSuffix. It must stay in sync with tcc/params.go.
+	ParamsTemplate = `
+package tcc
+
+var Params = "{{ Params }}"
+`
+)


### PR DESCRIPTION
GeneratePackage matched the suffix

    github.com/LFDT-Panurus/panurus/token/tcc/params.go

but the file holding the public parameters lives at

    token/services/network/fabric/tcc/params.go

(the token/tcc layout is a leftover of the token-sdk move). The packager passes the absolute path of every file it packages, so the replacer never fired and `tokengen ... --cc` produced a package still carrying the placeholder `var Params = ``', i.e. a token chaincode without public parameters.

The integration harness got this right, so the two definitions had silently drifted apart. Move the chaincode import path, the params file suffix and the params template into a single package in the root module, shared by tokengen and by the harness, and use it on both sides.

Cover the replacer with a test that fails on the old suffix.

Fixes #2202