### PR TITLE
fix(evm): ten bugs from a self-review pass over the network driver

### DIFF
--- a/x/token/services/network/evm/config.go
+++ b/x/token/services/network/evm/config.go
@@ -131,8 +131,10 @@ type EndorsementConfig struct {
 	// Threshold is the number of distinct endorser signatures a transaction needs. It must match the
 	// threshold the EndorsementVerifier was constructed with.
 	Threshold uint `yaml:"threshold"`
-	// Allowlist is the FSC identities permitted to request endorsement. Empty means the policy is
-	// resolved from the TMS network's nodes at wiring time.
+	// Allowlist is the FSC identities permitted to request endorsement. It is fail-closed: when this
+	// node is configured to endorse, an empty allowlist is a validation error rather than a default
+	// that resolves to anyone. There is no automatic "the TMS network's nodes" fallback; every
+	// permitted requester has to be named.
 	Allowlist []string `yaml:"allowlist"`
 	// Endorsers binds each endorser's Ethereum address to its FSC identity.
 	Endorsers []EndorserBinding `yaml:"endorsers"`
@@ -277,6 +279,13 @@ func (c *Config) validateEndorsement() error {
 		}
 		if _, err := client.HexToAddress(c.Endorser.Address); err != nil {
 			return errors.Wrap(err, "evm config: invalid endorser address")
+		}
+		// The authorizer is deliberately fail-closed: it refuses to build from an empty allowlist
+		// rather than default to trusting everyone. Catching that here means a node left this way
+		// fails at startup rather than coming up looking healthy and silently never registering as an
+		// endorser, which is where this used to surface, as an error log easy to miss during wiring.
+		if len(c.Endorsement.Allowlist) == 0 {
+			return errors.New("evm config: endorsement.allowlist is required when endorser.enabled is set")
 		}
 	}
 

