### PR TITLE
fix(tokens): always report a failed token delete

### DIFF
--- a/docs/services/tokens.md
+++ b/docs/services/tokens.md
@@ -12,6 +12,15 @@ The internal [Service](../../token/services/tokens/tokens.go) is responsible for
 *   **Lifecycle Monitoring**: Notifying local listeners (via `events.Publisher`) when tokens are added or removed.
 *   **Consistency**: Identifying and removing stale unspent tokens by cross-referencing local storage with the ledger via the [Network Service](../../token/services/network/network.go) (see `PruneInvalidUnspentTokens`).
 
+### Marking Spent Tokens
+
+`DBTransaction.DeleteToken` marks a spent token as deleted. Deletion is *idempotent*: a
+token that is not present in the local store — the ordinary case for inputs that are not
+mine, and for spent identifiers under graph hiding — is not an error, and no delete-token
+event is published for it. A failure reported by the underlying store is always returned,
+regardless of whether the token was found locally, so that a transaction is never recorded
+as processed while its spends were not applied.
+
 
 ## Token Representations
 

--- a/token/services/tokens/storage.go
+++ b/token/services/tokens/storage.go
@@ -135,22 +135,22 @@ func NewTransaction(notifier events.Publisher, tx *tokendb.Transaction, tmsID to
 }
 
 // DeleteToken removes a single token from the database and notifies listeners.
