### PR TITLE
fabtoken: PublicParams.SetAuditors panics on empty identity slice

### DIFF
--- a/cmd/tokengen/cobra/pp/zkatdlognoghv1/update.go
+++ b/cmd/tokengen/cobra/pp/zkatdlognoghv1/update.go
@@ -99,7 +99,9 @@ func Update(args *UpdateArgs) error {
 	// Clear auditor and issuers if provided, and add them again.
 	// If not provided, do not change them.
 	if len(args.Auditors) > 0 {
-		pp.SetAuditors(nil)
+		if err := pp.SetAuditors(nil); err != nil {
+			return errors.Wrapf(err, "failed to clear auditors")
+		}
 	}
 	if len(args.Issuers) > 0 {
 		pp.SetIssuers(nil)

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -1855,7 +1855,7 @@ func PrepareUpdatedPublicParams(network *integration.Infrastructure, auditor str
 		Validate() error
 		Serialize() ([]byte, error)
 		SetIssuers(identities []driver.Identity)
-		SetAuditors(identities []driver.Identity)
+		SetAuditors(identities []driver.Identity) error
 		AddAuditor(identity2 driver.Identity)
 		AddIssuer(identity2 driver.Identity)
 	}
@@ -1876,7 +1876,7 @@ func PrepareUpdatedPublicParams(network *integration.Infrastructure, auditor str
 		pp.AddAuditor(auditorId)
 		pp.AddIssuer(issuerId)
 	} else {
-		pp.SetAuditors([]driver.Identity{auditorId})
+		gomega.Expect(pp.SetAuditors([]driver.Identity{auditorId})).NotTo(gomega.HaveOccurred())
 		pp.SetIssuers([]driver.Identity{issuerId})
 	}
 

--- a/token/core/fabtoken/v1/setup/setup.go
+++ b/token/core/fabtoken/v1/setup/setup.go
@@ -225,9 +225,16 @@ func (p *PublicParams) SetIssuers(ids []driver.Identity) {
 	p.IssuerIDs = ids
 }
 
-// SetAuditors sets the auditors to the passed identities
-func (p *PublicParams) SetAuditors(ids []driver.Identity) {
+// SetAuditors sets the auditor to the first of the passed identities.
+// fabtoken supports a single auditor, so it uses ids[0] and ignores the rest.
+// It returns an error if ids is empty or nil, leaving the current auditor untouched.
+func (p *PublicParams) SetAuditors(ids []driver.Identity) error {
+	if len(ids) == 0 {
+		return errors.New("no auditor identities provided")
+	}
 	p.Auditor = ids[0]
+
+	return nil
 }
 
 // Auditors returns the list of authorized auditors

--- a/token/core/fabtoken/v1/setup/setup_test.go
+++ b/token/core/fabtoken/v1/setup/setup_test.go
@@ -119,7 +119,13 @@ func TestPublicParams_Methods(t *testing.T) {
 
 		// Test SetAuditors
 		newAuditor := driver.Identity([]byte("auditor2"))
-		pp.SetAuditors([]driver.Identity{newAuditor})
+		require.NoError(t, pp.SetAuditors([]driver.Identity{newAuditor}))
+		assert.Equal(t, newAuditor, pp.AuditorIdentity())
+
+		// Test SetAuditors with an empty/nil slice returns an error and leaves
+		// the current auditor untouched (guards against the index-out-of-range panic).
+		require.Error(t, pp.SetAuditors(nil))
+		require.Error(t, pp.SetAuditors([]driver.Identity{}))
 		assert.Equal(t, newAuditor, pp.AuditorIdentity())
 	})
 
@@ -730,7 +736,7 @@ func TestPublicParams_SettersWithMultipleValues(t *testing.T) {
 		[]byte("auditor1"),
 		[]byte("auditor2"),
 	}
-	pp.SetAuditors(auditors)
+	require.NoError(t, pp.SetAuditors(auditors))
 	assert.Equal(t, driver.Identity([]byte("auditor1")), pp.AuditorIdentity())
 	assert.Equal(t, []driver.Identity{driver.Identity([]byte("auditor1"))}, pp.Auditors())
 }

--- a/token/core/zkatdlog/nogh/v1/setup/setup.go
+++ b/token/core/zkatdlog/nogh/v1/setup/setup.go
@@ -620,9 +620,13 @@ func (p *PublicParams) SetIssuers(ids []driver.Identity) {
 	p.IssuerIDs = ids
 }
 
-// SetAuditors sets the auditors to the passed identities
-func (p *PublicParams) SetAuditors(ids []driver.Identity) {
+// SetAuditors sets the auditors to the passed identities.
+// zkatdlog supports a list of auditors, so an empty or nil slice simply clears it.
+// It always returns a nil error; the signature matches the shared setter contract.
+func (p *PublicParams) SetAuditors(ids []driver.Identity) error {
 	p.AuditorIDs = ids
+
+	return nil
 }
 
 func (p *PublicParams) ComputeHash() ([]byte, error) {

--- a/token/core/zkatdlog/nogh/v1/setup/setup_test.go
+++ b/token/core/zkatdlog/nogh/v1/setup/setup_test.go
@@ -289,8 +289,13 @@ func TestPublicParamsModification(t *testing.T) {
 
 	// Test SetAuditors
 	newAuditors := []driver.Identity{driver.Identity("newAuditor")}
-	pp.SetAuditors(newAuditors)
+	require.NoError(t, pp.SetAuditors(newAuditors))
 	assert.Equal(t, newAuditors, pp.Auditors())
+
+	// zkatdlog supports a list of auditors, so an empty/nil slice clears them
+	// without error (unlike fabtoken's single-auditor setter).
+	require.NoError(t, pp.SetAuditors(nil))
+	assert.Empty(t, pp.Auditors())
 
 	// Test AddIssuer
 	issuer1 := driver.Identity("issuer1")


### PR DESCRIPTION
Fixes #2029

### Summary

`PublicParams.SetAuditors` indexes into the passed slice without checking its length, and panics on an empty slice.

### Where

`token/core/fabtoken/v1/setup/setup.go:228-231`:
```go
// SetAuditors sets the auditors to the passed identities
func (p *PublicParams) SetAuditors(ids []driver.Identity) {
	p.Auditor = ids[0]
}
```

Compare with zkatdlog's equivalent (`token/core/zkatdlog/nogh/v1/setup/setup.go:617-620`), which does not index and handles an empty/nil slice safely:
```go
func (p *PublicParams) SetAuditors(ids []driver.Identity) {
	p.AuditorIDs = ids
}
```
(zkatdlog's `update.go` even calls `pp.SetAuditors(nil)` directly — safe there, would panic in fabtoken's version.)

### Reachability

No adversarial or untrusted-input call site specific to fabtoken was found during this review:
- fabtoken's own tokengen path (`cmd/tokengen/cobra/pp/fabtokenv1/gen.go` → `common.SetupIssuersAndAuditors`) builds auditors via `pp.AddAuditor(id)` per certificate, one at a time — it never calls `SetAuditors` at all.
- The only fabtoken call site found is a test helper (`integration/token/fungible/support.go:1707`), which always passes exactly one identity.

So this is currently an internal API-misuse hazard rather than a remotely-exploitable bug — filing for hardening/consistency with zkatdlog's safer implementation, and in case future callers (tooling, migrations, other integrations) pass an empty slice.

### Suggested fix

Add a length check and return an error (or no-op) on an empty slice, or change the field/semantics to support a list of auditors the way zkatdlog does, for consistency across drivers.

### Severity

LOW — no known exploitable call site today; hardening/consistency fix.