### PR TITLE
fix: no such transaction ID

### DIFF
--- a/token/services/storage/services/recovery/manager.go
+++ b/token/services/storage/services/recovery/manager.go
@@ -437,9 +437,10 @@ func (m *Manager) recoverTransaction(ctx context.Context, txID string, storedAt 
 //		"rpc error: code = NotFound desc = transaction ID [X]: not found in
 //		  index: tx not found"):
 //
-//	  - "code = NotFound"     — raw gRPC status text
-//	  - "not found in index"  — committer's gRPC status desc field
-//	  - "tx not found"        — FSC finality.TxNotFound sentinel appended
+//	  - "code = NotFound"         — raw gRPC status text
+//	  - "not found in index"      — committer's gRPC status desc field
+//	  - "tx not found"            — FSC finality.TxNotFound sentinel appended
+//	  - "no such transaction ID"  — direct return from fabric in common/ledger/blkstorage/blockindex.go
 //	    by fabric-x ledger.GetTransactionByID
 //	    (fabric-smart-client/platform/fabricx/core/ledger/ledger.go:64).
 //	    Stable across committer error format changes since the sentinel
@@ -455,6 +456,8 @@ func isNotFoundError(err error) bool {
 	case strings.Contains(msg, "not found in index"):
 		return true
 	case strings.Contains(msg, "tx not found"):
+		return true
+	case strings.Contains(msg, "no such transaction ID"):
 		return true
 	}
 

--- a/token/services/storage/services/recovery/manager_test.go
+++ b/token/services/storage/services/recovery/manager_test.go
@@ -408,6 +408,63 @@ func TestManager_StopDuringFanOutDoesNotDeadlock(t *testing.T) {
 	require.NoError(t, manager.Stop())
 }
 
+// TestManager_PromoteOrphanOnNoSuchTransactionID verifies that the
+// "no such transaction ID" error message returned by the Fabric-X ledger
+// (fabric-smart-client/platform/fabricx/core/ledger/ledger.go) is recognised
+// as a NotFound error, so the manager promotes the tx to storage.Orphan after
+// the NotFoundGracePeriod has elapsed.
+func TestManager_PromoteOrphanOnNoSuchTransactionID(t *testing.T) {
+	logger := logging.MustGetLogger()
+	mockDB := &mock2.Storage{}
+	mockHandler := &mock2.Handler{}
+	config := recovery2.Config{
+		Enabled:             true,
+		TTL:                 100 * time.Millisecond,
+		ScanInterval:        100 * time.Millisecond,
+		BatchSize:           100,
+		WorkerCount:         1,
+		LeaseDuration:       time.Second,
+		AdvisoryLockID:      1,
+		InstanceID:          "test-instance",
+		NotFoundGracePeriod: 10 * time.Millisecond,
+	}
+
+	// stored_at well beyond the 10ms grace period so the promotion fires.
+	txRecord := &ttxdb.RecoveryClaim{
+		TxID:     "txNoSuchTx",
+		StoredAt: time.Now().Add(-time.Hour),
+	}
+
+	leadership1 := &mock2.Leadership{}
+	leadership1.CloseReturns(nil)
+	leadership2 := &mock2.Leadership{}
+	leadership2.CloseReturns(nil)
+
+	mockDB.AcquireRecoveryLeadershipReturnsOnCall(0, leadership1, true, nil)
+	mockDB.AcquireRecoveryLeadershipReturns(leadership2, true, nil)
+	mockDB.ClaimPendingTransactionsReturnsOnCall(0, []*ttxdb.RecoveryClaim{txRecord}, nil)
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{}, nil)
+	// Use the Fabric-X ledger sentinel substring directly.
+	mockHandler.RecoverReturns(errors.New("Failed to get transaction with id d48c4, error no such transaction ID [d48c] in index"))
+	mockDB.ReleaseRecoveryClaimReturns(nil)
+	mockDB.SetStatusReturns(nil)
+
+	manager := recovery2.NewManager(logger, mockDB, mockHandler, config)
+
+	require.NoError(t, manager.Start())
+	// Wait for the initial sweep (jitter up to 1s + handler invocation).
+	time.Sleep(1300 * time.Millisecond)
+	_ = manager.Stop()
+
+	require.GreaterOrEqual(t, mockHandler.RecoverCallCount(), 1)
+	require.Equal(t, 1, mockDB.SetStatusCallCount(), "expected exactly one SetStatus call for the orphan promotion")
+
+	_, gotTxID, gotStatus, gotMsg := mockDB.SetStatusArgsForCall(0)
+	assert.Equal(t, "txNoSuchTx", gotTxID)
+	assert.Equal(t, storage.Orphan, gotStatus, "orphan path must promote to storage.Orphan, not storage.Deleted")
+	assert.Contains(t, gotMsg, "tx never reached ledger")
+}
+
 func TestDefaultConfig(t *testing.T) {
 	config := recovery2.DefaultConfig()
 


### PR DESCRIPTION
isNotFoundError function takes 3 possible cases

```
// - "code = NotFound" — raw gRPC status text
// - "not found in index" — committer's gRPC status desc field
// - "tx not found" — FSC finality.TxNotFound sentinel appended
```

But miss 'no such transaction ID' error case

It means that the operation is blocked forever, and never marked as orphan

Fixes #2225 