### PR TITLE
tokens: typed.go ASN.1 decoders accept trailing bytes and have no fuzz target

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -111,6 +111,12 @@ jobs:
           - name: storage-sql-table-names
             pkg: ./token/services/storage/db/sql/common
             func: FuzzGetTableNamesNoPanic
+          - name: tokens-typed-token-unmarshal
+            pkg: ./token/services/tokens
+            func: FuzzUnmarshalTypedTokenNoPanic
+          - name: tokens-typed-metadata-unmarshal
+            pkg: ./token/services/tokens
+            func: FuzzUnmarshalTypedMetadataNoPanic
           - name: driver-identity-configuration-unique-id
             pkg: ./token/driver
             func: FuzzIdentityConfigurationUniqueIDInjective

--- a/token/services/tokens/typed.go
+++ b/token/services/tokens/typed.go
@@ -30,9 +30,12 @@ func (i TypedToken) Bytes() ([]byte, error) {
 // UnmarshalTypedToken deserializes an ASN.1 encoded byte slice into a TypedToken structure.
 func UnmarshalTypedToken(token driver.Token) (*TypedToken, error) {
 	si := &TypedToken{}
-	_, err := asn1.Unmarshal(token, si)
+	rest, err := asn1.Unmarshal(token, si)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal to TypedToken")
+	}
+	if len(rest) != 0 {
+		return nil, errors.Errorf("trailing bytes after TypedToken")
 	}
 
 	return si, nil
@@ -64,9 +67,12 @@ func (i TypedMetadata) Bytes() ([]byte, error) {
 // UnmarshalTypedMetadata deserializes an ASN.1 encoded byte slice into a TypedMetadata structure.
 func UnmarshalTypedMetadata(metadata driver.Metadata) (*TypedMetadata, error) {
 	si := &TypedMetadata{}
-	_, err := asn1.Unmarshal(metadata, si)
+	rest, err := asn1.Unmarshal(metadata, si)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal to TypedMetadata")
+	}
+	if len(rest) != 0 {
+		return nil, errors.Errorf("trailing bytes after TypedMetadata")
 	}
 
 	return si, nil

--- a/token/services/tokens/typed_test.go
+++ b/token/services/tokens/typed_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const maxFuzzTypedBytes = 256 << 10
+
 func TestSerialization(t *testing.T) {
 	raw := []byte("pineapple")
 	wrappedToken, err := tokens.WrapWithType(0, raw)
@@ -23,4 +25,85 @@ func TestSerialization(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, driver.Type(0), tok.Type)
 	assert.Equal(t, driver.Token(raw), tok.Token)
+}
+
+// TestUnmarshalTypedTokenRejectsTrailingBytes verifies that a valid encoding
+// with arbitrary junk appended is rejected rather than silently accepted. See
+// issue #2189: ignoring the ASN.1 `rest` slice makes the decoder malleable —
+// two distinct byte strings would otherwise decode to the same object.
+func TestUnmarshalTypedTokenRejectsTrailingBytes(t *testing.T) {
+	valid, err := tokens.WrapWithType(7, driver.Token("payload"))
+	require.NoError(t, err)
+
+	// Sanity: the clean encoding still decodes fine.
+	_, err = tokens.UnmarshalTypedToken(valid)
+	require.NoError(t, err)
+
+	withTrailer := append(append([]byte{}, valid...), 0x00, 0x01, 0x02)
+	got, err := tokens.UnmarshalTypedToken(withTrailer)
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.Contains(t, err.Error(), "trailing bytes")
+}
+
+// TestUnmarshalTypedMetadataRejectsTrailingBytes is the metadata counterpart of
+// TestUnmarshalTypedTokenRejectsTrailingBytes.
+func TestUnmarshalTypedMetadataRejectsTrailingBytes(t *testing.T) {
+	valid, err := tokens.WrapMetadataWithType(7, driver.Metadata("payload"))
+	require.NoError(t, err)
+
+	_, err = tokens.UnmarshalTypedMetadata(valid)
+	require.NoError(t, err)
+
+	withTrailer := append(append([]byte{}, valid...), 0x00, 0x01, 0x02)
+	got, err := tokens.UnmarshalTypedMetadata(withTrailer)
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.Contains(t, err.Error(), "trailing bytes")
+}
+
+// FuzzUnmarshalTypedTokenNoPanic fuzzes UnmarshalTypedToken with arbitrary
+// bytes. This decoder sits on the receive path for untrusted, ledger-stored
+// and peer-supplied token bytes (see issue #2189), so any panic here is an
+// unauthenticated DoS against every caller that reads typed tokens.
+func FuzzUnmarshalTypedTokenNoPanic(f *testing.F) {
+	valid, err := tokens.WrapWithType(7, driver.Token("payload"))
+	require.NoError(f, err)
+
+	f.Add([]byte(valid))
+	f.Add([]byte{})
+	f.Add([]byte("malformed"))
+	f.Add([]byte(valid)[:len(valid)/2])
+	f.Add(append(append([]byte{}, valid...), 0x00, 0x01, 0x02))
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		if len(raw) > maxFuzzTypedBytes {
+			t.Skip()
+		}
+		require.NotPanics(t, func() {
+			_, _ = tokens.UnmarshalTypedToken(raw)
+		})
+	})
+}
+
+// FuzzUnmarshalTypedMetadataNoPanic fuzzes UnmarshalTypedMetadata with
+// arbitrary bytes, for the same reasons as FuzzUnmarshalTypedTokenNoPanic.
+func FuzzUnmarshalTypedMetadataNoPanic(f *testing.F) {
+	valid, err := tokens.WrapMetadataWithType(7, driver.Metadata("payload"))
+	require.NoError(f, err)
+
+	f.Add([]byte(valid))
+	f.Add([]byte{})
+	f.Add([]byte("malformed"))
+	f.Add([]byte(valid)[:len(valid)/2])
+	f.Add(append(append([]byte{}, valid...), 0x00, 0x01, 0x02))
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		if len(raw) > maxFuzzTypedBytes {
+			t.Skip()
+		}
+		require.NotPanics(t, func() {
+			_, _ = tokens.UnmarshalTypedMetadata(raw)
+		})
+	})
 }