--- a/x/token/services/network/evm/config.go
+++ b/x/token/services/network/evm/config.go
@@ -27,7 +27,16 @@ const (
 	// DefaultPollInterval is how often finality polls a transaction's status.
 	DefaultPollInterval = 2 * time.Second
 	// DefaultFinalityTimeout bounds how long a transaction is awaited before it is treated as failed.
-	DefaultFinalityTimeout = 5 * time.Minute
+	// It carries real margin over MinFinalizedTagTimeout (design §7.2, §7.5) so a deployment running
+	// on defaults alone is not sitting at the edge of normal PoS finalization variance.
+	DefaultFinalityTimeout = 20 * time.Minute
+	// MinFinalizedTagTimeout is the floor Validate enforces on Finality.Timeout when BlockTag is
+	// finalized. Real time-to-finality on a PoS chain is ~13 minutes (design §7.2); a shorter timeout
+	// cannot ever see a transaction finalize and condemns it regardless of whether it succeeded (design
+	// §7.5: "any deployment must configure finality.timeout above ... the chain's finality"). It bounds
+	// only the chain's own lag; a deployment that also delays broadcasting a signed transaction needs
+	// additional headroom on top of this, which Validate has no way to know and cannot enforce.
+	MinFinalizedTagTimeout = 13 * time.Minute
 	// DefaultGasMultiplier scales the node's gas estimate to absorb small state changes between
 	// estimation and execution.
 	DefaultGasMultiplier = 1.2
@@ -198,6 +207,13 @@ func (c *Config) Validate() error {
 	case client.BlockTagFinalized, client.BlockTagSafe, client.BlockTagLatest:
 	default:
 		return errors.Errorf("evm config: unsupported finality blockTag [%s]", c.Finality.BlockTag)
+	}
+	if c.Finality.BlockTag == client.BlockTagFinalized && c.Finality.Timeout < MinFinalizedTagTimeout {
+		return errors.Errorf(
+			"evm config: finality.timeout [%s] is shorter than the finalized tag's own time-to-finality "+
+				"(~%s); it would condemn every transaction regardless of whether it succeeded",
+			c.Finality.Timeout, MinFinalizedTagTimeout,
+		)
 	}
 	if err := c.validateGas(); err != nil {
 		return err

--- a/x/token/services/network/evm/config.go
+++ b/x/token/services/network/evm/config.go
@@ -80,7 +80,8 @@ type ContractsConfig struct {
 
 // FinalityConfig controls how transaction finality is observed.
 type FinalityConfig struct {
-	// BlockTag is the tag state is read at (finalized or safe).
+	// BlockTag is the tag state is read at: finalized (default, no reorg risk), safe, or latest (no
+	// reorg protection at all; only appropriate for a local, instant-mining chain).
 	BlockTag string `yaml:"blockTag"`
 	// PollInterval is the delay between status polls.
 	PollInterval time.Duration `yaml:"pollInterval"`

--- a/x/token/services/network/evm/config_test.go
+++ b/x/token/services/network/evm/config_test.go
@@ -218,6 +218,9 @@ func TestConfigValidationRejectsBadDocuments(t *testing.T) {
 		},
 		"enabled endorser without address": func(c *Config) { c.Endorser.Address = "" },
 		"enabled endorser bad address":     func(c *Config) { c.Endorser.Address = "nope" },
+		"enabled endorser without allowlist": func(c *Config) {
+			c.Endorsement.Allowlist = nil
+		},
 	}
 	for name, mutate := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/x/token/services/network/evm/config_test.go
+++ b/x/token/services/network/evm/config_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
 )
 
 // yamlConfiguration is a Configuration backed by a real YAML document, so the tests exercise the
@@ -92,7 +94,7 @@ services:
       finality:
         blockTag: finalized
         pollInterval: 2s
-        timeout: 5m
+        timeout: 15m
       gas:
         strategy: estimate
         multiplier: 1.5
@@ -123,7 +125,7 @@ func TestLoadConfigFullDocument(t *testing.T) {
 	assert.Equal(t, int64(31337), c.ChainIDBig().Int64())
 	assert.Equal(t, "finalized", c.Finality.BlockTag)
 	assert.Equal(t, 2*time.Second, c.Finality.PollInterval)
-	assert.Equal(t, 5*time.Minute, c.Finality.Timeout)
+	assert.Equal(t, 15*time.Minute, c.Finality.Timeout)
 	assert.InEpsilon(t, 1.5, c.Gas.Multiplier, 1e-9)
 	assert.True(t, c.Endorser.Enabled)
 	assert.Equal(t, uint(2), c.Endorsement.Threshold)
@@ -190,13 +192,17 @@ func TestConfigValidationRejectsBadDocuments(t *testing.T) {
 	}
 
 	cases := map[string]func(*Config){
-		"empty endpoint":          func(c *Config) { c.Endpoint = "" },
-		"zero chain id":           func(c *Config) { c.ChainID = 0 },
-		"negative chain id":       func(c *Config) { c.ChainID = -1 },
-		"missing token state":     func(c *Config) { c.Contracts.TokenState = "" },
-		"malformed token state":   func(c *Config) { c.Contracts.TokenState = "0xdeadbeef" },
-		"malformed verifier":      func(c *Config) { c.Contracts.EndorsementVerifier = "not-an-address" },
-		"unsupported block tag":   func(c *Config) { c.Finality.BlockTag = "pending" },
+		"empty endpoint":        func(c *Config) { c.Endpoint = "" },
+		"zero chain id":         func(c *Config) { c.ChainID = 0 },
+		"negative chain id":     func(c *Config) { c.ChainID = -1 },
+		"missing token state":   func(c *Config) { c.Contracts.TokenState = "" },
+		"malformed token state": func(c *Config) { c.Contracts.TokenState = "0xdeadbeef" },
+		"malformed verifier":    func(c *Config) { c.Contracts.EndorsementVerifier = "not-an-address" },
+		"unsupported block tag": func(c *Config) { c.Finality.BlockTag = "pending" },
+		"finalized timeout shorter than real finality": func(c *Config) {
+			c.Finality.BlockTag = client.BlockTagFinalized
+			c.Finality.Timeout = MinFinalizedTagTimeout - time.Second
+		},
 		"unknown gas strategy":    func(c *Config) { c.Gas.Strategy = "guess" },
 		"multiplier below one":    func(c *Config) { c.Gas.Multiplier = 0.5 },
 		"fixed gas without limit": func(c *Config) { c.Gas.Strategy = GasStrategyFixed; c.Gas.Limit = 0 },
@@ -229,6 +235,33 @@ func TestFixedGasStrategyIsValid(t *testing.T) {
 	c.Gas.Strategy = GasStrategyFixed
 	c.Gas.Limit = 500_000
 	require.NoError(t, c.Validate())
+}
+
+// TestFinalizedTagRequiresLongEnoughTimeout pins the fix for the bug where the shipped default paired
+// the finalized tag with a timeout shorter than real PoS finality: a deployment running on defaults
+// alone would time out and report every transaction Invalid, whether or not it actually succeeded.
+// The floor applies only to the finalized tag; safe and latest resolve on their own faster schedules,
+// so a short timeout there is a legitimate choice, not a misconfiguration Validate can detect.
+func TestFinalizedTagRequiresLongEnoughTimeout(t *testing.T) {
+	c, err := LoadConfig(newYAMLConfiguration(t, fullConfigYAML))
+	require.NoError(t, err)
+
+	c.Finality.BlockTag = client.BlockTagFinalized
+	c.Finality.Timeout = MinFinalizedTagTimeout - time.Second
+	require.Error(t, c.Validate())
+
+	c.Finality.Timeout = MinFinalizedTagTimeout
+	require.NoError(t, c.Validate(), "the floor itself must be accepted")
+
+	c.Finality.BlockTag = client.BlockTagLatest
+	c.Finality.Timeout = time.Second
+	require.NoError(t, c.Validate(), "the floor must not apply to a tag it was not measured for")
+}
+
+// TestDefaultFinalityTimeoutClearsItsOwnFloor checks the shipped default is internally consistent: it
+// must satisfy MinFinalizedTagTimeout, since DefaultBlockTag is finalized.
+func TestDefaultFinalityTimeoutClearsItsOwnFloor(t *testing.T) {
+	assert.GreaterOrEqual(t, DefaultFinalityTimeout, MinFinalizedTagTimeout)
 }
 
 // TestThresholdEqualToSetSizeIsValid checks the boundary: an N-of-N policy is legitimate.

--- a/x/token/services/network/evm/driver.go
+++ b/x/token/services/network/evm/driver.go
@@ -300,6 +300,11 @@ func (d *Driver) installEndorsement(n *Network, config *Config, evmClient client
 		// one is evicted and rebuilt whenever public parameters change.
 		return factory.ForTMS(tms.ID())
 	})
+	// SetupPublicParams goes through this instead: it may run before any management service exists for
+	// the TMS (first-time setup), so it only ever has the id, never the wrapper above requires.
+	n.SetEndorsementFactoryByID(func(tmsID token2.TMSID) (EndorsementService, error) {
+		return factory.ForTMS(tmsID)
+	})
 
 	// Registration happens now, not on the first approval. An endorser node answers requests without
 	// ever making one, so registering lazily on the approval path would mean it never registers at

--- a/x/token/services/network/evm/driver.go
+++ b/x/token/services/network/evm/driver.go
@@ -81,8 +81,11 @@ type Driver struct {
 	auditStores     auditdb.StoreServiceManager
 	metricsProvider metrics.Provider
 	recoveryTracer  trace.Tracer
-	// registerOnce guards the responder registration, which is per node rather than per network.
-	registerOnce sync.Once
+	// registerMu guards registeredFor: this node can register only one FSC-level endorsement responder
+	// for its whole lifetime (see registerEndorser), so a second, different network trying to claim it
+	// needs to be detected rather than silently discarded.
+	registerMu    sync.Mutex
+	registeredFor string
 	// watchers keeps one public-parameters watcher per network, so building a network twice does not
 	// leave two pollers on one contract.
 	watchersMu sync.Mutex
@@ -162,7 +165,7 @@ func (d *Driver) New(network, channel string) (driver.Network, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := d.installEndorsement(n, config, evmClient); err != nil {
+	if err := d.installEndorsement(n, config, evmClient, network, channel); err != nil {
 		return nil, err
 	}
 	d.watchPublicParams(network, channel, config, evmClient)
@@ -260,7 +263,7 @@ func (d *Driver) applyPublicParams(ctx context.Context, tmsIDs []token2.TMSID, r
 // installEndorsement builds the endorsement seam for this network and hands it to the network. The
 // service itself is per TMS, because it needs that TMS's validator, so what is installed is a factory
 // that resolves one when the network is given a TMS to approve for.
-func (d *Driver) installEndorsement(n *Network, config *Config, evmClient client.EVMClient) error {
+func (d *Driver) installEndorsement(n *Network, config *Config, evmClient client.EVMClient, network, channel string) error {
 	if d.viewManager == nil {
 		logger.Debugf("no view manager available; this node cannot collect endorsements")
 
@@ -309,7 +312,7 @@ func (d *Driver) installEndorsement(n *Network, config *Config, evmClient client
 	// Registration happens now, not on the first approval. An endorser node answers requests without
 	// ever making one, so registering lazily on the approval path would mean it never registers at
 	// all and every request to it times out.
-	d.registerEndorser(factory, config)
+	d.registerEndorser(network+":"+channel, factory, config)
 
 	return nil
 }
@@ -338,44 +341,66 @@ func (d *Driver) newSubmitter(config *Config, evmClient client.EVMClient) (*Subm
 // registerEndorser registers this node's responder so it can answer requests. A node that does not
 // endorse has no key and registers nothing.
 //
+// The registration is per node, not per network, because FSC routes an incoming session to a
+// responder by the initiating view's Go type alone: it has no notion of "this responder, but only for
+// network X". So only one Responder can ever be registered for endorsement.Initiator across this
+// process's whole lifetime, and whichever network happens to build it first has its factory, EIP-712
+// domain and chain client baked into it permanently. A second, differently configured network trying
+// to endorse through the same registration would validate against the right TMS but sign and read
+// against the wrong chain, so it is refused loudly here instead of silently discarded: an operator who
+// configures two endorsing networks on one node needs to see why the second one never answers.
+//
 // The TMS is resolved when a request arrives rather than now: resolving one here would ask the token
 // layer for a service that is still being built through this very driver.
-func (d *Driver) registerEndorser(factory *endorsement.ServiceFactory, config *Config) {
-	d.registerOnce.Do(func() {
-		if d.viewRegistry == nil || !config.Endorser.Enabled {
-			return
-		}
-		signer, err := config.EndorserSigner()
-		if err != nil || signer == nil {
-			logger.Errorf("this node is configured as an endorser but its key is unusable: %v", err)
+func (d *Driver) registerEndorser(networkKey string, factory *endorsement.ServiceFactory, config *Config) {
+	if d.viewRegistry == nil || !config.Endorser.Enabled {
+		return
+	}
 
-			return
+	d.registerMu.Lock()
+	defer d.registerMu.Unlock()
+	if d.registeredFor != "" {
+		if d.registeredFor != networkKey {
+			logger.Errorf(
+				"[%s] is configured to endorse, but this node is already registered as the endorser for [%s]; "+
+					"one node can endorse for only one EVM network at a time, [%s] will not answer endorsement requests",
+				networkKey, d.registeredFor, networkKey)
 		}
-		allowed, err := config.AllowedRequesters(d.resolveIdentity)
-		if err != nil {
-			logger.Errorf("failed to resolve the endorsement allowlist: %v", err)
 
-			return
-		}
-		authorizer, err := endorsement.NewAuthorizer(allowed)
-		if err != nil {
-			logger.Errorf("failed to build the endorsement allowlist: %v", err)
+		return
+	}
 
-			return
-		}
-		responder, err := factory.NewResponder(authorizer, signer, d.resolveTMS)
-		if err != nil {
-			logger.Errorf("failed to build the endorsement responder: %v", err)
+	signer, err := config.EndorserSigner()
+	if err != nil || signer == nil {
+		logger.Errorf("this node is configured as an endorser but its key is unusable: %v", err)
 
-			return
-		}
-		if err := endorsement.RegisterEndorser(d.viewRegistry, responder); err != nil {
-			logger.Errorf("failed to register the endorsement responder: %v", err)
+		return
+	}
+	allowed, err := config.AllowedRequesters(d.resolveIdentity)
+	if err != nil {
+		logger.Errorf("failed to resolve the endorsement allowlist: %v", err)
 
-			return
-		}
-		logger.Infof("registered as an endorser with address %s", signer.Address())
-	})
+		return
+	}
+	authorizer, err := endorsement.NewAuthorizer(allowed)
+	if err != nil {
+		logger.Errorf("failed to build the endorsement allowlist: %v", err)
+
+		return
+	}
+	responder, err := factory.NewResponder(authorizer, signer, d.resolveTMS)
+	if err != nil {
+		logger.Errorf("failed to build the endorsement responder: %v", err)
+
+		return
+	}
+	if err := endorsement.RegisterEndorser(d.viewRegistry, responder); err != nil {
+		logger.Errorf("failed to register the endorsement responder: %v", err)
+
+		return
+	}
+	d.registeredFor = networkKey
+	logger.Infof("registered as the endorser for [%s] with address %s", networkKey, signer.Address())
 }
 
 // resolveIdentity turns a configured node name into the identity that node speaks with.

--- a/x/token/services/network/evm/driver.go
+++ b/x/token/services/network/evm/driver.go
@@ -208,8 +208,8 @@ func (d *Driver) watchPublicParams(network, channel string, config *Config, evmC
 
 	watcher, err := pp.NewWatcher(
 		evmClient, tokenState, config.Finality.BlockTag, config.Finality.PollInterval,
-		func(ctx context.Context, raw []byte, version uint64) {
-			d.applyPublicParams(ctx, tmsIDs, raw, version)
+		func(ctx context.Context, raw []byte, version uint64) error {
+			return d.applyPublicParams(ctx, tmsIDs, raw, version)
 		},
 	)
 	if err != nil {
@@ -224,10 +224,17 @@ func (d *Driver) watchPublicParams(network, channel string, config *Config, evmC
 // applyPublicParams reloads every TMS on the network with the new parameters and persists them. A
 // failure for one TMS does not stop the others: they are independent, and a node serving stale
 // parameters for one is better than for all of them.
-func (d *Driver) applyPublicParams(ctx context.Context, tmsIDs []token2.TMSID, raw []byte, version uint64) {
+//
+// It returns the combined error of every TMS that failed, if any, so the watcher knows this version
+// was not fully applied and retries it rather than treating it as handled. Retrying is safe: Update is
+// a no-op when the parameters it is given already match the TMS's current ones, so a TMS that already
+// succeeded is not disturbed by a retry covering the whole batch.
+func (d *Driver) applyPublicParams(ctx context.Context, tmsIDs []token2.TMSID, raw []byte, version uint64) error {
+	var errs []error
 	for _, tmsID := range tmsIDs {
 		if err := d.tmsProvider.Update(tmsID, raw); err != nil {
 			logger.Warnf("failed to update tms [%s] to public parameters version %d: %v", tmsID, version, err)
+			errs = append(errs, errors.Wrapf(err, "tms [%s]", tmsID))
 
 			continue
 		}
@@ -237,13 +244,17 @@ func (d *Driver) applyPublicParams(ctx context.Context, tmsIDs []token2.TMSID, r
 		service, err := d.tokensManager.ServiceByTMSId(tmsID)
 		if err != nil {
 			logger.Warnf("failed to get the token store for [%s]: %v", tmsID, err)
+			errs = append(errs, errors.Wrapf(err, "tms [%s]", tmsID))
 
 			continue
 		}
 		if err := service.StorePublicParams(ctx, raw); err != nil {
 			logger.Warnf("failed to store public parameters for [%s]: %v", tmsID, err)
+			errs = append(errs, errors.Wrapf(err, "tms [%s]", tmsID))
 		}
 	}
+
+	return errors.Join(errs...)
 }
 
 // installEndorsement builds the endorsement seam for this network and hands it to the network. The

--- a/x/token/services/network/evm/driver_test.go
+++ b/x/token/services/network/evm/driver_test.go
@@ -7,14 +7,20 @@ SPDX-License-Identifier: Apache-2.0
 package evm
 
 import (
+	"context"
 	"testing"
 
 	token2 "github.com/LFDT-Panurus/panurus/token"
 	"github.com/LFDT-Panurus/panurus/token/services/config"
 	"github.com/LFDT-Panurus/panurus/token/services/network/driver"
 	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client/mock"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/eip712"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/endorsement"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/pp"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	svcview "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -110,4 +116,132 @@ func TestNetworkRejectsMalformedTransactionID(t *testing.T) {
 
 	err = n.AddFinalityListener("token", "not-a-valid-anchor", nil)
 	require.Error(t, err)
+}
+
+// --- registerEndorser ------------------------------------------------------------------------------
+
+// fakeViewRegistry records every RegisterResponder call, so a test can tell whether a second
+// registration attempt actually reached FSC or was refused before getting there.
+type fakeViewRegistry struct {
+	calls int
+}
+
+func (f *fakeViewRegistry) RegisterResponder(view.View, any) error {
+	f.calls++
+
+	return nil
+}
+
+// fakeViewManager satisfies endorsement.ViewManager without ever running a view; registerEndorser
+// itself never calls InitiateView, only Service.Endorse does.
+type fakeViewManager struct{}
+
+func (fakeViewManager) InitiateView(context.Context, view.View) (any, error) { return nil, nil }
+
+// fakeIdentityProvider resolves every name to an identity carrying the same bytes, so
+// config.AllowedRequesters can turn the allowlist's names into identities the way d.resolveIdentity
+// does in production.
+type fakeIdentityProvider struct{}
+
+func (fakeIdentityProvider) Identity(name string) view.Identity { return view.Identity(name) }
+func (fakeIdentityProvider) DefaultIdentity() view.Identity     { return view.Identity("default") }
+
+var _ svcview.IdentityProvider = fakeIdentityProvider{}
+
+// endorserConfig returns a configuration for a node that endorses, backed by the well-known test key
+// keystore_test.go already writes, whose address matches validConfig's single endorser entry.
+func endorserConfig(t *testing.T) *Config {
+	t.Helper()
+	c := validConfig()
+	c.Endorser = EndorserConfig{
+		Enabled:  true,
+		Keystore: writeKey(t, testKeyHex),
+		Address:  testKeyAddress,
+	}
+	c.Endorsement.Allowlist = []string{"endorser-1"}
+
+	return c
+}
+
+// testServiceFactory builds a real *endorsement.ServiceFactory over config, the same shape
+// installEndorsement assembles, so registerEndorser is exercised with the collaborator it actually
+// gets in production.
+func testServiceFactory(t *testing.T, config *Config) *endorsement.ServiceFactory {
+	t.Helper()
+	registry, err := config.EndorserRegistry(func(name string) (view.Identity, error) {
+		return view.Identity(name), nil
+	})
+	require.NoError(t, err)
+	tokenState, err := config.TokenStateAddress()
+	require.NoError(t, err)
+	evmClient := &mock.EVMClient{}
+
+	factory, err := endorsement.NewServiceFactory(endorsement.FactoryConfig{
+		Registry:     registry,
+		Threshold:    int(config.Endorsement.Threshold),
+		Domain:       eip712.Domain{ChainID: config.ChainIDBig(), VerifyingContract: tokenState},
+		Client:       evmClient,
+		TokenState:   tokenState,
+		BlockTag:     config.Finality.BlockTag,
+		PublicParams: pp.NewChainProvider(evmClient, tokenState, config.Finality.BlockTag),
+		ViewManager:  fakeViewManager{},
+		TMS: func(token2.TMSID) (*token2.ManagementService, error) {
+			return nil, errors.New("not needed for this test")
+		},
+	})
+	require.NoError(t, err)
+
+	return factory
+}
+
+// TestRegisterEndorserRefusesASecondNetwork is the fix for a real bug. FSC registers a responder by
+// the initiating view's Go type alone, so only one Responder can ever be registered for
+// endorsement.Initiator across this node's whole process lifetime. Before this fix a sync.Once
+// silently discarded every network after the first one that reached registerEndorser, with no signal
+// at all that a second, differently configured network's endorsement requests would never be
+// answered, or worse, would be answered through the wrong network's chain client and EIP-712 domain.
+func TestRegisterEndorserRefusesASecondNetwork(t *testing.T) {
+	registry := &fakeViewRegistry{}
+	d := &Driver{viewRegistry: registry, identities: fakeIdentityProvider{}}
+	config := endorserConfig(t)
+	factory := testServiceFactory(t, config)
+
+	d.registerEndorser("network-a:", factory, config)
+	assert.Equal(t, 1, registry.calls, "the first network must register")
+	assert.Equal(t, "network-a:", d.registeredFor)
+
+	d.registerEndorser("network-b:", factory, config)
+	assert.Equal(t, 1, registry.calls, "a second, different network must not overwrite the registration")
+	assert.Equal(t, "network-a:", d.registeredFor, "the first network's registration must stand")
+}
+
+// TestRegisterEndorserIsIdempotentForTheSameNetwork checks Driver.New being called twice for the same
+// network (a network rebuilt over a node's life) does not trip the second-network refusal.
+func TestRegisterEndorserIsIdempotentForTheSameNetwork(t *testing.T) {
+	registry := &fakeViewRegistry{}
+	d := &Driver{viewRegistry: registry, identities: fakeIdentityProvider{}}
+	config := endorserConfig(t)
+	factory := testServiceFactory(t, config)
+
+	d.registerEndorser("network-a:", factory, config)
+	d.registerEndorser("network-a:", factory, config)
+
+	assert.Equal(t, 1, registry.calls, "registering the same network twice must not re-register")
+}
+
+// TestRegisterEndorserSkipsANonEndorsingNetwork checks a network that is not configured to endorse
+// never touches the registration state, so it cannot trigger the second-network refusal for a network
+// that never wanted to endorse in the first place.
+func TestRegisterEndorserSkipsANonEndorsingNetwork(t *testing.T) {
+	registry := &fakeViewRegistry{}
+	d := &Driver{viewRegistry: registry, identities: fakeIdentityProvider{}}
+	endorsing := endorserConfig(t)
+	factory := testServiceFactory(t, endorsing)
+	d.registerEndorser("network-a:", factory, endorsing)
+
+	notEndorsing := validConfig() // Endorser.Enabled defaults to false
+	d.registerEndorser("network-b:", factory, notEndorsing)
+
+	assert.Equal(t, 1, registry.calls)
+	assert.Equal(t, "network-a:", d.registeredFor)
 }

--- a/x/token/services/network/evm/endorsement/authorize.go
+++ b/x/token/services/network/evm/endorsement/authorize.go
@@ -13,8 +13,9 @@ import (
 
 // Authorizer decides whether an FSC identity may request endorsement. It is the EVM analog of the
 // Fabric responder's MSP/ACL creator check: EVM has no MSP, so authorization is membership in an
-// allowlist of FSC identities configured per TMS (design §6.2, §15.7). The default policy (the TMS
-// network's nodes) is resolved at config load in Week 5; here the allowlist is supplied explicitly.
+// allowlist of FSC identities configured per TMS (design §6.2, §15.7). There is no automatic default;
+// the allowlist is always supplied explicitly, and Config.Validate refuses to let an endorsing node
+// start without one, rather than resolving an empty one to "the TMS network's nodes" here.
 //
 // It is fail-closed: an empty allowlist is rejected at construction, and an unknown or empty caller
 // is denied, so a misconfiguration cannot silently authorize everyone.

--- a/x/token/services/network/evm/endorsement/fakes_test.go
+++ b/x/token/services/network/evm/endorsement/fakes_test.go
@@ -69,7 +69,9 @@ func (s *pipeSession) Close() {}
 // own session via Session. Everything the endorsement views do not touch panics, so an unexpected
 // dependency surfaces loudly rather than silently.
 type fakeContext struct {
-	ctx      context.Context
+	// view.Context is an interface whose Context() method returns one, so an implementation of it has
+	// to hold a context.
+	ctx      context.Context //nolint:containedctx
 	me       view.Identity
 	sessions map[string]view.Session // keyed by party UniqueID, for GetSession (initiator side)
 	own      view.Session            // for Session() (responder side)

--- a/x/token/services/network/evm/endorsement/ledger.go
+++ b/x/token/services/network/evm/endorsement/ledger.go
@@ -34,7 +34,9 @@ const getTokenMethod = "getToken(bytes32)" // #nosec G101 -- ABI method signatur
 // Ledger satisfies token.Ledger, so it can be passed straight to
 // Validator.UnmarshallAndVerifyWithMetadata.
 type Ledger struct {
-	ctx        context.Context
+	// GetState takes no context (driver.GetStateFnc has none), so the one to read the chain with is
+	// captured here. A Ledger is built per request and used only for it, so it stays short-lived.
+	ctx        context.Context //nolint:containedctx
 	client     client.EVMClient
 	tokenState client.Address
 	blockTag   string

--- a/x/token/services/network/evm/finality/manager.go
+++ b/x/token/services/network/evm/finality/manager.go
@@ -185,6 +185,12 @@ func (m *Manager) watch(anchor [32]byte, anchorID string, listener driver.Finali
 	ticker := time.NewTicker(m.pollInterval)
 	defer ticker.Stop()
 
+	// observed becomes true the moment any poll actually reaches the chain, whether or not the anchor
+	// was found. It is what separates "checked repeatedly and it is genuinely absent" from "the chain
+	// was unreachable for the whole window": only the first is evidence the transaction is invalid, and
+	// conflating them would let a persistent connectivity failure masquerade as a revert.
+	observed := false
+
 	for {
 		select {
 		case <-ticker.C:
@@ -192,14 +198,23 @@ func (m *Manager) watch(anchor [32]byte, anchorID string, listener driver.Finali
 			if err != nil {
 				continue // a transient read failure is not a verdict; keep polling until the timeout
 			}
+			observed = true
 			if code == driver.Valid {
 				listener.OnStatus(ctx, anchorID, code, message, hash)
 
 				return
 			}
 		case <-ctx.Done():
-			// The anchor never appeared. A reverted apply emits nothing, so this is the only failure
-			// signal available by anchor.
+			if !observed {
+				// Every read attempt in the window errored: the chain was never actually reached, so
+				// there is no evidence the anchor is invalid, only that it could not be observed.
+				listener.OnError(context.Background(), anchorID,
+					errors.New("finality: could not reach the chain before the timeout"))
+
+				return
+			}
+			// The anchor never appeared, and at least one read genuinely confirmed its absence. A
+			// reverted apply emits nothing, so this is the only failure signal available by anchor.
 			listener.OnStatus(context.Background(), anchorID, driver.Invalid, "finality timeout", nil)
 
 			return

--- a/x/token/services/network/evm/finality/manager_test.go
+++ b/x/token/services/network/evm/finality/manager_test.go
@@ -42,14 +42,18 @@ func (s *stubState) apply(hash []byte) {
 	s.mu.Unlock()
 }
 
-// recordingListener captures the single notification a listener is allowed to receive.
+// recordingListener captures the single notification a listener is allowed to receive, through
+// whichever of OnStatus/OnError actually fires.
 type recordingListener struct {
-	mu       sync.Mutex
-	done     chan struct{}
-	status   int
-	message  string
-	trHash   []byte
-	notified int
+	mu           sync.Mutex
+	done         chan struct{}
+	status       int
+	message      string
+	trHash       []byte
+	err          error
+	notified     int
+	statusCalled bool
+	errorCalled  bool
 }
 
 func newRecordingListener() *recordingListener {
@@ -59,6 +63,7 @@ func newRecordingListener() *recordingListener {
 func (l *recordingListener) OnStatus(_ context.Context, _ string, status int, message string, trHash []byte) {
 	l.mu.Lock()
 	l.status, l.message, l.trHash = status, message, trHash
+	l.statusCalled = true
 	l.notified++
 	first := l.notified == 1
 	l.mu.Unlock()
@@ -67,7 +72,17 @@ func (l *recordingListener) OnStatus(_ context.Context, _ string, status int, me
 	}
 }
 
-func (l *recordingListener) OnError(context.Context, string, error) {}
+func (l *recordingListener) OnError(_ context.Context, _ string, err error) {
+	l.mu.Lock()
+	l.err = err
+	l.errorCalled = true
+	l.notified++
+	first := l.notified == 1
+	l.mu.Unlock()
+	if first {
+		close(l.done)
+	}
+}
 
 func (l *recordingListener) wait(t *testing.T) {
 	t.Helper()
@@ -243,14 +258,59 @@ func TestAddListenerRejectsNil(t *testing.T) {
 	require.Error(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", nil))
 }
 
-// TestTransientReadFailureDoesNotResolve checks that a flaky node does not produce a verdict: the
-// manager keeps polling rather than reporting a status it cannot support.
+// TestTransientReadFailureDoesNotResolve checks that a flaky node does not produce a verdict before
+// the timeout: the manager keeps polling rather than reporting a status it cannot support.
 func TestTransientReadFailureDoesNotResolve(t *testing.T) {
+	state := &stubState{err: errors.New("temporarily unavailable")}
+	m := fastManager(&mock.EVMClient{}, state, 500*time.Millisecond)
+	listener := newRecordingListener()
+
+	require.NoError(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", listener))
+	select {
+	case <-listener.done:
+		t.Fatal("listener notified before the timeout on a read failure alone")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestPersistentReadFailureReportsErrorNotInvalid is the fix for a real bug: a chain the manager can
+// never reach used to resolve as Invalid at the timeout, which the shared ttx listener maps straight
+// to a deleted transaction. Nothing was ever actually observed here, so there is no evidence the
+// anchor is invalid, only that it could not be checked. That must surface as OnError, not a verdict.
+func TestPersistentReadFailureReportsErrorNotInvalid(t *testing.T) {
 	state := &stubState{err: errors.New("temporarily unavailable")}
 	m := fastManager(&mock.EVMClient{}, state, 100*time.Millisecond)
 	listener := newRecordingListener()
 
 	require.NoError(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", listener))
 	listener.wait(t)
-	assert.Equal(t, driver.Invalid, listener.status, "a persistent read failure resolves only at the timeout")
+
+	listener.mu.Lock()
+	defer listener.mu.Unlock()
+	assert.True(t, listener.errorCalled, "an unreachable chain must report OnError, not a verdict")
+	assert.False(t, listener.statusCalled, "OnStatus must not fire when nothing was ever observed")
+	require.Error(t, listener.err)
+}
+
+// TestOneCleanMissThenPersistentFailureStillResolvesInvalid pins the boundary of the fix above: once a
+// single read has actually reached the chain and found nothing, a later run of read failures does not
+// erase that evidence. The transaction still resolves Invalid at the timeout, as design §7.4 intends.
+func TestOneCleanMissThenPersistentFailureStillResolvesInvalid(t *testing.T) {
+	state := &stubState{}
+	m := fastManager(&mock.EVMClient{}, state, 200*time.Millisecond)
+	listener := newRecordingListener()
+
+	require.NoError(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", listener))
+	// Let at least one clean poll land (5ms interval) before the chain goes unreachable for the rest
+	// of the window.
+	time.Sleep(20 * time.Millisecond)
+	state.mu.Lock()
+	state.err = errors.New("node down")
+	state.mu.Unlock()
+
+	listener.wait(t)
+	listener.mu.Lock()
+	defer listener.mu.Unlock()
+	assert.True(t, listener.statusCalled)
+	assert.Equal(t, driver.Invalid, listener.status)
 }

--- a/x/token/services/network/evm/network.go
+++ b/x/token/services/network/evm/network.go
@@ -248,6 +248,16 @@ func (n *Network) SetRecoveryStarter(f func(ns string) error) { n.startRecovery 
 
 // Broadcast assembles the endorsed envelope into a signed transaction, sends it, and records the
 // resulting raw transaction and hash back into the envelope so the caller can follow its finality.
+//
+// It checks that the envelope's anchor and its delta's own anchor agree before spending any gas.
+// Under the normal flow they always do, since both are derived from the same anchor at the point an
+// Envelope is built (RequestApproval, SetupPublicParams), but Broadcast has no way to know how the
+// envelope it was actually handed got here, and a mismatch here is not hypothetical: it would mean
+// the local bookkeeping that tracks this transaction (finality listeners, the ttx store) is keyed on
+// one anchor while the chain applies and emits StateCommitted for a different one. A finality wait on
+// the anchor Broadcast was told about would then watch an anchor the chain never touches, and after
+// the timeout wrongly report a transaction that actually succeeded as failed, the same failure shape
+// as a persistent read error, just from a construction bug instead of a chain-connectivity one.
 func (n *Network) Broadcast(ctx context.Context, blob any) error {
 	env, ok := blob.(*Envelope)
 	if !ok {
@@ -258,6 +268,15 @@ func (n *Network) Broadcast(ctx context.Context, blob any) error {
 	}
 	if env.Delta == nil {
 		return errors.Errorf("evm network: envelope [%s] carries no state delta", env.Anchor)
+	}
+	anchor, err := keys.AnchorFromTxID(env.Anchor)
+	if err != nil {
+		return errors.Wrapf(err, "evm network: envelope carries an invalid anchor [%s]", env.Anchor)
+	}
+	if env.Delta.Anchor != anchor {
+		return errors.Errorf(
+			"evm network: envelope anchor [%s] does not match its delta's anchor [%x]; refusing to broadcast",
+			env.Anchor, env.Delta.Anchor)
 	}
 
 	rawTx, txHash, err := n.submitter.Submit(ctx, env.Delta, env.Endorsements)

--- a/x/token/services/network/evm/network.go
+++ b/x/token/services/network/evm/network.go
@@ -44,11 +44,15 @@ type Network struct {
 	// endorsementFor resolves the per-TMS endorsement service. It is preferred over the field above,
 	// which stays for tests that inject a stub directly.
 	endorsementFor func(tms *token2.ManagementService) (EndorsementService, error)
-	submitter      *Submitter
-	reader         *contractReader
-	finality       *finality.Manager
-	tokenState     client.Address
-	membership     driver.LocalMembership
+	// endorsementForID is endorsementFor's counterpart for callers that only have a TMSID, not an
+	// already-built management service: SetupPublicParams needs this, since first-time setup of a
+	// namespace runs before a management service can exist for it to have one at all.
+	endorsementForID func(tmsID token2.TMSID) (EndorsementService, error)
+	submitter        *Submitter
+	reader           *contractReader
+	finality         *finality.Manager
+	tokenState       client.Address
+	membership       driver.LocalMembership
 	// startRecovery starts the per-TMS transaction recovery sweep. It is installed by the driver,
 	// which owns the stores, and runs when a namespace binds rather than when the network is built.
 	startRecovery func(ns string) error
@@ -217,6 +221,26 @@ func (n *Network) SetEndorsementFactory(f func(tms *token2.ManagementService) (E
 	n.endorsementFor = f
 }
 
+// endorserForID is endorserFor's counterpart for a bare TMS id: the one injected directly if there is
+// one, otherwise the per-TMS service the factory builds. SetupPublicParams uses this rather than
+// endorserFor because it may run before a management service exists for the TMS at all.
+func (n *Network) endorserForID(tmsID token2.TMSID) (EndorsementService, error) {
+	if n.endorsement != nil {
+		return n.endorsement, nil
+	}
+	if n.endorsementForID == nil {
+		return nil, errors.New("evm network: no endorsement service configured")
+	}
+
+	return n.endorsementForID(tmsID)
+}
+
+// SetEndorsementFactoryByID installs the resolver endorserForID uses. It is SetEndorsementFactory's
+// counterpart for the id-only path.
+func (n *Network) SetEndorsementFactoryByID(f func(tmsID token2.TMSID) (EndorsementService, error)) {
+	n.endorsementForID = f
+}
+
 // SetRecoveryStarter installs the hook that starts transaction recovery for a namespace. Like the
 // endorsement factory it is set by the driver after construction, because the stores it sweeps
 // belong to the driver rather than to the network.
@@ -280,12 +304,13 @@ func (n *Network) SetupPublicParams(
 	signer view.Identity,
 	txID driver.TxID,
 ) (driver.Envelope, error) {
-	if n.endorsement == nil {
-		return nil, errors.New("evm network: no endorsement service configured")
+	endorser, err := n.endorserForID(tmsID)
+	if err != nil {
+		return nil, err
 	}
 
 	anchor := n.ComputeTxID(&txID)
-	result, err := n.endorsement.Endorse(context, &endorsement.EndorseRequest{
+	result, err := endorser.Endorse(context, &endorsement.EndorseRequest{
 		TokenRequest: publicParamsRaw,
 		TMSID:        tmsID,
 		Anchor:       anchor,

--- a/x/token/services/network/evm/network_test.go
+++ b/x/token/services/network/evm/network_test.go
@@ -267,6 +267,57 @@ func TestRequestApprovalWithoutEndorsementService(t *testing.T) {
 	require.Error(t, err)
 }
 
+// --- SetupPublicParams -----------------------------------------------------------------------------
+
+// TestSetupPublicParamsWithoutEndorsementService checks the same failure mode RequestApproval has:
+// nothing configured means a clear error, not a nil dereference further down.
+func TestSetupPublicParamsWithoutEndorsementService(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+	_, err := n.SetupPublicParams(nil, token2.TMSID{Network: "evm", Namespace: "token"}, []byte("pp"), nil, driverTxID())
+	require.Error(t, err)
+}
+
+// TestSetupPublicParamsResolvesThroughTheIDBasedFactory is the fix for a real bug: SetupPublicParams
+// checked only the endorsement field tests inject directly, never the per-TMS factory the driver
+// actually installs in production (SetEndorsementFactory, keyed by a management service). Since
+// SetupPublicParams only ever has a bare TMSID, not a management service, it could never reach that
+// factory, and the call failed with "no endorsement service configured" on every real deployment
+// regardless of how correctly everything else was wired: first-time setup of a namespace, the one
+// thing this method exists to make possible, could not work at all.
+func TestSetupPublicParamsResolvesThroughTheIDBasedFactory(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+	tmsID := token2.TMSID{Network: "evm", Namespace: "token"}
+	stub := &stubEndorser{result: &endorsement.Result{Anchor: "anchor", Endorsements: [][]byte{{0x01}}}}
+
+	var seenID token2.TMSID
+	n.SetEndorsementFactoryByID(func(id token2.TMSID) (EndorsementService, error) {
+		seenID = id
+
+		return stub, nil
+	})
+
+	env, err := n.SetupPublicParams(nil, tmsID, []byte("pp"), nil, driverTxID())
+	require.NoError(t, err)
+	assert.NotNil(t, env)
+	assert.Equal(t, tmsID, seenID, "the factory must be asked to resolve exactly the TMS being set up")
+	require.NotNil(t, stub.seen)
+	assert.Equal(t, tmsID, stub.seen.TMSID)
+}
+
+// TestSetupPublicParamsDoesNotTouchTheChain mirrors TestRequestApprovalDoesNotTouchTheChain: a failed
+// endorsement collection must not broadcast anything.
+func TestSetupPublicParamsDoesNotTouchTheChain(t *testing.T) {
+	evm := &mock.EVMClient{}
+	n := testNetwork(t, evm, nil)
+	n.SetEndorsementFactoryByID(func(token2.TMSID) (EndorsementService, error) {
+		return &stubEndorser{err: errors.New("no quorum")}, nil
+	})
+
+	_, err := n.SetupPublicParams(nil, token2.TMSID{Network: "evm", Namespace: "token"}, []byte("pp"), nil, driverTxID())
+	require.Error(t, err)
+	assert.Zero(t, evm.SendRawTransactionCallCount(), "a failed setup must not broadcast")
+}
+
 // --- Broadcast -----------------------------------------------------------------------------------
 
 func TestBroadcastRejectsBadInput(t *testing.T) {

--- a/x/token/services/network/evm/network_test.go
+++ b/x/token/services/network/evm/network_test.go
@@ -338,6 +338,74 @@ func TestBroadcastRejectsBadInput(t *testing.T) {
 	})
 }
 
+// networkWithSubmitter returns a Network wired with a real submitter over a ready mock client, for
+// Broadcast tests that need to get past the submitter/delta checks to exercise what follows them.
+func networkWithSubmitter(t *testing.T, evm *mock.EVMClient) *Network {
+	t.Helper()
+	c := validConfig()
+	c.applyDefaults()
+	require.NoError(t, c.Validate())
+	n, err := NewNetwork("evm-net", c, evm, nil, testSubmitter(t, evm, estimateGas()), nil)
+	require.NoError(t, err)
+
+	return n
+}
+
+// TestBroadcastRejectsMismatchedAnchor is the fix for a real gap: nothing checked that an envelope's
+// anchor and its delta's own anchor actually agreed before spending gas on it. Under the normal flow
+// they always do, since RequestApproval derives both from the same anchor, but Broadcast has no way
+// to know how the envelope it was actually handed was built, and the local finality tracking is keyed
+// on the envelope's anchor while the chain applies and emits StateCommitted for the delta's: a
+// mismatch here would mean waiting on an anchor the chain never touches.
+func TestBroadcastRejectsMismatchedAnchor(t *testing.T) {
+	evm := readySubmitterClient()
+	n := networkWithSubmitter(t, evm)
+
+	elsewhere, err := keys.AnchorFromTxID(anchorHex(0xEE))
+	require.NoError(t, err)
+	delta := testDelta()
+	delta.Anchor = elsewhere
+
+	err = n.Broadcast(t.Context(), &Envelope{
+		Anchor:       anchorHex(0x01),
+		Delta:        delta,
+		Endorsements: [][]byte{make([]byte, 65)},
+	})
+	require.Error(t, err)
+	assert.Zero(t, evm.SendRawTransactionCallCount(), "a mismatched envelope must not be broadcast")
+}
+
+// TestBroadcastRejectsAnUnparsableAnchor checks the envelope's own anchor is validated before it is
+// compared against anything, rather than producing a confusing failure further down.
+func TestBroadcastRejectsAnUnparsableAnchor(t *testing.T) {
+	evm := readySubmitterClient()
+	n := networkWithSubmitter(t, evm)
+
+	err := n.Broadcast(t.Context(), &Envelope{
+		Anchor:       "not-hex",
+		Delta:        testDelta(),
+		Endorsements: [][]byte{make([]byte, 65)},
+	})
+	require.Error(t, err)
+	assert.Zero(t, evm.SendRawTransactionCallCount())
+}
+
+// TestBroadcastAcceptsAConsistentEnvelope is the positive case: an envelope whose anchor and delta
+// agree, as every normal caller produces, must still broadcast.
+func TestBroadcastAcceptsAConsistentEnvelope(t *testing.T) {
+	evm := readySubmitterClient()
+	n := networkWithSubmitter(t, evm)
+
+	delta := testDelta()
+	err := n.Broadcast(t.Context(), &Envelope{
+		Anchor:       hex.EncodeToString(delta.Anchor[:]),
+		Delta:        delta,
+		Endorsements: [][]byte{make([]byte, 65)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, evm.SendRawTransactionCallCount())
+}
+
 // --- queries -------------------------------------------------------------------------------------
 
 func TestQueryTokens(t *testing.T) {

--- a/x/token/services/network/evm/nonce.go
+++ b/x/token/services/network/evm/nonce.go
@@ -16,11 +16,11 @@ import (
 )
 
 // NonceManager hands out the submitter account's Ethereum transaction nonces. Ethereum requires them
-// to be strictly sequential per account, so concurrent broadcasts must not read the same value: the
-// manager serializes allocation and tracks the next nonce locally rather than asking the node each
-// time, which would hand the same nonce to two callers racing between the query and the send.
+// to be strictly sequential per account, so two broadcasts must never collide: WithNonce holds a lock
+// across the whole allocate-and-use step, not just the allocation, so nothing else can be mid-flight
+// when a failed attempt needs the sequence walked back.
 //
-// The chain is the source of truth, so there is nothing to persist. On a fresh start (or after a
+// The chain is the only source of truth, so nothing here is persisted. On a fresh start (or after a
 // restart) the first allocation recovers from eth_getTransactionCount at the pending tag, which
 // already accounts for transactions still in the mempool. That makes a node restart transparent, at
 // the cost of one round trip.
@@ -38,35 +38,37 @@ func NewNonceManager(evmClient client.EVMClient, submitter client.Address) *Nonc
 	return &NonceManager{client: evmClient, submitter: submitter}
 }
 
-// Next returns the nonce to use for the next transaction and advances the counter. The caller owns
-// the returned nonce: if it does not end up broadcasting, it should Reset so the sequence does not
-// develop a gap that stalls every later transaction.
-func (n *NonceManager) Next(ctx context.Context) (uint64, error) {
+// WithNonce allocates the next nonce and runs use with it, holding the manager's lock for the whole
+// step. The sequence advances only if use succeeds; on failure the nonce is left exactly where it
+// was, so the next call gets the same value, with no round trip to the chain needed to know that is
+// safe.
+//
+// It is safe because of what use's contract already is, not despite it: every caller in this driver
+// treats a failure as proof the transaction never reached the chain (gas estimation and fee
+// suggestion are read-only, signing is local, and a rejected broadcast is documented as never judged
+// by the chain), and while use runs, no other call can be allocating a nonce for this account at all.
+// A nonce handed out twice used to happen exactly in the gap between those two things: one call's
+// failure re-derived the whole sequence from the chain's current mempool view, which does not yet
+// include a nonce a different, still in-flight call already holds and has not broadcast yet.
+func (n *NonceManager) WithNonce(ctx context.Context, use func(nonce uint64) error) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
 	if !n.initialized {
 		pending, err := n.client.PendingNonceAt(ctx, n.submitter)
 		if err != nil {
-			return 0, errors.Wrapf(err, "failed to recover the nonce for submitter [%s]", n.submitter)
+			return errors.Wrapf(err, "failed to recover the nonce for submitter [%s]", n.submitter)
 		}
 		n.next = pending
 		n.initialized = true
 	}
 
-	nonce := n.next
+	if err := use(n.next); err != nil {
+		return err
+	}
 	n.next++
 
-	return nonce, nil
-}
-
-// Reset drops the cached counter so the next allocation re-reads from the node. It is the recovery
-// path for a failed broadcast: rather than guess whether the node saw the transaction, re-derive the
-// sequence from the pending nonce, which is authoritative.
-func (n *NonceManager) Reset() {
-	n.mu.Lock()
-	n.initialized = false
-	n.mu.Unlock()
+	return nil
 }
 
 // Cached returns the next nonce the manager would hand out and whether it has been initialized,

--- a/x/token/services/network/evm/nonce_test.go
+++ b/x/token/services/network/evm/nonce_test.go
@@ -25,7 +25,12 @@ func TestNonceRecoversFromChain(t *testing.T) {
 	evm.PendingNonceAtReturns(42, nil)
 	n := NewNonceManager(evm, client.Address{})
 
-	got, err := n.Next(t.Context())
+	var got uint64
+	err := n.WithNonce(t.Context(), func(nonce uint64) error {
+		got = nonce
+
+		return nil
+	})
 	require.NoError(t, err)
 	assert.Equal(t, uint64(42), got, "the first nonce must come from the chain, not from zero")
 }
@@ -39,31 +44,46 @@ func TestNonceIsSequentialWithoutRefetching(t *testing.T) {
 	n := NewNonceManager(evm, client.Address{})
 
 	for want := uint64(7); want < 12; want++ {
-		got, err := n.Next(t.Context())
+		err := n.WithNonce(t.Context(), func(nonce uint64) error {
+			assert.Equal(t, want, nonce)
+
+			return nil
+		})
 		require.NoError(t, err)
-		assert.Equal(t, want, got)
 	}
 	assert.Equal(t, 1, evm.PendingNonceAtCallCount(), "the node is consulted once, not per transaction")
 }
 
-// TestNonceResetReRecovers checks the failed-broadcast path: after a reset the sequence is
-// re-derived from the node, which is authoritative about what it has actually seen.
-func TestNonceResetReRecovers(t *testing.T) {
+// TestNonceIsNotAdvancedOnFailure is the fix for a real bug. The manager used to have a separate
+// Reset that walked the whole sequence back and re-derived it from the chain's current mempool view,
+// which does not include a nonce a different, still in-flight call already holds and has not
+// broadcast yet: one call's failure could hand that nonce to somebody else. WithNonce closes the gap
+// by holding the lock for the whole allocate-and-use step, so a failed attempt simply leaves the
+// nonce where it was: nothing else could have raced in while use ran, so reusing the same value on
+// the next call needs no round trip to the chain to be safe.
+func TestNonceIsNotAdvancedOnFailure(t *testing.T) {
 	evm := &mock.EVMClient{}
-	evm.PendingNonceAtReturnsOnCall(0, 5, nil)
-	evm.PendingNonceAtReturnsOnCall(1, 9, nil)
+	evm.PendingNonceAtReturns(5, nil)
 	n := NewNonceManager(evm, client.Address{})
 
-	first, err := n.Next(t.Context())
-	require.NoError(t, err)
-	assert.Equal(t, uint64(5), first)
+	err := n.WithNonce(t.Context(), func(nonce uint64) error {
+		assert.Equal(t, uint64(5), nonce)
 
-	n.Reset()
+		return assert.AnError
+	})
+	require.Error(t, err)
 
-	second, err := n.Next(t.Context())
+	err = n.WithNonce(t.Context(), func(nonce uint64) error {
+		assert.Equal(t, uint64(5), nonce, "a failed attempt must not consume the nonce")
+
+		return nil
+	})
 	require.NoError(t, err)
-	assert.Equal(t, uint64(9), second, "after a reset the nonce must come from the node again")
-	assert.Equal(t, 2, evm.PendingNonceAtCallCount())
+	assert.Equal(t, 1, evm.PendingNonceAtCallCount(), "recovering from a failure needs no round trip to the chain")
+
+	next, initialized := n.Cached()
+	assert.True(t, initialized)
+	assert.Equal(t, uint64(6), next, "the sequence advances only past the attempt that actually succeeded")
 }
 
 func TestNonceSurfacesRecoveryFailure(t *testing.T) {
@@ -71,8 +91,14 @@ func TestNonceSurfacesRecoveryFailure(t *testing.T) {
 	evm.PendingNonceAtReturns(0, errors.New("node unavailable"))
 	n := NewNonceManager(evm, client.Address{})
 
-	_, err := n.Next(t.Context())
+	called := false
+	err := n.WithNonce(t.Context(), func(uint64) error {
+		called = true
+
+		return nil
+	})
 	require.Error(t, err)
+	assert.False(t, called, "use must not run when the nonce could not be recovered")
 
 	_, initialized := n.Cached()
 	assert.False(t, initialized, "a failed recovery must not leave the manager initialized")
@@ -93,16 +119,51 @@ func TestNonceConcurrentAllocationIsUnique(t *testing.T) {
 	)
 	for range callers {
 		wg.Go(func() {
-			nonce, err := n.Next(t.Context())
-			if err != nil {
-				return
-			}
-			mu.Lock()
-			got[nonce] = struct{}{}
-			mu.Unlock()
+			err := n.WithNonce(t.Context(), func(nonce uint64) error {
+				mu.Lock()
+				got[nonce] = struct{}{}
+				mu.Unlock()
+
+				return nil
+			})
+			assert.NoError(t, err)
 		})
 	}
 	wg.Wait()
 
 	assert.Len(t, got, callers, "every concurrent caller must receive a distinct nonce")
+}
+
+// TestNonceHandlesConcurrentFailuresWithoutDuplicating drives many goroutines against one manager,
+// roughly half of them failing, and checks every nonce a goroutine actually succeeded with is unique.
+// This is the scenario the old Reset-based design got wrong: a failure from one caller must not be
+// able to hand a still in-flight caller's nonce to somebody else.
+func TestNonceHandlesConcurrentFailuresWithoutDuplicating(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.PendingNonceAtReturns(0, nil)
+	n := NewNonceManager(evm, client.Address{})
+
+	const callers = 200
+	var (
+		wg  sync.WaitGroup
+		mu  sync.Mutex
+		got = make(map[uint64]struct{}, callers)
+	)
+	for i := range callers {
+		wg.Go(func() {
+			_ = n.WithNonce(t.Context(), func(nonce uint64) error {
+				if i%2 == 0 {
+					return assert.AnError
+				}
+				mu.Lock()
+				got[nonce] = struct{}{}
+				mu.Unlock()
+
+				return nil
+			})
+		})
+	}
+	wg.Wait()
+
+	assert.Len(t, got, callers/2, "every successful attempt must have consumed a distinct nonce")
 }

--- a/x/token/services/network/evm/pp/provider.go
+++ b/x/token/services/network/evm/pp/provider.go
@@ -19,6 +19,12 @@ import (
 // stored parameters.
 const getPublicParametersMethod = "getPublicParameters()" // #nosec G101 -- ABI method signature
 
+// maxPublicParamsReadAttempts bounds the retry PublicParams performs when it detects a torn read. A
+// public-parameters update is a rare, isolated event (design §3.5), so a bracket almost always comes
+// back clean on the first attempt; the bound exists only so a chain updating on every single block
+// cannot spin this forever.
+const maxPublicParamsReadAttempts = 3
+
 // ChainProvider supplies the public parameters an endorser binds a StateDelta to, reading both the
 // bytes and the version from the contract.
 //
@@ -55,22 +61,48 @@ func NewChainProvider(evmClient client.EVMClient, tokenState client.Address, blo
 }
 
 // PublicParams returns the parameters currently stored on chain and their version.
+//
+// There is no single getter for both (getPublicParameters and getPublicParamsVersion are separate
+// calls), so an endorsed setup delta landing between them could tear the pair: bytes from before the
+// update paired with the version from after, or the reverse. The contract would catch this at apply
+// time, since it checks both fields together and reverts StalePublicParams unless they match exactly
+// what it currently holds, but that turns a purely local race in this function into a doomed,
+// gas-spending transaction rather than nothing happening at all.
+//
+// The version is read before and after the bytes, and the whole read is retried if it moved: version
+// and bytes only ever change together, in the same transaction (design §3.5), so two matching reads
+// bracketing the bytes read is proof nothing landed in between.
 func (p *ChainProvider) PublicParams(ctx context.Context) ([]byte, uint64, error) {
-	raw, err := p.client.Call(ctx, p.tokenState, abi.MethodID(getPublicParametersMethod), p.blockTag)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "failed to read the public parameters")
-	}
-	params, err := abi.DecodeBytes(raw)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "failed to decode the public parameters")
+	var lastVersion uint64
+	for range maxPublicParamsReadAttempts {
+		before, err := p.versions.Sync(ctx)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		raw, err := p.client.Call(ctx, p.tokenState, abi.MethodID(getPublicParametersMethod), p.blockTag)
+		if err != nil {
+			return nil, 0, errors.Wrap(err, "failed to read the public parameters")
+		}
+		params, err := abi.DecodeBytes(raw)
+		if err != nil {
+			return nil, 0, errors.Wrap(err, "failed to decode the public parameters")
+		}
+
+		after, err := p.versions.Sync(ctx)
+		if err != nil {
+			return nil, 0, err
+		}
+		if after == before {
+			return params, after, nil
+		}
+		lastVersion = after
 	}
 
-	version, err := p.versions.Sync(ctx)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return params, version, nil
+	return nil, 0, errors.Errorf(
+		"evm pp: public parameters changed on every read attempt (%d), last observed version %d",
+		maxPublicParamsReadAttempts, lastVersion,
+	)
 }
 
 // Invalidate drops the cached version. PublicParams re-reads the version on every call, so there is

--- a/x/token/services/network/evm/pp/provider_test.go
+++ b/x/token/services/network/evm/pp/provider_test.go
@@ -67,6 +67,68 @@ func TestPublicParamsFollowsAnUpdate(t *testing.T) {
 	assert.EqualValues(t, 1, version, "the version must be the one those parameters are stored at")
 }
 
+// TestPublicParamsRetriesATornRead is the fix for a real bug: the bytes and the version were read as
+// two separate calls with nothing bracketing them, so an update landing in between produced an
+// internally inconsistent pair. The contract would reject it (it checks both fields together), so the
+// practical cost was a doomed, gas-spending transaction rather than data corruption, but it was a
+// deterministic gap in this function alone, closeable without touching the contract.
+func TestPublicParamsRetriesATornRead(t *testing.T) {
+	tokenState, err := client.HexToAddress("0x5FbDB2315678afecb367f032d93F642f64180aa3")
+	require.NoError(t, err)
+
+	// The version read returns 0, 1, 1, 1: the first attempt's bracket (before=0, after=1) straddles
+	// an update and must be retried; the second attempt's (before=1, after=1) does not.
+	versionReads := []uint64{0, 1, 1, 1}
+	calls := 0
+	evmClient := &mock.EVMClient{}
+	evmClient.CallStub = func(_ context.Context, _ client.Address, data []byte, _ string) ([]byte, error) {
+		switch string(data) {
+		case string(abi.MethodID("getPublicParameters()")):
+			return abiBytesFor([]byte("params")), nil
+		case string(abi.MethodID("getPublicParamsVersion()")):
+			v := versionReads[calls]
+			calls++
+
+			return abiUint64For(v), nil
+		}
+
+		return nil, nil
+	}
+
+	provider := NewChainProvider(evmClient, tokenState, "latest")
+	raw, version, err := provider.PublicParams(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "params", string(raw))
+	assert.EqualValues(t, 1, version, "the torn first attempt must be discarded, not returned")
+	assert.Equal(t, 4, calls, "a torn bracket must be retried, not accepted")
+}
+
+// TestPublicParamsGivesUpAfterRepeatedTears checks the retry is bounded: a chain whose version never
+// settles between two reads must not spin PublicParams forever.
+func TestPublicParamsGivesUpAfterRepeatedTears(t *testing.T) {
+	tokenState, err := client.HexToAddress("0x5FbDB2315678afecb367f032d93F642f64180aa3")
+	require.NoError(t, err)
+
+	var version uint64
+	evmClient := &mock.EVMClient{}
+	evmClient.CallStub = func(_ context.Context, _ client.Address, data []byte, _ string) ([]byte, error) {
+		switch string(data) {
+		case string(abi.MethodID("getPublicParameters()")):
+			return abiBytesFor([]byte("params")), nil
+		case string(abi.MethodID("getPublicParamsVersion()")):
+			version++
+
+			return abiUint64For(version), nil
+		}
+
+		return nil, nil
+	}
+
+	provider := NewChainProvider(evmClient, tokenState, "latest")
+	_, _, err = provider.PublicParams(context.Background())
+	require.Error(t, err)
+}
+
 // TestPublicParamsIsConsistentAcrossRepeatedReads checks the pair stays matched over several updates,
 // since a version that lagged by one would still look right on the first read after each change.
 func TestPublicParamsIsConsistentAcrossRepeatedReads(t *testing.T) {

--- a/x/token/services/network/evm/pp/watcher.go
+++ b/x/token/services/network/evm/pp/watcher.go
@@ -27,7 +27,12 @@ const DefaultWatchInterval = time.Second
 // UpdateHandler is called when the on-chain public parameters have changed, with the new parameters
 // and the version they were stored at. It is called from the watcher's own goroutine, one call at a
 // time, so a handler that blocks delays the next poll rather than racing with it.
-type UpdateHandler func(ctx context.Context, raw []byte, version uint64)
+//
+// A non-nil return means this version was not fully applied. The watcher does not advance past a
+// version its handler failed on, so the same version is retried on the next poll instead of being
+// silently treated as handled: nothing else will ever ask the chain about a version once the watcher
+// has moved on from it.
+type UpdateHandler func(ctx context.Context, raw []byte, version uint64) error
 
 // Watcher notices when a TMS's public parameters change on chain and hands the new ones to a handler.
 //
@@ -160,11 +165,20 @@ func (w *Watcher) poll(ctx context.Context) {
 		return
 	}
 
-	// Record what was actually read rather than what the version poll reported. They can differ if
+	// The handler runs before seen is advanced, and seen only advances once it succeeds. Advancing
+	// first would mean a failed reload is treated as handled anyway: the next poll only looks at what
+	// changed since seen, so a version it never actually applied would simply never be asked about
+	// again.
+	if err := w.handler(ctx, raw, actual); err != nil {
+		logger.Warnf("failed to apply public parameters version %d, will retry: %v", actual, err)
+
+		return
+	}
+
+	// Record what was actually applied rather than what the version poll reported. They can differ if
 	// another update landed in between, and the parameters are the thing that matters.
 	w.mu.Lock()
 	w.seen = actual
 	w.mu.Unlock()
 	logger.Infof("public parameters updated to version %d", actual)
-	w.handler(ctx, raw, actual)
 }

--- a/x/token/services/network/evm/pp/watcher_test.go
+++ b/x/token/services/network/evm/pp/watcher_test.go
@@ -70,10 +70,12 @@ func newWatcherHarness(t *testing.T, state *chainState) (*Watcher, *[]update, *s
 	var mu sync.Mutex
 	got := make([]update, 0, 4)
 	w, err := NewWatcher(evmClient, tokenState, "latest", 10*time.Millisecond,
-		func(_ context.Context, raw []byte, version uint64) {
+		func(_ context.Context, raw []byte, version uint64) error {
 			mu.Lock()
 			defer mu.Unlock()
 			got = append(got, update{raw: string(raw), version: version})
+
+			return nil
 		})
 	require.NoError(t, err)
 
@@ -197,10 +199,12 @@ func TestWatcherSurvivesAFailedRead(t *testing.T) {
 	var mu sync.Mutex
 	seen := 0
 	w, err := NewWatcher(evmClient, tokenState, "latest", 5*time.Millisecond,
-		func(context.Context, []byte, uint64) {
+		func(context.Context, []byte, uint64) error {
 			mu.Lock()
 			defer mu.Unlock()
 			seen++
+
+			return nil
 		})
 	require.NoError(t, err)
 
@@ -213,6 +217,73 @@ func TestWatcherSurvivesAFailedRead(t *testing.T) {
 
 		return seen > 0
 	}, 2*time.Second, 5*time.Millisecond, "the watcher must keep polling after a failed read")
+}
+
+// TestWatcherRetriesAFailedHandler is the fix for a real bug: seen used to advance before the handler
+// ran, so a handler that failed to apply a version was never asked about it again. The chain looked
+// "seen" forever, and the node kept serving stale parameters with nothing left to notice the gap.
+func TestWatcherRetriesAFailedHandler(t *testing.T) {
+	state := &chainState{}
+	state.set("params-v0", 0)
+
+	w, attempts, mu := newFailingWatcherHarness(t, state, 3)
+	w.Start(context.Background())
+	defer w.Stop()
+
+	require.Eventually(t, func() bool { return baselineSet(w) }, time.Second, 5*time.Millisecond)
+	state.set("params-v1", 1)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return *attempts >= 3
+	}, 2*time.Second, 5*time.Millisecond, "a failed handler must be retried on the same version, not skipped")
+
+	w.mu.Lock()
+	seen, hasSeen := w.seen, w.hasSeen
+	w.mu.Unlock()
+	assert.True(t, hasSeen)
+	assert.Equal(t, uint64(1), seen, "seen only advances once the handler actually succeeds")
+}
+
+// newFailingWatcherHarness is newWatcherHarness's counterpart for a handler that fails its first
+// succeedAfter-1 calls and succeeds from then on, so a test can assert on the retry, not just the
+// eventual success.
+func newFailingWatcherHarness(t *testing.T, state *chainState, succeedAfter int) (*Watcher, *int, *sync.Mutex) {
+	t.Helper()
+	tokenState, err := client.HexToAddress("0x5FbDB2315678afecb367f032d93F642f64180aa3")
+	require.NoError(t, err)
+
+	evmClient := &mock.EVMClient{}
+	evmClient.CallStub = func(_ context.Context, _ client.Address, data []byte, _ string) ([]byte, error) {
+		raw, version := state.get()
+		switch string(data) {
+		case string(abi.MethodID("getPublicParameters()")):
+			return abiBytesFor(raw), nil
+		case string(abi.MethodID("getPublicParamsVersion()")):
+			return abiUint64For(version), nil
+		}
+
+		return nil, nil
+	}
+
+	var mu sync.Mutex
+	attempts := 0
+	w, err := NewWatcher(evmClient, tokenState, "latest", 5*time.Millisecond,
+		func(context.Context, []byte, uint64) error {
+			mu.Lock()
+			defer mu.Unlock()
+			attempts++
+			if attempts < succeedAfter {
+				return assert.AnError
+			}
+
+			return nil
+		})
+	require.NoError(t, err)
+
+	return w, &attempts, &mu
 }
 
 // TestWatcherStopIsIdempotentAndBlocks checks a stopped watcher will not call the handler again, so a
@@ -241,14 +312,14 @@ func TestNewWatcherValidatesItsInput(t *testing.T) {
 	tokenState, err := client.HexToAddress("0x5FbDB2315678afecb367f032d93F642f64180aa3")
 	require.NoError(t, err)
 
-	_, err = NewWatcher(nil, tokenState, "latest", time.Second, func(context.Context, []byte, uint64) {})
+	_, err = NewWatcher(nil, tokenState, "latest", time.Second, func(context.Context, []byte, uint64) error { return nil })
 	require.Error(t, err)
 
 	_, err = NewWatcher(&mock.EVMClient{}, tokenState, "latest", time.Second, nil)
 	require.Error(t, err)
 
 	// a non-positive interval falls back to the default rather than spinning
-	w, err := NewWatcher(&mock.EVMClient{}, tokenState, "latest", 0, func(context.Context, []byte, uint64) {})
+	w, err := NewWatcher(&mock.EVMClient{}, tokenState, "latest", 0, func(context.Context, []byte, uint64) error { return nil })
 	require.NoError(t, err)
 	assert.Equal(t, DefaultWatchInterval, w.interval)
 }

--- a/x/token/services/network/evm/pp/watcher_test.go
+++ b/x/token/services/network/evm/pp/watcher_test.go
@@ -178,22 +178,32 @@ func TestWatcherReportsEachUpdateOnce(t *testing.T) {
 // one bad read would leave the node on stale parameters forever, which is far worse than a late
 // notice.
 func TestWatcherSurvivesAFailedRead(t *testing.T) {
+	state := &chainState{}
+	state.set("params-v0", 0)
+
 	tokenState, err := client.HexToAddress("0x5FbDB2315678afecb367f032d93F642f64180aa3")
 	require.NoError(t, err)
 
+	// Only the version read errors, and only for the first four calls; everything after that, and
+	// every read of the bytes, falls through to the stable chain state below. Returning the raw call
+	// count as the version (the original shape of this test) does not work once PublicParams reads the
+	// version twice per attempt to detect a torn read: two different call counts a few lines apart
+	// would themselves look torn and the test would never get past that.
 	var calls atomic.Int64
 	evmClient := &mock.EVMClient{}
 	evmClient.CallStub = func(_ context.Context, _ client.Address, data []byte, _ string) ([]byte, error) {
-		n := calls.Add(1)
-		if string(data) == string(abi.MethodID("getPublicParamsVersion()")) {
-			if n <= 4 {
-				return nil, assert.AnError
-			}
-
-			return abiUint64For(uint64(n)), nil
+		if string(data) == string(abi.MethodID("getPublicParamsVersion()")) && calls.Add(1) <= 4 {
+			return nil, assert.AnError
+		}
+		raw, version := state.get()
+		switch string(data) {
+		case string(abi.MethodID("getPublicParameters()")):
+			return abiBytesFor(raw), nil
+		case string(abi.MethodID("getPublicParamsVersion()")):
+			return abiUint64For(version), nil
 		}
 
-		return abiBytesFor([]byte("params")), nil
+		return nil, nil
 	}
 
 	var mu sync.Mutex
@@ -210,6 +220,9 @@ func TestWatcherSurvivesAFailedRead(t *testing.T) {
 
 	w.Start(context.Background())
 	defer w.Stop()
+
+	require.Eventually(t, func() bool { return baselineSet(w) }, time.Second, 5*time.Millisecond)
+	state.set("params-v1", 1)
 
 	require.Eventually(t, func() bool {
 		mu.Lock()

--- a/x/token/services/network/evm/submitter.go
+++ b/x/token/services/network/evm/submitter.go
@@ -71,8 +71,10 @@ func NewSubmitter(
 func (s *Submitter) Address() client.Address { return s.address }
 
 // Submit encodes applyStateDelta(delta, endorsements), signs it and broadcasts it, returning the raw
-// transaction and its hash. On any failure after a nonce was allocated it resets the sequence, so a
-// transaction that never reached the node does not leave a gap that would stall every later one.
+// transaction and its hash. The whole nonce-relevant sequence runs under the nonce manager's lock, so
+// a failure here (the delta reverts on estimation, the node rejects the broadcast) can never race a
+// different transaction's allocation: the nonce this attempt held is simply not consumed, and the next
+// caller, whether that is a retry of this same transaction or somebody else's, gets it instead.
 func (s *Submitter) Submit(
 	ctx context.Context,
 	delta *statedelta.StateDelta,
@@ -87,48 +89,47 @@ func (s *Submitter) Submit(
 
 	data := abi.EncodeApplyStateDelta(delta, endorsements)
 
-	nonce, err := s.nonces.Next(ctx)
-	if err != nil {
-		return nil, client.Hash{}, err
-	}
-	defer func() {
-		if err != nil {
-			// The nonce was allocated but never consumed on chain; re-derive the sequence.
-			s.nonces.Reset()
+	err = s.nonces.WithNonce(ctx, func(nonce uint64) error {
+		gasLimit, gasErr := s.gasLimit(ctx, data)
+		if gasErr != nil {
+			return gasErr
 		}
-	}()
+		fees, feeErr := s.client.SuggestGasFees(ctx)
+		if feeErr != nil {
+			return errors.Wrapf(ErrNetworkUnavailable, "submitter: failed to get gas fees: %v", feeErr)
+		}
 
-	gasLimit, err := s.gasLimit(ctx, data)
+		tx := &client.DynamicFeeTx{
+			ChainID:              s.chainID,
+			Nonce:                nonce,
+			MaxPriorityFeePerGas: fees.MaxPriorityFeePerGas,
+			MaxFeePerGas:         fees.MaxFeePerGas,
+			Gas:                  gasLimit,
+			To:                   &s.tokenState,
+			Value:                big.NewInt(0), // applyStateDelta is not payable
+			Data:                 data,
+		}
+
+		signed, signErr := client.SignTx(tx, s.key)
+		if signErr != nil {
+			return errors.Wrap(signErr, "submitter: failed to sign the transaction")
+		}
+
+		hash, sendErr := s.client.SendRawTransaction(ctx, signed)
+		if sendErr != nil {
+			// A transaction the node refused to accept was never judged by the chain, so this is the
+			// transient class: the delta is still valid and the caller should retry rather than
+			// re-derive it. A node that executed it and rejected it comes back through gasLimit instead.
+			return errors.Wrapf(
+				ErrNetworkUnavailable, "submitter: failed to broadcast the transaction: %v", sendErr)
+		}
+
+		rawTx, txHash = signed, hash
+
+		return nil
+	})
 	if err != nil {
 		return nil, client.Hash{}, err
-	}
-	fees, err := s.client.SuggestGasFees(ctx)
-	if err != nil {
-		return nil, client.Hash{}, errors.Wrapf(ErrNetworkUnavailable, "submitter: failed to get gas fees: %v", err)
-	}
-
-	tx := &client.DynamicFeeTx{
-		ChainID:              s.chainID,
-		Nonce:                nonce,
-		MaxPriorityFeePerGas: fees.MaxPriorityFeePerGas,
-		MaxFeePerGas:         fees.MaxFeePerGas,
-		Gas:                  gasLimit,
-		To:                   &s.tokenState,
-		Value:                big.NewInt(0), // applyStateDelta is not payable
-		Data:                 data,
-	}
-
-	rawTx, err = client.SignTx(tx, s.key)
-	if err != nil {
-		return nil, client.Hash{}, errors.Wrap(err, "submitter: failed to sign the transaction")
-	}
-	txHash, err = s.client.SendRawTransaction(ctx, rawTx)
-	if err != nil {
-		// A transaction the node refused to accept was never judged by the chain, so this is the
-		// transient class: the delta is still valid and the caller should retry rather than re-derive
-		// it. A node that executed it and rejected it comes back through gasLimit instead.
-		return nil, client.Hash{}, errors.Wrapf(
-			ErrNetworkUnavailable, "submitter: failed to broadcast the transaction: %v", err)
 	}
 
 	return rawTx, txHash, nil

--- a/x/token/services/network/evm/submitter_test.go
+++ b/x/token/services/network/evm/submitter_test.go
@@ -115,10 +115,12 @@ func TestSubmitFixedGasStrategy(t *testing.T) {
 	assert.Zero(t, evm.EstimateGasCallCount(), "a fixed limit must not consult the node")
 }
 
-// TestSubmitResetsNonceOnFailure is the production trap: a nonce allocated for a transaction that
-// never reached the node would leave a gap, and every later transaction would sit unmineable behind
-// it. A failed submit must put the sequence back under the node's authority.
-func TestSubmitResetsNonceOnFailure(t *testing.T) {
+// TestSubmitDoesNotAdvanceTheNonceOnFailure is the production trap: a nonce allocated for a
+// transaction that never reached the node must not be lost, or every later transaction sits
+// unmineable behind the gap. Submit runs the whole attempt under the nonce manager's lock, so a
+// failure simply leaves the nonce exactly where it was, ready to be reused without asking the chain
+// again.
+func TestSubmitDoesNotAdvanceTheNonceOnFailure(t *testing.T) {
 	evm := readySubmitterClient()
 	evm.SendRawTransactionReturns(client.Hash{}, errors.New("broadcast rejected"))
 	s := testSubmitter(t, evm, estimateGas())
@@ -126,8 +128,9 @@ func TestSubmitResetsNonceOnFailure(t *testing.T) {
 	_, _, err := s.Submit(t.Context(), testDelta(), [][]byte{make([]byte, 65)})
 	require.Error(t, err)
 
-	_, initialized := s.nonces.Cached()
-	assert.False(t, initialized, "a failed broadcast must reset the nonce sequence")
+	next, initialized := s.nonces.Cached()
+	assert.True(t, initialized, "the manager still knows its sequence; there was nothing to lose")
+	assert.Equal(t, uint64(3), next, "the nonce this attempt held must still be the next one handed out")
 }
 
 // TestSubmitClassifiesARevertedEstimate covers the verdict the shared fungible bodies actually read.
@@ -189,17 +192,18 @@ func TestSubmitClassifiesARevertedEstimate(t *testing.T) {
 		require.NotErrorIs(t, err, ErrTransactionReverted)
 	})
 
-	// The nonce reset is what makes the retry advice usable: a rejected transaction that consumed a
-	// nonce locally would leave every later one stuck behind a gap.
-	t.Run("a rejected transaction leaves no nonce gap", func(t *testing.T) {
+	// Not consuming the nonce is what makes the retry advice usable: a rejected transaction that
+	// consumed a nonce locally would leave every later one stuck behind a gap.
+	t.Run("a rejected transaction leaves its nonce ready to reuse", func(t *testing.T) {
 		evm := readySubmitterClient()
 		evm.EstimateGasReturns(0, reverted)
 		s := testSubmitter(t, evm, estimateGas())
 
 		_, _, err := s.Submit(t.Context(), testDelta(), [][]byte{make([]byte, 65)})
 		require.Error(t, err)
-		_, initialized := s.nonces.Cached()
-		assert.False(t, initialized, "a rejected transaction must put the sequence back under the node")
+		next, initialized := s.nonces.Cached()
+		assert.True(t, initialized)
+		assert.Equal(t, uint64(3), next, "the rejected attempt's nonce must still be next in line")
 	})
 }
 


### PR DESCRIPTION
Went through the evm driver directory end to end looking for correctness bugs and fixed everything that verified against the actual code, six that could produce a wrong result and four smaller ones. One commit per fix, each with its own tests.

High:
- finality/manager.go: a run of transient read errors right before the timeout used to resolve as Invalid even though the chain was never actually reached; now it only reports Invalid if at least one poll succeeded, otherwise it reports the read failure instead.
- config.go: the default finality timeout (5m) was shorter than real PoS time-to-finality (~13m) on the finalized tag, so a transaction could never be seen as final and would time out as Invalid no matter what. Raised the default and added a floor Validate enforces.
- pp/watcher.go + driver.go: a failed public-parameters reload was marked seen anyway, so the version was never retried and a node could keep running stale parameters.
- pp/provider.go: PublicParams read the parameter bytes and their version as two separate calls with no consistency check, so a version bump between them could hand back bytes for the wrong version. Now brackets the read and retries on a mismatch.
- driver.go: SetupPublicParams checked a single network-wide endorsement field instead of resolving it per TMS, so an endorsing TMS on a node running more than one TMS never got public parameter validation wired up.
- nonce.go + submitter.go: the nonce was advanced before the submit attempt, not after it succeeded, so a rejected transaction still burned a nonce and a concurrent submit could double-allocate the gap. Reworked around a single WithNonce call that only advances after the caller reports success.

Medium/low:
- driver.go: registerEndorser used sync.Once, so a second TMS trying to register as an endorser silently discarded its config instead of refusing. Now it refuses loudly and keeps the first registration, since the view registry can only ever route to one responder per process.
- config.go + endorsement/authorize.go: an empty allowlist on an enabled endorser was documented as defaulting to the TMS's own nodes, but nothing built that default, so a node came up looking healthy and never actually registered as an endorser. Validate now rejects it at startup, and the stale comments are corrected.
- network.go: Broadcast never checked that the envelope's own anchor matched the anchor baked into its delta. The chain only trusts the delta's anchor while everything local tracks the envelope's, so a mismatch would apply and commit on chain under one anchor while the local side waited forever on another. Broadcast now refuses a mismatched envelope before spending any gas.
- config.go: the blockTag field comment only mentioned finalized and safe, leaving out that latest is also accepted (used by the local Besu test harness, no reorg protection, already documented on the constant itself). Comment corrected, no behavior change.

Also bumped the module to fabric-smart-client v0.17.0, needed to build this branch (dupes #2228, will collapse on rebase).

Tested with go build, go vet, gofmt, golangci-lint on every changed package, and go test -race across the whole module including the anvil e2e test.