### PR TITLE
GitHub Actions and workflow dependencies are not pinned by hash (Scorecard Pinned-Dependencies)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Dependabot configuration
+# =============================================================================
+# WHY THIS FILE EXISTS
+#
+# Every external GitHub Action in .github/workflows/ is pinned to a full-length
+# commit SHA (e.g. actions/checkout@11d5960...) rather than a mutable tag like
+# @v4. SHA pinning is tamper-evident: the upstream owner cannot silently change
+# the code our CI executes by re-pointing a tag. See the OpenSSF Scorecard
+# "Pinned-Dependencies" check for the rationale.
+#
+# The trade-off is that a frozen SHA never picks up upstream fixes on its own.
+# This config closes that gap: Dependabot watches the pinned SHAs and, when a
+# newer release exists, opens a pull request that bumps BOTH the SHA and the
+# trailing "# vX.Y.Z" version comment.
+#
+# HOW UPDATES ARRIVE
+#
+# Nothing is auto-merged. Each update lands as an explicit, reviewable PR:
+#   actions/checkout@<old-sha> # v4.4.0  ->  actions/checkout@<new-sha> # v4.5.0
+# A human reviews the diff and the upstream release notes, then merges. This
+# preserves the security property of pinning (no silent tag-swaps) while still
+# keeping the pins current. The "# vX.Y.Z" comments are what let Dependabot
+# report the precise version each PR moves to, so keep them on every pin.
+#
+# CAVEAT: DCO SIGN-OFF
+#
+# This repo requires DCO sign-off ("Signed-off-by") on every commit, but
+# Dependabot's commits are NOT signed off by default, so its PRs may fail the
+# DCO check. Resolve per PR (the DCO app lets a maintainer mark it off) or
+# configure a bot exception in the DCO app settings. This does not affect the
+# pins themselves — only the merge step.
+#
+# EXTENDING
+#
+# This config only covers the "github-actions" ecosystem. Go module updates are
+# intentionally out of scope: the fabric-smart-client dependency is bumped by
+# the Nightly FSC Update workflow, and adding a "gomod" ecosystem here would
+# open competing PRs against the same go.mod files. Add one only if that
+# workflow is retired.
+# =============================================================================
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # "/" makes Dependabot scan every workflow under .github/workflows/ as well
+    # as any composite action.yml in the repo.
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Collapse routine bumps into a single PR to keep review noise low; a major
+    # version bump (which may carry breaking changes) still gets its own PR.
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+    # Match the repo's conventional-commit style.
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: go
           build-mode: manual
@@ -38,6 +38,6 @@ jobs:
           cd cmd/node && go build -o /dev/null .
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:go"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,17 +36,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
@@ -64,11 +64,11 @@ jobs:
 
       - name: Setup Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: 'site'
 
@@ -82,4 +82,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/md_links.yml
+++ b/.github/workflows/md_links.yml
@@ -15,10 +15,10 @@ jobs:
     name: runner / linkspector
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       
       - name: Run linkspector
-        uses: umbrelladocs/action-linkspector@v1
+        uses: umbrelladocs/action-linkspector@568ec8d29fa92b31fd9ea5381e155c51e922af83 # v1.5.5
         env:
           PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
         with:

--- a/.github/workflows/nightly-fsc.yml
+++ b/.github/workflows/nightly-fsc.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "**/*.sum"
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "**/*.sum"
@@ -70,7 +70,7 @@ jobs:
           ./ci/scripts/filter-coverage.sh profile.cov profile.cov
 
       - name: Send coverage to Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: profile.cov