### PR DESCRIPTION
Fixes #2189

### Summary
`typed.go`'s ASN.1 decoders discard `asn1.Unmarshal`'s `rest` return value, so any number of trailing bytes appended after a validly-encoded token or metadata payload are silently accepted rather than rejected — the classic ASN.1 malleability pattern: two distinct byte strings decode to the same value. Neither decoder has a `FuzzXxx` target, which AGENTS.md mandates for any exported function that parses untrusted/attacker-controlled bytes; every sibling ASN.1 decoder in the repo (`token/core/common/encoding/asn1`, `token/core/fabtoken/...`, `token/core/zkatdlog/...`) already has one.

### Where
`token/services/tokens/typed.go` — `UnmarshalTypedToken` (~line 31) and `UnmarshalTypedMetadata` (~line 65) each call `asn1.Unmarshal(raw, &typed)` and check only the returned error, ignoring the `rest []byte` return that reports unconsumed trailing bytes.

### Impact
A byte string `X` and `X + arbitrary trailer` are treated as identical tokens/metadata by every caller of these two functions. Depending on where the raw bytes originate (any wire format that carries a typed token/metadata payload), this is a substrate for hash/signature-mismatch or replay-style confusion between two representations that "look the same" to this decoder but differ byte-for-byte.

### Reproduction
```go
valid, _ := tokens.WrapWithType(7, driver.Token("payload"))
withTrailer := append(append([]byte{}, valid...), 0x00, 0x01, 0x02)

want, _ := tokens.UnmarshalTypedToken(valid)
got, err := tokens.UnmarshalTypedToken(withTrailer)

require.NoError(t, err, "trailing bytes after a valid encoding should be rejected, not silently accepted")
require.Equal(t, want, got, "a valid encoding and the same encoding with an arbitrary trailer decode to the same TypedToken")
```
```
=== RUN   TestUnmarshalTypedToken_AcceptsTrailingBytes
--- PASS: TestUnmarshalTypedToken_AcceptsTrailingBytes (0.00s)
=== RUN   TestUnmarshalTypedMetadata_AcceptsTrailingBytes
--- PASS: TestUnmarshalTypedMetadata_AcceptsTrailingBytes (0.00s)
PASS
```
Both tests pass — i.e., the trailing-byte acceptance is confirmed present on current `main`. (A `FuzzUnmarshalTypedTokenNoPanic`/`FuzzUnmarshalTypedMetadataNoPanic` pair, seeded with valid/empty/truncated/valid+trailer inputs, also ran clean for 20s with no panics — the decoders don't crash on malformed input, they just accept more than they should.)

### Severity
Medium — a real ASN.1 malleability bug with no panic/crash component, but no fuzz coverage either, on functions that parse externally-sourced bytes.