+//
+// Delete is idempotent: marking an unknown token as spent is not an error, so a
+// failure returned by Delete always signals a real storage failure and is
+// propagated even when the token is not present in the local store. Swallowing
+// it there would let a lost spend be recorded as a processed transaction.
 func (t *DBTransaction) DeleteToken(ctx context.Context, tokenID token2.ID, deletedBy string) error {
 	tok, owners, err := t.Tx.GetToken(ctx, tokenID, true)
 	if err != nil {
 		return errors.WithMessagef(err, "failed to get token [%s]", tokenID)
 	}
 
-	err = t.Tx.Delete(ctx, tokenID, deletedBy)
-	if err != nil {
-		if tok == nil {
-			logger.DebugfContext(ctx, "nothing further to delete for [%s]", tokenID)
-
-			return nil
-		}
-
+	if err := t.Tx.Delete(ctx, tokenID, deletedBy); err != nil {
 		return errors.WithMessagef(err, "failed to delete token [%s]", tokenID)
 	}
+
+	// The token is not in the local store, so there are no owners to notify.
 	if tok == nil {
 		logger.DebugfContext(ctx, "nothing further to delete for [%s]", tokenID)
 

--- a/token/services/tokens/storage_test.go
+++ b/token/services/tokens/storage_test.go
@@ -168,6 +168,44 @@ func TestTransaction_DeleteToken_Error(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestTransaction_DeleteToken_DeleteErrorWhenTokenAbsent checks that a Delete
+// failure is reported even when the token is not present in the local store,
+// which is the ordinary case for inputs that are not mine. Swallowing it would
+// let a transaction be recorded as processed while the spend was never applied.
+func TestTransaction_DeleteToken_DeleteErrorWhenTokenAbsent(t *testing.T) {
+	ctx := context.Background()
+	tmsID := token.TMSID{Network: "net", Channel: "ch", Namespace: "ns"}
+	mockTx := &mock.FakeTokenStoreTransaction{}
+
+	tx, err := tokens.NewTransaction(nil, &tokendb.Transaction{TokenStoreTransaction: mockTx}, tmsID)
+	require.NoError(t, err)
+
+	// token absent locally, but Delete hits a genuine storage failure
+	mockTx.GetTokenReturns(nil, nil, nil)
+	mockTx.DeleteReturns(assert.AnError)
+
+	err = tx.DeleteToken(ctx, token2.ID{TxId: "tx1", Index: 0}, "me")
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+// TestTransaction_DeleteToken_AbsentTokenIsNotAnError checks that deleting a
+// token that is not in the local store succeeds without notifying any owner.
+func TestTransaction_DeleteToken_AbsentTokenIsNotAnError(t *testing.T) {
+	ctx := context.Background()
+	tmsID := token.TMSID{Network: "net", Channel: "ch", Namespace: "ns"}
+	mockTx := &mock.FakeTokenStoreTransaction{}
+	pub := &mock.FakePublisher{}
+
+	tx, err := tokens.NewTransaction(pub, &tokendb.Transaction{TokenStoreTransaction: mockTx}, tmsID)
+	require.NoError(t, err)
+
+	mockTx.GetTokenReturns(nil, nil, nil)
+
+	require.NoError(t, tx.DeleteToken(ctx, token2.ID{TxId: "tx1", Index: 0}, "me"))
+	assert.Equal(t, 1, mockTx.DeleteCallCount())
+	assert.Equal(t, 0, pub.PublishCallCount())
+}
+
 func TestTransaction_SetSpendableBySupportedTokenTypes(t *testing.T) {
 	ctx := context.Background()
 	tmsID := token.TMSID{Network: "net", Channel: "ch", Namespace: "ns"}


### PR DESCRIPTION
## Problem

`DBTransaction.DeleteToken` only returned a `Delete` error when the preceding `GetToken`
lookup had found the token locally. `GetToken` returns `(nil, owners, nil)` — no error —
whenever the token is absent from the local store, which is the *ordinary* case: inputs
that are not mine, and under graph hiding, spent identifiers that were never stored
locally. On that common path the genuine `Delete` failure was discarded.

### Why "token absent locally" is the ordinary case

Alice pays Bob. Bob's node commits that transaction and, as part of it, marks the spent
inputs as deleted — including Alice's input. But Bob's database never held Alice's token:
a node only stores tokens that concern it (`Parse` discards outputs that are
`!mine && !auditor && !issuer`, `tokens.go:481-485`), and under graph hiding the spent
identifiers in `toSpend` come straight from the metadata with no ownership filter at all
(`tokens.go:408-412`). So `GetToken` finds nothing, which is entirely normal.

That "nothing found" is not a failure. The pre-fix code, however, used it as grounds to
also ignore a real failure of the *write* that follows.

### Where this sits: the commit path of every transaction

```
network finality event
  └─ finality.Listener.OnStatus                        ttx/finality/listener.go:93
       └─ runOnStatus  (status == Confirmed)           ttx/finality/listener.go:110
            └─ finality.Commit                         ttx/finality/listener.go:142 → :188
                 │
                 ├─ tokens.AppendValid                 listener.go:209 → tokens/tokens.go:97
                 │    ├─ TransactionExists?  no        tokens.go:110
                 │    ├─ getActions → toSpend/toAppend tokens.go:122
                 │    ├─ ContinueTransaction(tx)       tokens.go:129
                 │    ├─ defer: Rollback() **only if err != nil**   tokens.go:133-142
                 │    ├─ AppendToken(new outputs)      tokens.go:146   ✔ applied
                 │    └─ DeleteTokens(spent inputs)    tokens.go:153 → storage.go:169
                 │         └─ DeleteToken(id)          storage.go:143   ← the bug
                 │              ├─ GetToken(id, true) → (nil, nil, nil)
                 │              │     // absent locally: not mine, or graph-hidden
                 │              ├─ Delete(id)         → transient DB error
                 │              │     // dropped conn, lock timeout, ctx deadline
                 │              └─ if tok == nil { return nil }   ← error dropped
                 │         ⇒ DeleteTokens returns nil
                 │    ⇒ AppendValid returns nil  ⇒ deferred Rollback does NOT fire
                 │
                 ├─ tx.SetStatus(txID, Confirmed)      listener.go:216
                 └─ tx.Commit()                        listener.go:222   ⇒ durable
```

Result: the outputs are appended and the transaction is durably recorded as `Confirmed`,
while its inputs were never marked spent. Local state diverges from the ledger and nothing
appears in the logs.

Two details make it consequential:

1. **`AppendValid`'s rollback guard is keyed on its own return value** (`tokens.go:133-142`) —
   the deferred `ts.Rollback()` fires only `if err != nil`. A swallowed delete error means
   `err == nil`, so nothing is rolled back: the appends stay, the spends do not.
2. **`Commit` proceeds** to `SetStatus(..., Confirmed)` and `tx.Commit()` on that same DB
   transaction, making the inconsistent state durable.

The same `Commit` is also reached from the **recovery handler** (`ttx/finality/recovery.go:125`)
that replays transactions after a restart or a missed event. There the loss becomes
permanent rather than retried: `AppendValid`'s early `TransactionExists` check
(`tokens.go:110`) sees the transaction already recorded and skips it.

## Fix

`Delete` is documented and implemented as **idempotent** — marking an unknown token as
spent is a zero-row `UPDATE` (`storage/db/sql/common/tokens.go:1617`), not an error. So any
error it returns is a real storage failure and is now propagated unconditionally. The
`tok == nil` check remains only where it belongs: skipping the delete-token notification,
since there are no local owners to notify.

```go
if err := t.Tx.Delete(ctx, tokenID, deletedBy); err != nil {
    return errors.WithMessagef(err, "failed to delete token [%s]", tokenID)
}

// The token is not in the local store, so there are no owners to notify.
if tok == nil {
    return nil
}
```

With the error propagated, `AppendValid` returns non-nil, its deferred `Rollback()` fires,
and `finality.Commit` aborts before `SetStatus`/`Commit` — so the transaction is left
unconfirmed and is retried instead of being recorded with a lost spend.

## Tests

- `TestTransaction_DeleteToken_DeleteErrorWhenTokenAbsent` — token absent + failing
  `Delete` must surface the error (fails on `main`, passes here).
- `TestTransaction_DeleteToken_AbsentTokenIsNotAnError` — token absent + successful
  `Delete` still succeeds and publishes no event.

`make checks` and `make lint` are clean.

## Docs

`docs/services/tokens.md` gains a **Marking Spent Tokens** section stating the idempotent
delete contract and that store failures always surface.

Fixes #2182
