### PR TITLE
Workflows do not restrict GITHUB_TOKEN permissions (Scorecard Token-Permissions)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: '39 22 * * 5'
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/md_links.yml
+++ b/.github/workflows/md_links.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, feature/evm-network-driver, feature/zkat-snark-driver ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check-links:
     name: runner / linkspector

--- a/.github/workflows/protect-integration-test-types.yml
+++ b/.github/workflows/protect-integration-test-types.yml
@@ -11,6 +11,9 @@ on:
 env:
   GOFLAGS: -mod=mod
 
+permissions:
+  contents: read
+
 jobs:
   guard-all-test-types:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,9 @@ on:
 env:
   GOFLAGS: -mod=mod
 
+permissions:
+  contents: read
+
 jobs:
 
   checks:


### PR DESCRIPTION
Fixes #2219

OpenSSF Scorecard reports a **Token-Permissions** finding (severity: high, score 0) against several GitHub Actions workflows: no top-level `permissions` block is defined, so the `GITHUB_TOKEN` in these workflows runs with the repository/organization default scopes rather than the least privilege each workflow actually needs.

## Impact
Without an explicit least-privilege `permissions` declaration, a compromised action, dependency, or injected step in these workflows would inherit broad write access to the repository (contents, pull requests, issues, packages, etc.). This widens the blast radius of any supply-chain or workflow compromise and keeps the repository's Scorecard security posture below its potential.

## Affected workflows
- `.github/workflows/tests.yml`
- `.github/workflows/protect-integration-test-types.yml`
- `.github/workflows/md_links.yml`
- `.github/workflows/codeql-analysis.yml`

Reported by code scanning (Scorecard) alerts #150, #151, #152, #153.