### PR TITLE
fix: hide password in log error notifier

### DIFF
--- a/token/services/storage/db/sql/postgres/notifier.go
+++ b/token/services/storage/db/sql/postgres/notifier.go
@@ -14,6 +14,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -128,7 +130,7 @@ func NewNotifier(
 		Listener: &pgxlisten.Listener{
 			Connect: func(ctx context.Context) (*pgx.Conn, error) { return pgx.Connect(ctx, dataSource) },
 			LogError: func(ctx context.Context, err error) {
-				logger.Errorf("error encountered in [%s]: %s", dataSource, err.Error())
+				logger.Errorf("error encountered in [%s]: %s", redactDataSource(dataSource), err.Error())
 			},
 			ReconnectDelay: reconnectInterval,
 		},
@@ -488,4 +490,22 @@ func pgChannelName(input string) string {
 	sum := sha256.Sum256([]byte(input))
 
 	return prefix + hex.EncodeToString(sum[:])[:16] // 23 chars total
+}
+
+// redactDataSource removes the password from a PostgreSQL connection string before logging.
+func redactDataSource(dataSource string) string {
+	if strings.HasPrefix(dataSource, "postgres://") || strings.HasPrefix(dataSource, "postgresql://") {
+		if u, err := url.Parse(dataSource); err == nil {
+			if _, pwSet := u.User.Password(); pwSet {
+				u.User = url.UserPassword(u.User.Username(), "xxxxx")
+			}
+
+			return u.String()
+		}
+	}
+	quotedKV := regexp.MustCompile(`password='[^']*'`)
+	dataSource = quotedKV.ReplaceAllLiteralString(dataSource, "password=xxxxx")
+	plainKV := regexp.MustCompile(`password=[^ ]*`)
+
+	return plainKV.ReplaceAllLiteralString(dataSource, "password=xxxxx")
 }

--- a/token/services/storage/db/sql/postgres/notifier_test.go
+++ b/token/services/storage/db/sql/postgres/notifier_test.go
@@ -591,3 +591,65 @@ func TestNotifierGetSchema(t *testing.T) {
 	require.Contains(t, schema, `CREATE OR REPLACE TRIGGER "trigger_public.test_table"`)
 	require.Contains(t, schema, `AFTER INSERT ON public.test_table`)
 }
+
+func TestRedactDataSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// #nosec
+		{
+			name:     "classic URL",
+			input:    "postgres://alice:s3cr3t@localhost:5432/mydb",
+			expected: "postgres://alice:xxxxx@localhost:5432/mydb",
+		},
+		// #nosec
+		{
+			name:     "postgresql scheme with password",
+			input:    "postgresql://bob:hunter2@db.example.com/prod",
+			expected: "postgresql://bob:xxxxx@db.example.com/prod",
+		},
+		{
+			name:     "URL without password",
+			input:    "postgres://alice@localhost:5432/mydb",
+			expected: "postgres://alice@localhost:5432/mydb",
+		},
+		{
+			name:     "URL without user info",
+			input:    "postgres://localhost:5432/mydb",
+			expected: "postgres://localhost:5432/mydb",
+		},
+		{
+			name:     "DSN key=value with quoted password",
+			input:    "host=localhost user=alice password='s3cr3t' dbname=mydb",
+			expected: "host=localhost user=alice password=xxxxx dbname=mydb",
+		},
+		{
+			name:     "DSN key=value with unquoted password",
+			input:    "host=localhost user=alice password=s3cr3t dbname=mydb",
+			expected: "host=localhost user=alice password=xxxxx dbname=mydb",
+		},
+		{
+			name:     "DSN key=value without password",
+			input:    "host=localhost user=alice dbname=mydb",
+			expected: "host=localhost user=alice dbname=mydb",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "DSN with quoted password containing spaces",
+			input:    "host=localhost password='my secret pass' dbname=mydb",
+			expected: "host=localhost password=xxxxx dbname=mydb",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, redactDataSource(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
After EOF error in the notifier, the error log is showing the full data source including the password

```
[31m2026-08-11 19:41:46.428 UTC [fts.services.storage.db.sql.postgres] func2 -> ERRO 15b[0m error encountered in [host=postgresql-XXX port=5432 user=XXX password=XXX dbname=tmsdb sslmode=disable]: waiting for notification: unexpected EOF
```

Fixes #2224 