### PR TITLE
fix(identity): avoid nil notifier dereference in LocalMembership.Close

### DIFF
--- a/docs/services/identity.md
+++ b/docs/services/identity.md
@@ -222,6 +222,12 @@ core.TMSProvider.Update            (token/core/tms.go)
                     └── Role.Done() → LocalMembership.Close()
 ```
 
+`LocalMembership.Close()` is best-effort: it releases its key managers, then unsubscribes
+from the identity store's change notifier. If the store cannot supply a notifier — because
+it does not support one (`storage.ErrNotSupported`) or because it fails outright — the
+unsubscribe step is skipped and, in the failure case, logged. `Close()` returns no error and
+must never panic, since it runs on the shutdown path of an already-degraded node.
+
 `role.Registry.Done()` closes wallets through a local `interface{ Close() }` assertion
 rather than through `driver.Wallet`, so wallet types with nothing to release need not
 implement a no-op `Close()`. If you add a wallet type that owns a goroutine, a ticker or

--- a/token/services/identity/membership/lm.go
+++ b/token/services/identity/membership/lm.go
@@ -276,11 +276,11 @@ func (l *LocalMembership) Close() {
 
 		notifier, err := l.identityDB.Notifier()
 		if err != nil {
-			if errors.Is(err, storage.ErrNotSupported) {
-				// notithing to close
-				return
+			if !errors.Is(err, storage.ErrNotSupported) {
+				logger.Errorf("failed to get identity notifier: [%s]", err)
 			}
-			logger.Errorf("failed to get identity notifier: [%s]", err)
+			// no notifier, nothing to close
+			return
 		}
 		if err := notifier.UnsubscribeAll(); err != nil {
 			logger.Errorf("failed to unsubscribe [%s]: [%s]", l.IdentityType, err)

--- a/token/services/identity/membership/lm_discovery_test.go
+++ b/token/services/identity/membership/lm_discovery_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/services/identity/membership/mock"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	"github.com/LFDT-Panurus/panurus/token/services/storage"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -391,4 +392,35 @@ func TestLocalMembership_Close(t *testing.T) {
 
 	// Should be safe to call multiple times
 	lm.Close()
+}
+
+// TestLocalMembership_Close_NotifierError checks that Close does not panic when the
+// identity store fails to return a notifier with an error other than storage.ErrNotSupported.
+// In that case the notifier is nil and must not be used.
+func TestLocalMembership_Close_NotifierError(t *testing.T) {
+	ip := &mock.IdentityProvider{}
+	des := &mock.SignerDeserializerManager{}
+	iss := &mock.IdentityStoreService{}
+	iss.NotifierReturns(nil, errors.New("backend unavailable"))
+
+	kmp := &mock.KeyManagerProvider{}
+
+	lm := membership.NewLocalMembership(
+		logging.MustGetLogger("test"),
+		&mock.Config{},
+		[]byte("netid"),
+		des,
+		iss,
+		"testType",
+		false,
+		ip,
+		kmp,
+	)
+
+	// Load is not called on purpose: a failing Notifier makes Load fail, so Close must be
+	// safe on its own. A nil notifier dereference would panic and fail the test.
+	assert.NotPanics(t, lm.Close)
+
+	// Should be safe to call multiple times
+	assert.NotPanics(t, lm.Close)
 }


### PR DESCRIPTION
Fixes #2067

## What was wrong

When the identity component shuts down, it tries to unhook itself from the storage layer's
**notifier** — the mechanism the store uses to tell it "an identity record just changed".

There are two possible answers to "give me your notifier":

1. *"I don't have one"* (`storage.ErrNotSupported`) — expected, and handled: nothing to unhook.
2. *"Something went wrong"* — a real error. Here the code logged the error and then carried on
   to call `UnsubscribeAll()` on the notifier it never received, i.e. on `nil`. That panics.

The timing is what makes it matter: a storage backend is most likely to fail this call when it
is already unhealthy, so shutdown would crash exactly during an incident — turning an
incomplete-but-clean teardown into a panic.

## The fix

Return on *every* error, not just the expected one. Unexpected errors are still logged; either
way the unsubscribe step is skipped and shutdown completes cleanly. This is the same handling
`subscribeNotifier` already uses on the startup side.

```go
token/services/identity/membership/lm.go, inside Close():

Before — the bug
notifier, err := l.identityDB.Notifier()
if err != nil {
    if errors.Is(err, storage.ErrNotSupported) {
        return                  // ← only THIS error path returns
    }
    logger.Errorf("failed to get identity notifier: [%s]", err)
}                               // ← any other error falls through, notifier == nil
notifier.UnsubscribeAll()       // ← panic

After — the fix
notifier, err := l.identityDB.Notifier()
if err != nil {
    if !errors.Is(err, storage.ErrNotSupported) {
        logger.Errorf("failed to get identity notifier: [%s]", err)
    }
    // no notifier, nothing to close
    return                      // ← now covers EVERY error
}
notifier.UnsubscribeAll()       // ← only reached when notifier is non-nil

The check is inverted so the log is the conditional part and the return is unconditional — same shape subscribeNotifier already uses at lm.go:490.
```

Note `Close()` has no return value, so the error is logged rather than propagated.

## Verification

`TestLocalMembership_Close_NotifierError` mocks the store to return a non-sentinel error and
asserts `Close()` does not panic (twice, to also cover idempotency). It fails with
`invalid memory address or nil pointer dereference` against the old code and passes with the fix.

```
go test ./token/services/identity/membership/... -run TestLocalMembership_Close
```

`make lint-auto-fix` and `make checks` are clean.