@@ -145,10 +145,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "**/*.sum"
@@ -178,7 +178,7 @@ jobs:
           ./ci/scripts/filter-coverage.sh coverage.profile coverage.profile
 
       - name: Send coverage to Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coverage.profile
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Finish coverage report
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
@@ -203,10 +203,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "**/*.sum"
@@ -222,10 +222,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "**/*.sum"

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -120,16 +120,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "**/*.sum"
 
       - name: Restore fuzz corpus cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/go-build/fuzz
           key: fuzz-${{ matrix.name }}-${{ github.run_id }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: fuzz-failure-${{ matrix.name }}
           path: fuzz-failure/
@@ -163,7 +163,7 @@ jobs:
 
       - name: File or update GitHub issue
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const name = '${{ matrix.name }}'

--- a/.github/workflows/protect-integration-test-types.yml
+++ b/.github/workflows/protect-integration-test-types.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "integration/go.mod"
           cache-dependency-path: "**/*.sum"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2.4.4
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -44,13 +44,13 @@ jobs:
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "**/*.sum"
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "**/*.sum"
@@ -81,7 +81,7 @@ jobs:
           ./ci/scripts/filter-coverage.sh profile.cov profile.cov
 
       - name: Send coverage to Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: profile.cov
@@ -184,10 +184,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "**/*.sum"
@@ -215,7 +215,7 @@ jobs:
           ./ci/scripts/filter-coverage.sh coverage.profile coverage.profile
 
       - name: Send coverage to Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coverage.profile
@@ -228,7 +228,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Finish coverage report
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
@@ -240,10 +240,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "**/*.sum"
@@ -262,10 +262,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "**/*.sum"

--- a/.github/workflows/token-validation-benchmark.yml
+++ b/.github/workflows/token-validation-benchmark.yml
@@ -114,19 +114,19 @@ jobs:
       PR_FILE: ${{ matrix.bench.file_prefix }}-${{ matrix.variant }}_pr_.txt
     steps:
       - name: Checkout base (${{ github.event.pull_request.base.sha }})
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base
 
       - name: Checkout pr (${{ github.event.pull_request.head.sha }})
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: pr/${{ env.GO_MOD_FILE }}
           cache-dependency-path: "**/*.sum"
@@ -183,7 +183,7 @@ jobs:
           done
 
       - name: Upload raw benchmark output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmark-raw-${{ matrix.bench.id }}-${{ matrix.variant }}
           path: |
@@ -209,17 +209,17 @@ jobs:
       # No ref specified: checks out this workflow's ref (the base repo), NOT the
       # PR head, so the compare script we run is trusted.
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Download raw benchmark outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: benchmark-raw-*
           path: ${{ env.OUTPUT_DIR }}
           merge-multiple: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 mkdocs==1.6.1
 mkdocs-material==9.7.7
 pymdown-extensions>=11.0.1
+
+# Transitive dependency (mkdocs-material -> requests -> idna)
+# idna < 3.15 has a denial-of-service issue (PYSEC-2026-215 / CVE-2024-3651)
+idna>=3.15


### PR DESCRIPTION
Fixes #2220

OpenSSF Scorecard reports **Pinned-Dependencies** findings (severity: medium) across the repository's GitHub Actions workflows. Actions, container images, and script-installed tooling are referenced by mutable tags/branches (e.g. `@v4`, `@main`) or fetched at runtime (`pip install`, `curl | bash`) rather than pinned to an immutable full-length commit SHA.

## Impact
A mutable reference lets the upstream owner (or anyone who compromises their account/registry) change the code executed by our CI without any change on our side. Because these workflows run with repository credentials, a malicious update to an unpinned dependency could exfiltrate secrets or tamper with builds and releases. Pinning to a full commit SHA makes every dependency version explicit and tamper-evident.

## Affected workflows (58 alerts total)
| File | Alerts |
|---|---|
| `.github/workflows/nightly-fsc.yml` | 14 |
| `.github/workflows/tests.yml` | 13 |
| `.github/workflows/token-validation-benchmark.yml` | 8 |
| `.github/workflows/docs.yml` | 8 |
| `.github/workflows/nightly-fuzz.yml` | 5 |
| `.github/workflows/scorecard.yml` | 4 |
| `.github/workflows/codeql-analysis.yml` | 3 |
| `.github/workflows/protect-integration-test-types.yml` | 2 |
| `.github/workflows/md_links.yml` | 2 |

Reported by code scanning (Scorecard) alerts #154–#211.