### PR TITLE
fix(evm): a second bug-hunt pass, five subsystems plus nwo and statedelta

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -173,6 +173,14 @@ jobs:
             dir: ./x/token/services/network/evm
             pkg: ./client
             func: FuzzBytesToAddress
+          - name: evm-json-log-to-log
+            dir: ./x/token/services/network/evm
+            pkg: ./client
+            func: FuzzJSONLogToLog
+          - name: evm-json-receipt-to-receipt
+            dir: ./x/token/services/network/evm
+            pkg: ./client
+            func: FuzzJSONReceiptToReceipt
 
     steps:
       - name: Checkout code

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -141,6 +141,10 @@ jobs:
             dir: ./x/token/services/network/evm
             pkg: .
             func: FuzzComputeAnchor
+          - name: evm-anchor-from-txid
+            dir: ./x/token/services/network/evm
+            pkg: ./keys
+            func: FuzzAnchorFromTxID
           - name: evm-abi-decode-bytes
             dir: ./x/token/services/network/evm
             pkg: ./abi

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ cmd/token_validation_service/out/
 coverage.out
 /.codex/
 plan.md
+x/BUG_HUNT_PROMPT.md
 
 # The EVM integration suites generate a node binary tree and a network under out/ and testdata/.
 # Both hold real Go files, so a stray "git add -A" commits them and a linter then reports on them.

--- a/docs/services/network-ethereum.md
+++ b/docs/services/network-ethereum.md
@@ -323,12 +323,12 @@ sequenceDiagram
     
     Note over Driver,State: On-Chain Execution Phase
     Driver->>Node: eth_sendRawTransaction
-    Node->>Contract: Execute applyStateUpdate()
-    Contract->>Contract: Verify endorser signatures
-    Contract->>Contract: Check signature threshold
-    Contract->>Contract: Double Spending Check
+    Node->>Contract: Execute applyStateDelta()
+    Contract->>Contract: Recompute the EIP-712 digest
+    Contract->>Contract: Verify endorser quorum
+    Contract->>Contract: Check public parameters are current
     Contract->>State: Apply state delta
-    Contract->>Contract: Emit StateUpdateEvent
+    Contract->>Contract: Emit StateCommitted
     
     Node->>Node: Include in block
     Node->>Node: Mine block
@@ -337,7 +337,297 @@ sequenceDiagram
     Driver-->>App: OnStatus(VALID)
 ```
 
+### How the contracts interact
+
+This section describes the contracts as built. Every name, error and check order below comes from
+[`contracts/src`](../../x/token/services/network/evm/contracts/src); the conceptual sketch further down
+the page predates them.
+
+#### Where the work happens
+
+The single most important thing to understand is that **the chain does not validate token requests**.
+Zero-knowledge proofs are not verified on chain, signatures on the token request are not checked on
+chain, and balances are not recomputed on chain. All of that happens off chain, in FSC endorsers running
+the same Token SDK validator that a Fabric deployment uses.
+
+What reaches the chain is a `StateDelta`: a flat list of storage writes that the endorsers agreed on,
+plus their signatures over it. The contract's job is narrow and cheap.
+
+```mermaid
+flowchart LR
+    subgraph off ["Off chain"]
+        direction TB
+        R["Token request<br/>proofs, signatures, amounts"]
+        E["Endorsers<br/>each validates independently<br/>and derives the same StateDelta"]
+        R --> E
+    end
+
+    subgraph on ["On chain"]
+        direction TB
+        T["TokenState<br/>checks the signatures<br/>applies the writes"]
+    end
+
+    E -->|"StateDelta + N signatures"| T
+
+    style off fill:#f6f8fa,stroke:#d1d9e0,color:#1f2328
+    style on fill:#ddf4ff,stroke:#54aeff,color:#1f2328
+```
+
+This is why the contracts are small. They never see a proof. They answer one question: did enough
+authorized endorsers sign *this exact set of writes*, and are those writes still valid to apply?
+
+#### The StateDelta
+
+Everything below revolves around this struct, so it is worth reading once. It is defined in
+[`StateDelta.sol`](../../x/token/services/network/evm/contracts/src/StateDelta.sol) and mirrored exactly
+by the Go type in `evm/statedelta`. Field order is frozen: the EIP-712 hash depends on it, and every
+endorser signs over that hash.
+
+| Field | What it is | Who consumes it |
+|---|---|---|
+| `anchor` | The token-request id, `SHA-256(nonce‖creator)`. **Not** the Ethereum transaction hash. | Replay guard, and the key a recipient watches for |
+| `spentRefs` | The references being consumed. Meaning depends on the contract's mode, see below. | Double-spend check |
+| `outputs` | New tokens: `tokenID`, `snMarker`, and the opaque `tokenData` from the token driver | Written to storage |
+| `metadataKeys` / `metadataVals` | Aligned lists, keys sorted ascending so every endorser builds identical bytes | Written once, never overwritten |
+| `tokenRequestHash` | `SHA-256` of the token request, matching what the rest of the Token SDK stores | Recorded against the anchor |
+| `publicParamsHash` / `publicParamsVersion` | The parameters the endorsers validated against | Staleness check |
+| `isSetup` | Marks a parameters-update delta rather than a token transfer | Selects which branch applies |
+| `setupParameters` | The new public parameters, present only when `isSetup` | Stored by the setup branch |
+
+Two things about this struct trip people up.
+
+**`anchor` is not the transaction hash.** A contract cannot read its own transaction hash, so the driver
+identifies transactions by the anchor it derived off chain. This is why finality is resolved by scanning
+for an event keyed on the anchor rather than by looking up a transaction.
+
+**`spentRefs` means one of two things, fixed per contract.** With `graphHiding` off, each ref is a
+content-bound marker that must already exist and be unspent; because the marker commits to the token's
+bytes, a spender cannot substitute different content at the same position. With `graphHiding` on, each
+ref is a serial number that simply must not have been seen before, which reveals nothing about which
+output is being consumed. One TMS runs one token driver, so the mode is chosen at deployment and never
+changes.
+
+#### The six files, and what each one is
+
+`contracts/src` holds six files, but only four of them become contracts at an address. The other two are
+libraries whose functions are all `internal`, which the Solidity compiler inlines into whoever calls them,
+so they never get deployed on their own.
+
+```mermaid
+flowchart TB
+    subgraph dep ["Deployed to an address"]
+        direction TB
+        TSI["TokenState.sol<br/>implementation, deployed once"]
+        TSC["TokenState clone<br/>one per TMS, holds all storage"]
+        EV["EndorsementVerifier.sol<br/>endorser set and threshold"]
+        FAC["TokenStateFactory.sol<br/>deploy time only"]
+    end
+
+    subgraph inl ["Libraries, inlined into the caller"]
+        direction TB
+        E712["EIP712.sol<br/>compiled into TokenState"]
+        CL["Clones.sol<br/>compiled into TokenStateFactory"]
+    end
+
+    subgraph typ ["Types only, no code"]
+        SD["StateDelta.sol<br/>two structs, field order frozen"]
+    end
+
+    style dep fill:#ddf4ff,stroke:#54aeff,color:#1f2328
+    style inl fill:#fff8c5,stroke:#d4a72c,color:#1f2328
+    style typ fill:#f6f8fa,stroke:#d1d9e0,color:#1f2328
+```
+
+`StateDelta.sol` is compiled into both `TokenState` and `EIP712`. Its field order is frozen because the
+EIP-712 hash is computed from it and every endorser signs that hash, so reordering a field would silently
+invalidate every signature.
+
+The two libraries are worth being explicit about, because their names suggest more than they are.
+`Clones.sol` is production code, not test scaffolding: `TokenStateFactory.create` calls
+`Clones.clone(implementation)` to create each per-TMS clone. It also appears in the contract tests, which
+clone directly so they exercise the same shape production uses.
+
+#### Phase 1, deployment
+
+Run once per network, from
+[`Deploy.s.sol`](../../x/token/services/network/evm/contracts/script/Deploy.s.sol). Three contracts are
+created, and then the factory produces the clone that a TMS will actually use.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant S as Deploy script
+    participant EV as EndorsementVerifier
+    participant I as TokenState implementation
+    participant F as TokenStateFactory
+    participant C as TokenState clone
+
+    S->>EV: new EndorsementVerifier(endorsers, threshold)
+    S->>I: new TokenState()
+    Note over I: locks itself in its constructor,<br/>so only a clone can be initialized
+    S->>F: new TokenStateFactory(implementation)
+
+    S->>F: create(verifier, deployer, pp0, graphHiding)
+    F->>C: Clones.clone deploys an EIP-1167 proxy
+    F->>C: initialize(verifier, deployer, pp0, graphHiding)
+    Note over F,C: both in one transaction, so an<br/>uninitialized clone is never reachable
+    F-->>S: clone address
+
+    S->>C: read back verifier, params hash, version, mode, deployer
+```
+
+Cloning and initializing in one call is deliberate. `initialize` is deliberately unguarded, because the
+implementation is locked and only a fresh clone can ever be initialized. Doing it in two transactions
+would leave a window in which anyone could seize the clone by initializing it first with their own
+verifier, and the honest deployer's call would then revert with `AlreadyInitialized`.
+
+Each TMS gets its own [EIP-1167](https://eips.ethereum.org/EIPS/eip-1167) minimal proxy, so a new TMS
+costs a proxy rather than a full deployment while sharing one copy of the logic. Every clone has its own
+storage.
+
+#### Phase 2, processing a transaction
+
+Three addresses take part, but only one of them holds any state.
+
+```mermaid
+flowchart LR
+    D["Driver"] -->|"applyStateDelta<br/>delta + signatures"| C
+
+    subgraph clone ["TokenState clone: the address, and all the storage"]
+        C["EIP-1167 proxy,<br/>almost no code of its own"]
+    end
+
+    subgraph impl ["TokenState implementation: the code, no storage of its own"]
+        direction TB
+        E["applyStateDelta,<br/>running on the clone's storage"] --> H["EIP712, inlined here:<br/>recompute the digest"]
+        H --> A["apply the writes"]
+    end
+
+    C -->|"delegatecall"| E
+    H -->|"verify(digest, signatures)"| V["EndorsementVerifier"]
+    V -->|"accepted, or revert"| H
+    A -->|"emit StateCommitted"| L["Logs, at the clone's address"]
+
+    style clone fill:#ddf4ff,stroke:#54aeff,color:#1f2328
+    style impl fill:#f6f8fa,stroke:#d1d9e0,color:#1f2328
+    style V fill:#dafbe1,stroke:#4ac26b,color:#1f2328
+```
+
+Two things there are easy to get wrong when reading the sources.
+
+**The code does not live where the storage lives.** The clone owns the address, the token map, the spent
+markers and the public parameters, but it is a minimal proxy and carries almost no logic. Every call to it
+`delegatecall`s the shared implementation, which then executes against the clone's storage. So
+`applyStateDelta` is the implementation's code running as though it were the clone.
+
+**`EIP712` is not a contract.** Its functions are all `internal`, so the compiler copies them into
+`TokenState` at build time. Recomputing the digest costs no external call, and there is no `EIP712`
+address to look up on a block explorer.
+
+That leaves exactly one call crossing an address boundary while a transaction is processed: `TokenState`
+asking `EndorsementVerifier` to check the quorum. `TokenStateFactory` and `Clones` play no part at all
+once deployment is over.
+
+Because the writes and the event happen in the clone's context, `StateCommitted` is emitted at the
+clone's address, and that is the address the finality layer filters `eth_getLogs` on.
+
+#### The same transaction, step by step
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant D as Driver
+    participant N as EVM node
+    participant TS as TokenState
+    participant EV as EndorsementVerifier
+
+    Note over D: delta and signatures already<br/>collected from endorsers
+    D->>N: eth_sendRawTransaction
+    N->>TS: applyStateDelta(delta, signatures)
+
+    TS->>TS: cheap rejects first:<br/>initialized, anchor unseen, lists aligned
+    TS->>TS: recompute the EIP-712 digest<br/>from the delta in calldata
+
+    TS->>EV: verify(digest, signatures)
+    EV-->>TS: accepted, or revert with the reason
+
+    TS->>TS: are the public parameters still current?
+    TS->>TS: apply the writes
+
+    TS-->>N: emit StateCommitted(anchor)
+    N-->>D: receipt, status 1
+```
+
+Step 4 is the one worth pausing on. **`TokenState` computes the digest itself, from the delta sitting in
+calldata.** The digest is never passed in as an argument. That is what makes the endorsers' signatures
+binding: they signed the same typed structure the contract is about to apply. The digest also folds in a
+domain separator bound to this chain id and this contract address, so signatures gathered for one TMS
+cannot be replayed against another.
+
+#### The checks, in order
+
+`applyStateDelta` runs these gates in sequence. There is no partial success: any failure reverts the whole
+transaction, so state is either fully applied or completely untouched.
+
+```mermaid
+flowchart TB
+    G1["1 - contract is initialized"] --> G2["2 - anchor has never been processed"]
+    G2 --> G3["3 - metadata keys and values are the same length"]
+    G3 --> G4["4 - endorser quorum verifies against the digest"]
+    G4 --> G5["5 - public parameters are still current"]
+    G5 --> G6{"isSetup?"}
+    G6 -->|"yes"| S["store new parameters<br/>bump the version"]
+    G6 -->|"no"| T["consume spentRefs<br/>write outputs<br/>write metadata"]
+    S --> Z["record the request hash<br/>mark the anchor processed<br/>emit StateCommitted"]
+    T --> Z
+
+    style Z fill:#dafbe1,stroke:#4ac26b,color:#1f2328
+```
+
+The order is deliberate: the cheap rejections come before signature recovery, which is the expensive part,
+so a replayed or malformed delta costs as little gas as possible.
+
+#### What each failure means
+
+Every gate reverts with its own typed error, so a failed receipt tells you exactly what happened. This is
+the table to reach for when a transaction reverts.
+
+| Error | Meaning | Usual cause |
+|---|---|---|
+| `NotInitialized` | The clone was never seeded | Deployment did not go through the factory |
+| `AnchorAlreadyProcessed` | This anchor was applied before | A resubmitted transaction, or a genuine replay attempt |
+| `MetadataLengthMismatch` | Key and value lists differ in length | A malformed delta; the endorser's translator builds these aligned |
+| `InsufficientEndorsements` | Fewer signatures than the threshold | An endorser was unreachable when the quorum was collected |
+| `UnauthorizedSigner` | A signature came from a non-endorser | The driver's endorser set has drifted from the contract's |
+| `DuplicateSigner` | The same endorser signed twice | A broken initiator; N signatures from one endorser are not N endorsements |
+| `InvalidSignatureLength` | A signature was not 65 bytes | A malformed or truncated signature |
+| `StalePublicParams` | The delta names parameters that are no longer current | Someone updated the parameters between endorsement and submission; re-endorse |
+| `InputMissingOrSpent` | A consumed marker does not exist, or is already spent | A double spend, or a token whose content does not match what was recorded |
+| `DoubleSpend` | A serial number was already used (graph-hiding mode) | A double spend |
+| `MetadataKeyOccupied` | A metadata key was already written | A reused key, for example an HTLC claim seen twice |
+| `MalformedSetupDelta` | A setup delta carried spends, outputs or metadata, or no parameters | A driver bug; setup deltas carry only new parameters |
+| `MalformedTransferDelta` | A transfer delta carried setup parameters | A driver bug |
+
+Metadata keys being write-once is worth calling out. A reused key reverts rather than overwriting, which
+matches Fabric's `StateMustNotExist`. Silently overwriting something like an HTLC claim key would be a
+correctness bug, not a convenience.
+
+#### Why a failure is invisible to a recipient
+
+A revert emits no `StateCommitted` event. Since a recipient who only saw the token request knows the
+anchor and nothing else, and finds the transaction by scanning for that event, **log scanning can only
+ever discover success**. There is no failure event to find, because the failed transaction wrote nothing.
+
+A recipient must therefore treat "no event by the timeout" as failure. This asymmetry is a consequence of
+identifying transactions by anchor rather than by transaction hash, and it is why the finality timeout is a
+correctness setting rather than a tuning knob.
+
 ### Smart Contract Interface
+
+The sketch below predates the implementation and is kept for the shape of the idea. The contracts that
+were actually built live in
+[`contracts/src`](../../x/token/services/network/evm/contracts/src): the entry point is
+`TokenState.applyStateDelta(StateDelta, bytes[])`, described above.
 
 ```solidity
 // Conceptual interface - not production code

--- a/x/token/services/network/evm/abi/fuzz_test.go
+++ b/x/token/services/network/evm/abi/fuzz_test.go
@@ -102,7 +102,21 @@ func FuzzDecodeUint64(f *testing.F) {
 	f.Add(make([]byte, wordLength*2))
 
 	f.Fuzz(func(t *testing.T, ret []byte) {
-		_, _ = DecodeUint64(ret)
+		got, err := DecodeUint64(ret)
+		if err != nil {
+			return
+		}
+		if len(ret) < wordLength {
+			t.Fatalf("decoded a uint64 from a %d byte response, shorter than one word", len(ret))
+		}
+		// The value must actually fit: every byte outside the low 8 has to be zero, checked here by an
+		// independent comparison rather than the same byte-loop DecodeUint64 itself uses.
+		if !bytes.Equal(ret[:wordLength-8], make([]byte, wordLength-8)) {
+			t.Fatalf("accepted a value whose high bytes are not zero: it does not fit in a uint64")
+		}
+		if want := binary.BigEndian.Uint64(ret[wordLength-8 : wordLength]); got != want {
+			t.Fatalf("decoded %d, but the low 8 bytes actually encode %d", got, want)
+		}
 	})
 }
 

--- a/x/token/services/network/evm/client/evmclient.go
+++ b/x/token/services/network/evm/client/evmclient.go
@@ -53,14 +53,19 @@ type Log struct {
 // Topics follows the eth_getLogs convention: position i lists the acceptable values for topic i;
 // an empty inner slice matches any value at that position.
 //
-// ToBlock == 0 means "latest": a range ending at genesis is never a useful query, and searching up to
-// the head is what a caller looking for an event actually wants, so the zero value is spent on the
-// common case rather than requiring a separate round trip to read the current block number.
+// The upper end of the range is ToBlockTag when set, otherwise ToBlock, with ToBlock == 0 meaning
+// "latest": a range ending at genesis is never a useful query, and searching up to the head is what a
+// caller looking for an event actually wants, so the zero value is spent on the common case rather
+// than requiring a separate round trip to read the current block number. ToBlockTag lets a caller that
+// cares about reorg safety search only up to its configured tag (e.g. "finalized") instead.
 type LogFilter struct {
 	Address   Address
 	FromBlock uint64
 	ToBlock   uint64
-	Topics    [][]Hash
+	// ToBlockTag, when non-empty, is sent as the upper bound instead of ToBlock (e.g. BlockTagFinalized
+	// or BlockTagSafe).
+	ToBlockTag string
+	Topics     [][]Hash
 }
 
 // GasFees carries the EIP-1559 fee parameters suggested by the node.

--- a/x/token/services/network/evm/client/evmclient.go
+++ b/x/token/services/network/evm/client/evmclient.go
@@ -43,6 +43,10 @@ type Log struct {
 	Data        []byte
 	TxHash      Hash
 	BlockNumber uint64
+	// Removed is true when the node is reporting that a reorg has undone the block this log was
+	// mined in. A caller treating a log as evidence of a committed, permanent effect must not trust
+	// one with Removed set.
+	Removed bool
 }
 
 // LogFilter selects logs by contract address, block range and indexed topics.

--- a/x/token/services/network/evm/client/fuzz_test.go
+++ b/x/token/services/network/evm/client/fuzz_test.go
@@ -8,6 +8,7 @@ package client
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -91,5 +92,50 @@ func FuzzBytesToAddress(f *testing.F) {
 		if len(b) >= AddressLength && !bytes.Equal(address[:], b[len(b)-AddressLength:]) {
 			t.Fatalf("right-alignment dropped bytes: %x from %x", address, b)
 		}
+	})
+}
+
+// FuzzJSONLogToLog fuzzes the eth_getLogs record decoder. It is the point where a response body from
+// whatever node the driver was pointed at (a compromised, buggy, or simply mismatched one, per the
+// design's own framing of alternative EVM backends) turns into a driver type, so the property is that
+// a malformed record is rejected rather than panicking the caller.
+func FuzzJSONLogToLog(f *testing.F) {
+	f.Add(
+		`{"address":"0x5FbDB2315678afecb367f032d93F642f64180aa3",` +
+			`"topics":["0x853f272fffc6efc284fc16a254decca742d2347e05703e501c59968f78f81ffa"],"data":"0xabcd",` +
+			`"transactionHash":"0x853f272fffc6efc284fc16a254decca742d2347e05703e501c59968f78f81ffa","blockNumber":"0x1"}`,
+	)
+	f.Add(`{}`)
+	f.Add(`{"topics":[""]}`)
+	f.Add(`{"topics":["not hex"]}`)
+	f.Add(`{"data":"not hex"}`)
+	f.Add(`{"blockNumber":"not hex"}`)
+	f.Add(`not json at all`)
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		var j jsonLog
+		if err := json.Unmarshal([]byte(raw), &j); err != nil {
+			return
+		}
+		_, _ = j.toLog()
+	})
+}
+
+// FuzzJSONReceiptToReceipt fuzzes the eth_getTransactionReceipt record decoder, the same node-supplied
+// boundary as FuzzJSONLogToLog, including the nested logs it decodes through jsonLog.toLog.
+func FuzzJSONReceiptToReceipt(f *testing.F) {
+	f.Add(`{"transactionHash":"0x853f272fffc6efc284fc16a254decca742d2347e05703e501c59968f78f81ffa","blockNumber":"0x1","status":"0x1","logs":[]}`)
+	f.Add(`{}`)
+	f.Add(`{"status":"not hex"}`)
+	f.Add(`{"blockNumber":null,"status":"0x0"}`)
+	f.Add(`{"logs":[{"data":"not hex"}]}`)
+	f.Add(`not json at all`)
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		var j jsonReceipt
+		if err := json.Unmarshal([]byte(raw), &j); err != nil {
+			return
+		}
+		_, _ = j.toReceipt()
 	})
 }

--- a/x/token/services/network/evm/client/fuzz_test.go
+++ b/x/token/services/network/evm/client/fuzz_test.go
@@ -117,8 +117,47 @@ func FuzzJSONLogToLog(f *testing.F) {
 		if err := json.Unmarshal([]byte(raw), &j); err != nil {
 			return
 		}
-		_, _ = j.toLog()
+		log, err := j.toLog()
+		if err != nil {
+			return
+		}
+		assertLogMatchesRaw(t, log, j)
 	})
+}
+
+// assertLogMatchesRaw re-derives every field of log directly from j's raw strings and requires an
+// exact match. toLog is glue over the already-fuzzed HexToAddress/HexToHash/decodeHexBytes/
+// parseHexUint, so this does not re-implement hex parsing; it proves toLog actually wires each field
+// through its parser and propagates that parser's error, rather than, say, silently substituting a
+// zero value for a field it failed to parse.
+func assertLogMatchesRaw(t *testing.T, log Log, j jsonLog) {
+	t.Helper()
+
+	addr, err := HexToAddress(j.Address)
+	if err != nil || log.Address != addr {
+		t.Fatalf("toLog succeeded but Address does not match parsing j.Address directly (err=%v)", err)
+	}
+	txHash, err := HexToHash(j.TxHash)
+	if err != nil || log.TxHash != txHash {
+		t.Fatalf("toLog succeeded but TxHash does not match parsing j.TxHash directly (err=%v)", err)
+	}
+	data, err := decodeHexBytes(j.Data)
+	if err != nil || !bytes.Equal(log.Data, data) {
+		t.Fatalf("toLog succeeded but Data does not match parsing j.Data directly (err=%v)", err)
+	}
+	blockNumber, err := parseHexUint(j.BlockNumber)
+	if err != nil || log.BlockNumber != blockNumber {
+		t.Fatalf("toLog succeeded but BlockNumber does not match parsing j.BlockNumber directly (err=%v)", err)
+	}
+	if len(log.Topics) != len(j.Topics) {
+		t.Fatalf("toLog succeeded but topic count changed: got %d, raw had %d", len(log.Topics), len(j.Topics))
+	}
+	for i, raw := range j.Topics {
+		h, err := HexToHash(raw)
+		if err != nil || log.Topics[i] != h {
+			t.Fatalf("toLog succeeded but topic %d does not match parsing it directly (err=%v)", i, err)
+		}
+	}
 }
 
 // FuzzJSONReceiptToReceipt fuzzes the eth_getTransactionReceipt record decoder, the same node-supplied
@@ -136,6 +175,33 @@ func FuzzJSONReceiptToReceipt(f *testing.F) {
 		if err := json.Unmarshal([]byte(raw), &j); err != nil {
 			return
 		}
-		_, _ = j.toReceipt()
+		receipt, err := j.toReceipt()
+		if err != nil {
+			return
+		}
+
+		txHash, err := HexToHash(j.TxHash)
+		if err != nil || receipt.TxHash != txHash {
+			t.Fatalf("toReceipt succeeded but TxHash does not match parsing j.TxHash directly (err=%v)", err)
+		}
+		status, err := parseHexUint(j.Status)
+		if err != nil || receipt.Status != status {
+			t.Fatalf("toReceipt succeeded but Status does not match parsing j.Status directly (err=%v)", err)
+		}
+		if (j.BlockNumber == nil) != (receipt.BlockNumber == nil) {
+			t.Fatalf("toReceipt succeeded but BlockNumber presence does not match the raw field")
+		}
+		if j.BlockNumber != nil {
+			bn, err := parseHexUint(*j.BlockNumber)
+			if err != nil || *receipt.BlockNumber != bn {
+				t.Fatalf("toReceipt succeeded but BlockNumber does not match parsing it directly (err=%v)", err)
+			}
+		}
+		if len(receipt.Logs) != len(j.Logs) {
+			t.Fatalf("toReceipt succeeded but log count changed: got %d, raw had %d", len(receipt.Logs), len(j.Logs))
+		}
+		for i := range j.Logs {
+			assertLogMatchesRaw(t, receipt.Logs[i], j.Logs[i])
+		}
 	})
 }

--- a/x/token/services/network/evm/client/jsonrpc.go
+++ b/x/token/services/network/evm/client/jsonrpc.go
@@ -430,6 +430,7 @@ type jsonLog struct {
 	Data        string   `json:"data"`
 	TxHash      string   `json:"transactionHash"`
 	BlockNumber string   `json:"blockNumber"`
+	Removed     bool     `json:"removed"`
 }
 
 func (j *jsonLog) toLog() (Log, error) {
@@ -458,7 +459,9 @@ func (j *jsonLog) toLog() (Log, error) {
 		return Log{}, errors.Wrap(err, "invalid log block number")
 	}
 
-	return Log{Address: addr, Topics: topics, Data: data, TxHash: txHash, BlockNumber: blockNumber}, nil
+	return Log{
+		Address: addr, Topics: topics, Data: data, TxHash: txHash, BlockNumber: blockNumber, Removed: j.Removed,
+	}, nil
 }
 
 type jsonReceipt struct {

--- a/x/token/services/network/evm/client/jsonrpc.go
+++ b/x/token/services/network/evm/client/jsonrpc.go
@@ -517,9 +517,9 @@ func encodeHexBytes(b []byte) string {
 	return "0x" + hex.EncodeToString(b)
 }
 
-// decodeHexBytes decodes 0x-prefixed hex data, tolerating an empty or bare "0x" value.
+// decodeHexBytes decodes 0x/0X-prefixed hex data, tolerating an empty or bare prefix value.
 func decodeHexBytes(s string) ([]byte, error) {
-	s = strings.TrimPrefix(strings.TrimSpace(s), "0x")
+	s = trimHexPrefix(s)
 	if s == "" {
 		return nil, nil
 	}
@@ -531,9 +531,9 @@ func decodeHexBytes(s string) ([]byte, error) {
 	return b, nil
 }
 
-// parseHexUint parses a 0x-prefixed hex quantity into a uint64.
+// parseHexUint parses a 0x/0X-prefixed hex quantity into a uint64.
 func parseHexUint(s string) (uint64, error) {
-	trimmed := strings.TrimPrefix(strings.TrimSpace(s), "0x")
+	trimmed := trimHexPrefix(s)
 	if trimmed == "" {
 		return 0, errors.Errorf("empty hex quantity")
 	}
@@ -545,9 +545,9 @@ func parseHexUint(s string) (uint64, error) {
 	return v, nil
 }
 
-// parseHexBig parses a 0x-prefixed hex quantity into a big.Int.
+// parseHexBig parses a 0x/0X-prefixed hex quantity into a big.Int.
 func parseHexBig(s string) (*big.Int, error) {
-	trimmed := strings.TrimPrefix(strings.TrimSpace(s), "0x")
+	trimmed := trimHexPrefix(s)
 	if trimmed == "" {
 		return nil, errors.Errorf("empty hex quantity")
 	}

--- a/x/token/services/network/evm/client/jsonrpc.go
+++ b/x/token/services/network/evm/client/jsonrpc.go
@@ -113,7 +113,10 @@ func (c *JSONRPCClient) GetLogs(ctx context.Context, q LogFilter) ([]Log, error)
 		topics = append(topics, values)
 	}
 	toBlock := any(encodeHexUint(q.ToBlock))
-	if q.ToBlock == 0 {
+	switch {
+	case q.ToBlockTag != "":
+		toBlock = q.ToBlockTag
+	case q.ToBlock == 0:
 		toBlock = BlockTagLatest
 	}
 	arg := map[string]any{

--- a/x/token/services/network/evm/client/jsonrpc.go
+++ b/x/token/services/network/evm/client/jsonrpc.go
@@ -218,13 +218,19 @@ func (c *JSONRPCClient) SuggestGasFees(ctx context.Context) (GasFees, error) {
 }
 
 // baseFee reads the base fee of the latest block. A chain with no base fee at all (a pre-London or
-// zero-fee configuration) reports none, which is a base fee of zero rather than an error.
+// zero-fee configuration) reports the field absent, which is a base fee of zero rather than an error.
+// A null result, by contrast, means the node did not return a block at all and is an error: head is a
+// pointer so that case is distinguishable, since unmarshaling JSON null into a non-pointer target is a
+// silent no-op that would otherwise be indistinguishable from the legitimate absent-field case.
 func (c *JSONRPCClient) baseFee(ctx context.Context) (*big.Int, error) {
-	var head struct {
+	var head *struct {
 		BaseFeePerGas string `json:"baseFeePerGas"`
 	}
 	if err := c.call(ctx, "eth_getBlockByNumber", &head, "latest", false); err != nil {
 		return nil, err
+	}
+	if head == nil {
+		return nil, errors.New("evm client: eth_getBlockByNumber(\"latest\") returned no block")
 	}
 	if head.BaseFeePerGas == "" {
 		return new(big.Int), nil

--- a/x/token/services/network/evm/client/jsonrpc.go
+++ b/x/token/services/network/evm/client/jsonrpc.go
@@ -72,14 +72,25 @@ func (c *JSONRPCClient) Ping(ctx context.Context) error {
 	return err
 }
 
-// Call performs a read-only contract call at the given block tag.
+// Call performs a read-only contract call at the given block tag. A revert is classified the same way
+// EstimateGas classifies one (ErrExecutionReverted), so a caller that later adds a Call against a
+// method capable of reverting does not have to rediscover this distinction: eth_call and
+// eth_estimateGas fail the same way against the same node.
 func (c *JSONRPCClient) Call(ctx context.Context, to Address, data []byte, blockTag string) ([]byte, error) {
 	if blockTag == "" {
 		blockTag = BlockTagFinalized
 	}
 	arg := map[string]any{"to": to.Hex(), "data": encodeHexBytes(data)}
 	var out string
-	if err := c.call(ctx, "eth_call", &out, arg, blockTag); err != nil {
+	rpcErr, err := c.invoke(ctx, "eth_call", &out, arg, blockTag)
+	if rpcErr != nil {
+		if isReverted(rpcErr) {
+			return nil, errors.Wrapf(ErrExecutionReverted, "eth_call failed: %s", rpcErr.Message)
+		}
+
+		return nil, errors.Wrap(rpcErr, "eth_call failed")
+	}
+	if err != nil {
 		return nil, err
 	}
 

--- a/x/token/services/network/evm/client/jsonrpc_test.go
+++ b/x/token/services/network/evm/client/jsonrpc_test.go
@@ -501,4 +501,18 @@ func TestHexHelpers(t *testing.T) {
 		_, err = decodeHexBytes("0xodd")
 		require.Error(t, err)
 	})
+
+	t.Run("an uppercase 0X prefix is tolerated exactly like decodeHex accepts one", func(t *testing.T) {
+		got, err := parseHexUint("0X2a")
+		require.NoError(t, err)
+		assert.Equal(t, uint64(42), got)
+
+		gotBig, err := parseHexBig("0X2a")
+		require.NoError(t, err)
+		assert.Zero(t, gotBig.Cmp(big.NewInt(42)))
+
+		gotBytes, err := decodeHexBytes("0Xdead")
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0xde, 0xad}, gotBytes)
+	})
 }

--- a/x/token/services/network/evm/client/jsonrpc_test.go
+++ b/x/token/services/network/evm/client/jsonrpc_test.go
@@ -120,6 +120,32 @@ func TestCallSurfacesRPCError(t *testing.T) {
 	assert.Contains(t, err.Error(), "method not found")
 }
 
+// TestCallClassifiesReverts mirrors TestEstimateGasClassifiesReverts: eth_call can revert against a
+// real node exactly as eth_estimateGas can, and a caller needs the same distinction between "the chain
+// rejected this" and "the node failed to answer" for either one.
+func TestCallClassifiesReverts(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		code     int
+		message  string
+		reverted bool
+	}{
+		{name: "geth wording", code: -32000, message: "execution reverted", reverted: true},
+		{name: "besu wording", code: -32000, message: "Execution reverted", reverted: true},
+		{name: "another server error", code: -32000, message: "header not found", reverted: false},
+		{name: "method not found", code: -32601, message: "method not found", reverted: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newErrorServer(t, tc.code, tc.message)
+
+			_, err := c.Call(context.Background(), Address{}, nil, "latest")
+			require.Error(t, err)
+			assert.Equal(t, tc.reverted, errors.Is(err, ErrExecutionReverted))
+			assert.Contains(t, err.Error(), tc.message)
+		})
+	}
+}
+
 func TestPendingNonceAt(t *testing.T) {
 	c, calls := newTestServer(t, map[string]string{"eth_getTransactionCount": `"0x2a"`})
 

--- a/x/token/services/network/evm/client/jsonrpc_test.go
+++ b/x/token/services/network/evm/client/jsonrpc_test.go
@@ -440,6 +440,24 @@ func TestGetLogs(t *testing.T) {
 	assert.Equal(t, "0x64", arg["toBlock"])
 }
 
+// TestGetLogsCapturesRemoved checks a log the node marks as reorged-out decodes with Removed set,
+// rather than being indistinguishable from a canonical one.
+func TestGetLogsCapturesRemoved(t *testing.T) {
+	c, _ := newTestServer(t, map[string]string{
+		"eth_getLogs": `[{
+			"address":"0x5FbDB2315678afecb367f032d93F642f64180aa3",
+			"topics":["0x1111111111111111111111111111111111111111111111111111111111111111"],
+			"data":"0x","transactionHash":"0x853f272fffc6efc284fc16a254decca742d2347e05703e501c59968f78f81ffa",
+			"blockNumber":"0x2","removed":true
+		}]`,
+	})
+
+	logs, err := c.GetLogs(context.Background(), LogFilter{})
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	assert.True(t, logs[0].Removed, "a reorged-out log must be reported as such")
+}
+
 // TestGetLogsWildcardTopic checks that an empty inner slice becomes a null (match-any) position,
 // which is the eth_getLogs convention.
 func TestGetLogsWildcardTopic(t *testing.T) {

--- a/x/token/services/network/evm/client/jsonrpc_test.go
+++ b/x/token/services/network/evm/client/jsonrpc_test.go
@@ -273,6 +273,19 @@ func TestSuggestGasFeesOnAZeroFeeChain(t *testing.T) {
 	assert.Equal(t, big.NewInt(0), fees.MaxFeePerGas)
 }
 
+// TestSuggestGasFeesErrorsOnANullBlock covers a node that returns no block at all for "latest" (a
+// gateway hiccup or a malformed response), which must not be treated as the pre-London zero-base-fee
+// case: both look like an empty BaseFeePerGas field unless the two are told apart.
+func TestSuggestGasFeesErrorsOnANullBlock(t *testing.T) {
+	c, _ := newTestServer(t, map[string]string{
+		"eth_maxPriorityFeePerGas": `"0x1"`,
+		"eth_getBlockByNumber":     `null`,
+	})
+
+	_, err := c.SuggestGasFees(context.Background())
+	require.Error(t, err)
+}
+
 // TestSuggestGasFeesSurfacesRealFailures checks the fallback is only for an unimplemented method: a
 // node that implements neither is a failure rather than a silent zero fee.
 func TestSuggestGasFeesSurfacesRealFailures(t *testing.T) {

--- a/x/token/services/network/evm/client/types.go
+++ b/x/token/services/network/evm/client/types.go
@@ -167,11 +167,17 @@ func (h *Hash) UnmarshalJSON(data []byte) error {
 	return h.UnmarshalText([]byte(s))
 }
 
-// decodeHex decodes a hex string, tolerating an optional 0x/0X prefix and surrounding whitespace.
-func decodeHex(s string) ([]byte, error) {
+// trimHexPrefix strips surrounding whitespace and an optional 0x/0X prefix. It is the one place that
+// decides what counts as a prefix, shared by every hex parser in this package so a JSON-RPC quantity
+// and an address/hash literal are never held to different rules for the same syntax.
+func trimHexPrefix(s string) string {
 	s = strings.TrimSpace(s)
 	s = strings.TrimPrefix(s, "0x")
-	s = strings.TrimPrefix(s, "0X")
 
-	return hex.DecodeString(s)
+	return strings.TrimPrefix(s, "0X")
+}
+
+// decodeHex decodes a hex string, tolerating an optional 0x/0X prefix and surrounding whitespace.
+func decodeHex(s string) ([]byte, error) {
+	return hex.DecodeString(trimHexPrefix(s))
 }

--- a/x/token/services/network/evm/contracts/src/TokenState.sol
+++ b/x/token/services/network/evm/contracts/src/TokenState.sol
@@ -71,6 +71,7 @@ contract TokenState {
     error MetadataKeyOccupied(bytes32 key);
     error MalformedSetupDelta();
     error MalformedTransferDelta();
+    error UnsupportedForGraphHiding();
 
     event StateCommitted(bytes32 indexed anchor, bool success, string message);
     event PublicParametersUpdated(bytes32 indexed paramsHash, uint64 version);
@@ -192,12 +193,19 @@ contract TokenState {
     }
 
     /// @notice Graph-revealing spent status by token id, resolved through the content-bound marker.
+    /// @dev    Reverts on a graph-hiding clone: that mode never records a marker (translator.go leaves
+    ///         SNMarker zero for it), so tokenMarker[tokenID] would always resolve to snSpent[0x0],
+    ///         which is never set here - a caller would silently get "not spent" for a token that was
+    ///         in fact spent via serialUsed. Use isSerialUsed for a graph-hiding clone instead.
     function isSpent(bytes32 tokenID) external view returns (bool) {
+        if (graphHiding) revert UnsupportedForGraphHiding();
         return snSpent[tokenMarker[tokenID]];
     }
 
     /// @notice Graph-revealing spent status for a batch of token ids, aligned with the input.
+    /// @dev    Reverts on a graph-hiding clone, for the same reason as isSpent.
     function areTokensSpent(bytes32[] calldata tokenIDs) external view returns (bool[] memory out) {
+        if (graphHiding) revert UnsupportedForGraphHiding();
         out = new bool[](tokenIDs.length);
         for (uint256 i = 0; i < tokenIDs.length; i++) {
             out[i] = snSpent[tokenMarker[tokenIDs[i]]];

--- a/x/token/services/network/evm/contracts/test/TokenState.t.sol
+++ b/x/token/services/network/evm/contracts/test/TokenState.t.sol
@@ -344,6 +344,20 @@ contract TokenStateTest is Test {
         gh.applyStateDelta(d2, _signFor(gh, d2));
     }
 
+    function test_GraphHiding_IsSpentQueriesRevert() public {
+        TokenState gh = TokenState(Clones.clone(address(impl)));
+        gh.initialize(address(verifier), address(this), pp0, true);
+
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = keccak256("whatever");
+
+        vm.expectRevert(TokenState.UnsupportedForGraphHiding.selector);
+        gh.isSpent(ids[0]);
+
+        vm.expectRevert(TokenState.UnsupportedForGraphHiding.selector);
+        gh.areTokensSpent(ids);
+    }
+
     // --- lifecycle guards --------------------------------------------------------------------------
 
     function test_DoubleInitialize_Reverts() public {

--- a/x/token/services/network/evm/driver.go
+++ b/x/token/services/network/evm/driver.go
@@ -312,7 +312,9 @@ func (d *Driver) installEndorsement(n *Network, config *Config, evmClient client
 	// Registration happens now, not on the first approval. An endorser node answers requests without
 	// ever making one, so registering lazily on the approval path would mean it never registers at
 	// all and every request to it times out.
-	d.registerEndorser(network+":"+channel, factory, config)
+	if err := d.registerEndorser(network+":"+channel, factory, config); err != nil {
+		return errors.Wrap(err, "evm: failed to register this node as an endorser")
+	}
 
 	return nil
 }
@@ -350,11 +352,19 @@ func (d *Driver) newSubmitter(config *Config, evmClient client.EVMClient) (*Subm
 // against the wrong chain, so it is refused loudly here instead of silently discarded: an operator who
 // configures two endorsing networks on one node needs to see why the second one never answers.
 //
+// Because a broken endorser configuration answers no requests and looks identical to network trouble
+// from the outside, discoverable only once a quorum times out, every failure past that check is
+// returned to the caller instead of only logged: a node explicitly configured with endorser.enabled
+// must not start up looking healthy while unable to fulfil that role, the same contract newSubmitter
+// already holds for a configured-but-broken submitter key. registeredFor is set only once every step
+// succeeds, so a failed attempt does not permanently lock the node out of registering on a later,
+// successful call for the same network.
+//
 // The TMS is resolved when a request arrives rather than now: resolving one here would ask the token
 // layer for a service that is still being built through this very driver.
-func (d *Driver) registerEndorser(networkKey string, factory *endorsement.ServiceFactory, config *Config) {
+func (d *Driver) registerEndorser(networkKey string, factory *endorsement.ServiceFactory, config *Config) error {
 	if d.viewRegistry == nil || !config.Endorser.Enabled {
-		return
+		return nil
 	}
 
 	d.registerMu.Lock()
@@ -367,40 +377,32 @@ func (d *Driver) registerEndorser(networkKey string, factory *endorsement.Servic
 				networkKey, d.registeredFor, networkKey)
 		}
 
-		return
+		return nil
 	}
 
 	signer, err := config.EndorserSigner()
 	if err != nil || signer == nil {
-		logger.Errorf("this node is configured as an endorser but its key is unusable: %v", err)
-
-		return
+		return errors.Wrap(err, "this node is configured as an endorser but its key is unusable")
 	}
 	allowed, err := config.AllowedRequesters(d.resolveIdentity)
 	if err != nil {
-		logger.Errorf("failed to resolve the endorsement allowlist: %v", err)
-
-		return
+		return errors.Wrap(err, "failed to resolve the endorsement allowlist")
 	}
 	authorizer, err := endorsement.NewAuthorizer(allowed)
 	if err != nil {
-		logger.Errorf("failed to build the endorsement allowlist: %v", err)
-
-		return
+		return errors.Wrap(err, "failed to build the endorsement allowlist")
 	}
 	responder, err := factory.NewResponder(authorizer, signer, d.resolveTMS)
 	if err != nil {
-		logger.Errorf("failed to build the endorsement responder: %v", err)
-
-		return
+		return errors.Wrap(err, "failed to build the endorsement responder")
 	}
 	if err := endorsement.RegisterEndorser(d.viewRegistry, responder); err != nil {
-		logger.Errorf("failed to register the endorsement responder: %v", err)
-
-		return
+		return errors.Wrap(err, "failed to register the endorsement responder")
 	}
 	d.registeredFor = networkKey
 	logger.Infof("registered as the endorser for [%s] with address %s", networkKey, signer.Address())
+
+	return nil
 }
 
 // resolveIdentity turns a configured node name into the identity that node speaks with.

--- a/x/token/services/network/evm/driver_test.go
+++ b/x/token/services/network/evm/driver_test.go
@@ -245,3 +245,22 @@ func TestRegisterEndorserSkipsANonEndorsingNetwork(t *testing.T) {
 	assert.Equal(t, 1, registry.calls)
 	assert.Equal(t, "network-a:", d.registeredFor)
 }
+
+// TestRegisterEndorserReturnsAnErrorForABrokenKey is the regression test for the finding that a node
+// explicitly configured as an endorser, but whose signing key cannot be loaded, used to register
+// nothing and only log the failure: nothing told the caller registration never happened, so
+// installEndorsement and Driver.New both reported success regardless. A broken endorser answers no
+// requests, which looks identical to ordinary network trouble from the outside and was otherwise
+// discoverable only once a quorum it was needed for timed out.
+func TestRegisterEndorserReturnsAnErrorForABrokenKey(t *testing.T) {
+	registry := &fakeViewRegistry{}
+	d := &Driver{viewRegistry: registry, identities: fakeIdentityProvider{}}
+	config := endorserConfig(t)
+	config.Endorser.Keystore = "" // unusable: LoadKey rejects an empty path
+	factory := testServiceFactory(t, config)
+
+	err := d.registerEndorser("network-a:", factory, config)
+	require.Error(t, err)
+	assert.Zero(t, registry.calls, "a broken key must not reach the view registry")
+	assert.Empty(t, d.registeredFor, "a failed attempt must not mark the network as registered")
+}

--- a/x/token/services/network/evm/driver_test.go
+++ b/x/token/services/network/evm/driver_test.go
@@ -206,11 +206,12 @@ func TestRegisterEndorserRefusesASecondNetwork(t *testing.T) {
 	config := endorserConfig(t)
 	factory := testServiceFactory(t, config)
 
-	d.registerEndorser("network-a:", factory, config)
+	require.NoError(t, d.registerEndorser("network-a:", factory, config))
 	assert.Equal(t, 1, registry.calls, "the first network must register")
 	assert.Equal(t, "network-a:", d.registeredFor)
 
-	d.registerEndorser("network-b:", factory, config)
+	require.NoError(t, d.registerEndorser("network-b:", factory, config),
+		"a second network is refused loudly via a log line, not an error - see registerEndorser's doc comment")
 	assert.Equal(t, 1, registry.calls, "a second, different network must not overwrite the registration")
 	assert.Equal(t, "network-a:", d.registeredFor, "the first network's registration must stand")
 }
@@ -223,8 +224,8 @@ func TestRegisterEndorserIsIdempotentForTheSameNetwork(t *testing.T) {
 	config := endorserConfig(t)
 	factory := testServiceFactory(t, config)
 
-	d.registerEndorser("network-a:", factory, config)
-	d.registerEndorser("network-a:", factory, config)
+	require.NoError(t, d.registerEndorser("network-a:", factory, config))
+	require.NoError(t, d.registerEndorser("network-a:", factory, config))
 
 	assert.Equal(t, 1, registry.calls, "registering the same network twice must not re-register")
 }
@@ -237,10 +238,10 @@ func TestRegisterEndorserSkipsANonEndorsingNetwork(t *testing.T) {
 	d := &Driver{viewRegistry: registry, identities: fakeIdentityProvider{}}
 	endorsing := endorserConfig(t)
 	factory := testServiceFactory(t, endorsing)
-	d.registerEndorser("network-a:", factory, endorsing)
+	require.NoError(t, d.registerEndorser("network-a:", factory, endorsing))
 
 	notEndorsing := validConfig() // Endorser.Enabled defaults to false
-	d.registerEndorser("network-b:", factory, notEndorsing)
+	require.NoError(t, d.registerEndorser("network-b:", factory, notEndorsing))
 
 	assert.Equal(t, 1, registry.calls)
 	assert.Equal(t, "network-a:", d.registeredFor)

--- a/x/token/services/network/evm/eip712/fuzz_test.go
+++ b/x/token/services/network/evm/eip712/fuzz_test.go
@@ -18,10 +18,14 @@ import (
 // endorser over an FSC session, and the initiator recovers a signer from it before it has any reason
 // to trust the peer. A panic here is reachable by any node that can open a session.
 //
-// The property is that RecoverAddress either returns an address or an error, never panics, and never
-// accepts a signature the EndorsementVerifier contract would reject. The second half matters as much
-// as the first: a signature accepted here but rejected on chain would let an initiator assemble a
-// quorum that cannot be applied.
+// The property this fuzz target checks is narrower than "never accepts a signature the contract would
+// reject": RecoverAddress calls checkSignatureFormat itself and returns before recovery on failure, so
+// re-checking format here on an accepted signature would only be asking the same pure function the
+// same question twice and could never fail. What this actually verifies is that RecoverAddress never
+// panics and, whenever it does accept a signature, recovers a real, non-zero address from it. That Go's
+// format rules match the EndorsementVerifier contract's is a real property, proven independently by
+// TestRecoverRejectsMalformed (signer_test.go) and the on-chain EndorsementVerifier.t.sol cases, plus
+// the golden-fixture cross-check in TestGoldenFixtureEndorsement / GoEndorsement.t.sol.
 func FuzzRecoverAddress(f *testing.F) {
 	signer, err := NewSignerFromBytes(testScalar(1))
 	if err != nil {
@@ -48,12 +52,6 @@ func FuzzRecoverAddress(f *testing.F) {
 		address, err := RecoverAddress(d, sig)
 		if err != nil {
 			return
-		}
-
-		// Anything accepted must have passed the contract's own format rules, since the two have to
-		// agree for an endorsement to be applyable.
-		if err := checkSignatureFormat(sig); err != nil {
-			t.Fatalf("accepted a signature the contract would reject: %v", err)
 		}
 		if address == (client.Address{}) {
 			t.Fatal("recovered the zero address without an error")

--- a/x/token/services/network/evm/eip712/signer.go
+++ b/x/token/services/network/evm/eip712/signer.go
@@ -55,17 +55,33 @@ func NewSigner(key *secp256k1.PrivateKey) *Signer {
 }
 
 // NewSignerFromBytes returns a Signer over a raw 32-byte private-key scalar. It rejects scalars of
-// the wrong length and the zero scalar (whose public key is the point at infinity).
+// the wrong length, the zero scalar (whose public key is the point at infinity), and a scalar at or
+// above the curve order: secp256k1.PrivKeyFromBytes would silently reduce such a value modulo the
+// order rather than erroring, producing a signer for a different key than the raw bytes represent.
 func NewSignerFromBytes(raw []byte) (*Signer, error) {
 	if len(raw) != PrivateKeyLength {
 		return nil, errors.Errorf("invalid private key length: expected %d bytes, got %d", PrivateKeyLength, len(raw))
 	}
-	key := secp256k1.PrivKeyFromBytes(raw)
-	if key.Key.IsZero() {
-		return nil, errors.New("invalid private key: zero scalar")
+	key, err := DecodePrivateKeyScalar(raw)
+	if err != nil {
+		return nil, err
 	}
 
 	return NewSigner(key), nil
+}
+
+// DecodePrivateKeyScalar parses raw as a private-key scalar, rejecting the zero scalar and anything
+// that overflows the curve order instead of silently reducing it modulo the order.
+func DecodePrivateKeyScalar(raw []byte) (*secp256k1.PrivateKey, error) {
+	var scalar secp256k1.ModNScalar
+	if overflow := scalar.SetByteSlice(raw); overflow {
+		return nil, errors.New("invalid private key: scalar is not less than the curve order")
+	}
+	if scalar.IsZero() {
+		return nil, errors.New("invalid private key: zero scalar")
+	}
+
+	return secp256k1.NewPrivateKey(&scalar), nil
 }
 
 // Address returns the Ethereum address of the signer, as registered in the EndorsementVerifier.

--- a/x/token/services/network/evm/eip712/signer_test.go
+++ b/x/token/services/network/evm/eip712/signer_test.go
@@ -154,6 +154,12 @@ func TestNewSignerFromBytesRejectsInvalid(t *testing.T) {
 
 	_, err = NewSignerFromBytes(make([]byte, PrivateKeyLength))
 	require.Error(t, err, "zero scalar must be rejected")
+
+	// A scalar at or above the curve order must be rejected rather than silently reduced modulo the
+	// order into a different, unrelated key.
+	overflowing := bytes.Repeat([]byte{0xff}, PrivateKeyLength)
+	_, err = NewSignerFromBytes(overflowing)
+	require.Error(t, err, "a scalar exceeding the curve order must be rejected")
 }
 
 // TestGoldenFixtureEndorsement pins the fixture endorsement (statedelta_digest_fixture.json): the

--- a/x/token/services/network/evm/endorsement/authorize.go
+++ b/x/token/services/network/evm/endorsement/authorize.go
@@ -13,9 +13,18 @@ import (
 
 // Authorizer decides whether an FSC identity may request endorsement. It is the EVM analog of the
 // Fabric responder's MSP/ACL creator check: EVM has no MSP, so authorization is membership in an
-// allowlist of FSC identities configured per TMS (design §6.2, §15.7). There is no automatic default;
-// the allowlist is always supplied explicitly, and Config.Validate refuses to let an endorsing node
-// start without one, rather than resolving an empty one to "the TMS network's nodes" here.
+// allowlist of FSC identities (design §6.2, §15.7). There is no automatic default; the allowlist is
+// always supplied explicitly, and Config.Validate refuses to let an endorsing node start without one,
+// rather than resolving an empty one to "the TMS network's nodes" here.
+//
+// The design describes this allowlist as configured per TMS, but in the current wiring it is really
+// per node: configNetworkResolver.ConfigFor loads the EVM configuration of whichever TMS declares it
+// first for a network/channel, on the reasoning that connection fields (endpoint, chain id) are
+// genuinely shared - and Endorsement.Allowlist rides along as part of that same Config, so every TMS a
+// Responder resolves a factory for (Responder.factoryFor) is checked against the first TMS's list, not
+// its own. Two TMS on one network cannot be given different requester sets today; giving Authorizer
+// its own per-TMS lookup would need Config's connection fields and its endorsement policy fields
+// (allowlist, threshold, endorser settings) to stop being loaded as one struct.
 //
 // It is fail-closed: an empty allowlist is rejected at construction, and an unknown or empty caller
 // is denied, so a misconfiguration cannot silently authorize everyone.

--- a/x/token/services/network/evm/endorsement/responder_test.go
+++ b/x/token/services/network/evm/endorsement/responder_test.go
@@ -241,5 +241,37 @@ func TestResponderSurfacesPublicParamsFailure(t *testing.T) {
 	assert.Empty(t, resp.Signature)
 }
 
+// fakeSetup is a minimal SetupAction (the SDK ships no counterfeiter fake for it), mirroring
+// statedelta's own test double for the same interface.
+type fakeSetup struct {
+	params []byte
+}
+
+func (f *fakeSetup) GetSetupParameters() ([]byte, error) { return f.params, nil }
+
+// TestResponderEndorsesASetupAction drives a public-parameters update through the real endorsement
+// pipeline: authorize, validate, translate via Translator.writeSetup, sign. Nothing else in this
+// package's unit tests exercises a setup request this way, and the integration harness's own way of
+// bumping public parameters mid-test (nwo.SetupUpdater) hand-assembles and signs a StateDelta directly
+// rather than going through Responder/DeltaFactory - so this is that pipeline's first real exercise
+// against a genuine setup action.
+func TestResponderEndorsesASetupAction(t *testing.T) {
+	newPP := []byte("new-public-parameters")
+	actions := []any{&fakeSetup{params: newPP}}
+	meta := map[string][]byte{common.TokenRequestToSign: []byte(trsMessage)}
+	signer := newSigner(t, 1)
+	r := newResponder(t, &fakeValidator{actions: actions, meta: meta}, &fakePP{raw: []byte(testPPRaw), version: testPPVer}, signer)
+
+	req := validRequest()
+	resp := r.Handle(context.Background(), view.Identity(testCaller), req)
+	require.NoError(t, resp.Error())
+	require.NotEmpty(t, resp.Signature)
+
+	digest := recomputeDigest(t, req.Anchor, actions, meta)
+	got, err := eip712.RecoverAddress(digest, resp.Signature)
+	require.NoError(t, err)
+	assert.Equal(t, signer.Address(), got, "endorser must have signed the setup delta it built")
+}
+
 // compile-time check that the concrete signer satisfies the injected interface.
 var _ EndorserSigner = (*eip712.Signer)(nil)

--- a/x/token/services/network/evm/eth_network_driver_design.md
+++ b/x/token/services/network/evm/eth_network_driver_design.md
@@ -143,6 +143,12 @@ token/services/network/evm/
 
 ## 3. Smart Contracts
 
+This section is the specification: storage layout, semantics, and the reasoning behind each decision. For
+a reader meeting the contracts for the first time, the walkthrough in
+[Network Service - Ethereum Implementation Guide](../../../../../docs/services/network-ethereum.md#how-the-contracts-interact)
+covers the same ground with diagrams, a field-by-field tour of the `StateDelta`, and a table of every
+revert and what causes it.
+
 ### 3.1 Storage layout — TokenState
 
 ```solidity

--- a/x/token/services/network/evm/eth_network_driver_implementation_plan.md
+++ b/x/token/services/network/evm/eth_network_driver_implementation_plan.md
@@ -353,17 +353,17 @@ Deferred to Week 5 (need the config/DI + storage wiring, not the endorsement log
   (on-chain source in production); comparing against a client-declared version arrives with the
   `VersionKeeper` (Week 5). The contract is the final enforcer at apply time either way.
 
-## Week 5 — Driver, 16 methods, JSON-RPC client, DI, receipt-finality baseline
+## Week 5 — Driver, 16 methods, JSON-RPC client, DI, receipt-finality baseline ✅ DONE
 
-- [ ] `client/jsonrpc.go`: real `EVMClient` (the frozen interface: `IsPending`, receipt, call+blockTag,
+- [x] `client/jsonrpc.go`: real `EVMClient` (the frozen interface: `IsPending`, receipt, call+blockTag,
       getLogs, estimateGas, fees, pendingNonce, chainId) + **generate the counterfeiter mock** deferred from
       1.2. **Raw-tx (RLP) encoding + EIP-1559 tx signing must be permissive, not go-ethereum** (see design §9);
       the depguard test will catch a regression.
-- [ ] `config.go` (+validation) + a **real-YAML routing test** for `Driver.New`/`IsEVMNetwork` (Week-1 review:
+- [x] `config.go` (+validation) + a **real-YAML routing test** for `Driver.New`/`IsEVMNetwork` (Week-1 review:
       `config.IsSet("services.network.evm")` on a parent key is unproven; confirm with an evm + a non-evm TMS,
       or probe a leaf like `...evm.endpoint`). `pp/versionkeeper.go` (+provider) synced from
       `getPublicParamsVersion`.
-- [ ] `network.go`: all 16 methods (§5.3); `ComputeTxID` = `hex(crypto.SHA256(lenPrefix(nonce)‖creator))`,
+- [x] `network.go`: all 16 methods (§5.3); `ComputeTxID` = `hex(crypto.SHA256(lenPrefix(nonce)‖creator))`,
       decodable by `keys.AnchorFromTxID` (round-trip test); `NonceManager` (init flag+recovery); `ledger.go`,
       `envelope.go`. `AreTokensSpent` (graph-revealing) resolves through the **content-bound marker** per the
       Week-2 query-surface decision (§5.3), not `isSpent(ComputeTokenID)` — see the Week-2 note.
@@ -372,16 +372,19 @@ Deferred to Week 5 (need the config/DI + storage wiring, not the endorsement log
       that is the contract the fabric driver and FSC implement and the ttx layer depends on. Tests: two calls
       with an empty-nonce `id` produce different anchors; the generated nonce is written back; a caller-set
       nonce is respected and round-trips.
-- [ ] `finality/manager.go` **baseline**: receipt polling at `finalized`; reuse `OnlyOnceListener` + event
+- [x] `finality/manager.go` **baseline**: receipt polling at `finalized`; reuse `OnlyOnceListener` + event
       queue; `StateCommitted` indexed-log resolution (recipient-side); wire `AddFinalityListener`/
       `GetTransactionStatus` + `getTokenRequestHash`. **Status mapping (verified vs `driver/vault.go`
       2026-07-11):** return the SDK's `driver.ValidationCode` values — `Valid=1`, `Invalid=2`, `Busy=3`,
       `Unknown=4` (0 is not a code). Receipt status 1 → `Valid`; receipt status 0 → `Invalid`; tx known but
       unmined → `Busy`; anchor/tx never seen → `Unknown` (then `Invalid` after the configured timeout).
-- [ ] `driver.go` `NewDriver(...)` finalized DI (model `fabric/driver.go:119`); SDK module provides EVM services.
+- [x] `driver.go` `NewDriver(...)` finalized DI (model `fabric/driver.go:119`); SDK module provides EVM services.
 
-Gate: with the real client against anvil, issue→transfer round-trips RequestApproval→Broadcast→finality; the
-container resolves the real driver.
+Gate MET: with the real client against anvil, issue→transfer round-trips RequestApproval→Broadcast→finality;
+the container resolves the real driver. Landed in #2082 + #2094; this section's checkboxes were never
+flipped at the time. Verified 2026-08-20 against the merged tree, not re-derived from memory: all five files
+exist with real implementations (no `errNotImplemented` stubs, no TODO/FIXME in the module), `go build`/
+`go vet`/`gofmt` clean.
 
 ## Week 6 — Besu NWO bootstrap + fabtoken END-TO-END (the integration milestone)
 
@@ -547,16 +550,20 @@ Closing the gaps the work above left open, before the gate run:
 - [x] Stray `weekly sync.html` removed from the branch; the goimports failure on CI (`topology.go`) is
       fixed in the tree.
 
-## Week 7 — endorsed PP-update + zkatdlog END-TO-END
+## Week 7 — endorsed PP-update + zkatdlog END-TO-END ✅ DONE
 
 - [x] Endorsed **PP-update flow**: setup token request → setup delta → contract stores PP, bumps version,
       emits `PublicParametersUpdated`; driver `VersionKeeper` resyncs; stale-PP delta rejected. **Pulled
       forward into Week 6**: the fungible bodies update parameters to authorise a new issuer wallet, so
       the Week-6 gate depends on it. `nwo.SetupUpdater` builds and submits the delta; `pp.Watcher` is how
       a node notices somebody else's update.
-- [ ] zkatdlog/nogh end-to-end on Besu (same path; opaque token bytes) added to the Ginkgo suite.
+- [x] zkatdlog/nogh end-to-end on Besu (same path; opaque token bytes) added to the Ginkgo suite. Went
+      green alongside fabtoken on 2026-08-08, same run as the rest of the Week-6 gate (CI run 31415800806,
+      commit 90020d19a, both `itest-evm (evm)` and `itest-evm (evm-fabtoken)` passing). This checkbox was
+      just never flipped to match — confirmed still green on the current tip (`itest-evm (evm)`, run
+      32334501975, 2026-08-20).
 
-Gate: endorsed PP update + version bump tested; zkatdlog suite green on Besu.
+Gate MET: endorsed PP update + version bump tested; zkatdlog suite green on Besu.
 
 *(Recipient anchor→finality moved to Week 6: the fungible suite depends on it, so it cannot trail the gate.)*
 
@@ -565,13 +572,34 @@ through NWO and layer the gateway `TransactionByHash().isPending` lifecycle (des
 no-blockNumber→dropped; superseded→synthetic status-0) onto the finality manager, keeping the receipt path as
 the fallback. Coordinate with Storm1289 on gateway readiness. Not required for "done."
 
-## Week 8 — Hardening, full matrix, metrics, buffer
+## Week 8 — Hardening, full matrix, metrics, buffer ✅ DONE (superseded-tx excluded, see below)
 
-- [ ] Full integration matrix: stale-PP reject, superseded tx, concurrent transfers / nonce recovery,
-      recipient-only finality, restart/recovery.
-- [ ] Error taxonomy (§13), metrics (§12, `disabled.Provider` in tests), structured logging.
-- [ ] `make checks`/lint clean; godoc on exports; `go generate` mocks; DCO sign-off.
-- [ ] **Buffer (~1 wk absorbed across Wk6–8)** for the integration/EIP-712/gateway surprises.
+- [x] Stale-PP reject: 3 forge tests (`test_StalePublicParams_Reverts`,
+      `test_Setup_ThenOldVersionTransferIsStale`, `test_Setup_StaleSecondSetupReverts`) plus `pp/` package
+      unit tests for version sync and the watcher.
+- [x] Concurrent transfers: exercised by the Week-6 Besu run itself ("the concurrent transfers and the
+      parallel token selector", §Week-6 log above), not a separate matrix test.
+- [x] Nonce recovery: `nonce.go` + `nonce_test.go` (`TestNonceRecoversFromChain`, the explicit
+      "restart story" test; `TestNonceResetReRecovers`).
+- [x] Recipient-only finality: §7.4, done in Week 6 (`StateCommitted` log resolution,
+      `AddFinalityListener`).
+- [x] Restart/recovery: `recovery.go` + `recovery_test.go`, §7.5.
+- [ ] **Superseded tx: out of scope, not a gap.** Design §7.1 (dated 2026-07-08, same day as the
+      Besu-acceptance call) is explicit: "the fabric-x gateway-specific lifecycle (`isPending` semantics,
+      superseded-tx) is an efficiency layer added only for the fabric-x-evm stretch... not required for the
+      Besu acceptance path." Confirmed in code, not just the doc: `EVMClient.IsPending` is a plain
+      `(pending, found, err)` tri-state in both the interface and the real Besu client, with no third state
+      and no dangling hook for one. Writing a test for it today would mean fabricating a gateway that
+      doesn't exist in this codebase. Leave unchecked until fabric-x-evm (stretch) is picked up, not before.
+- [x] Error taxonomy (§13), metrics (§12, `disabled.Provider` in tests), structured logging. `errors.go` /
+      `endorsement/errors.go` (permanent-vs-transient split, §13); `metrics.Provider` threaded through
+      `driver.go` and `recovery.go`.
+- [x] `make checks`/lint clean; godoc on exports; `go generate` mocks; DCO sign-off. Verified 2026-08-20:
+      `golangci-lint run` on the module — 0 issues; `go test -race ./...` — all packages green; `forge
+      test` — 55/55 passing; `gofmt -l .` — clean.
+- [x] **Buffer (~1 wk absorbed across Wk6–8)** for the integration/EIP-712/gateway surprises. Consumed —
+      the actual gaps it covered (Besu JSON-RPC quirks, the six Week-6 log items, the zkatdlog audit-timing
+      bug) are all resolved in the tree as of this update.
 
 Gate (DONE): fabtoken + zkatdlog Ginkgo suites green **on Besu**; receipt-based finality exercised; endorsed
 PP update works; driver registered via the `evmdlog` SDK module; `make checks` clean. (Stretch, not required:
@@ -617,5 +645,16 @@ green. If contracts can't be parallelized in Week 2, expect to use the full 8 an
   (`dlogx`-style), so the `evm` topology mirrors `fabricx`'s public interface.
 - Deferred (additive, not demo cuts): EIP-1167 clones, ERC-4337, graph-hiding driver.
 - Status legend: `[ ] Pending`, `[x] Done`, `[~] In progress`, `[!] Blocked`.
+- **Status sync (2026-08-20):** Weeks 5–8's checkboxes had drifted well behind the actual merged tree —
+  Week 5 and Week 7's zkatdlog gate were fully built and green in CI but never flipped, and most of Week
+  8's hardening had also landed without the boxes being checked. Corrected against the real tree (file
+  presence, `go build`/`vet`/`gofmt`/`golangci-lint`/`go test -race`/`forge test`, and CI run history), not
+  against this file's own prior claims. The one remaining unchecked item, superseded-tx handling, is
+  confirmed out of scope (fabric-x-evm stretch only), not a gap. **This does not cover two things outside
+  this plan's scope**: a follow-on self-review bug-hunt found and fixed 26 issues across two PRs (#2231,
+  #2232, both open and unreviewed as of this update) on top of the Week-8 baseline, and three findings from
+  that hunt are deliberately deferred pending a design decision (floating block-tag in `Ledger.GetState`,
+  per-TMS endorser-policy/`Config` split, integration harness bypassing the real endorsement pipeline for
+  PP updates) — see the PRs for detail.
 
-✅ COMPLETE when the Week-8 gate is met.
+✅ COMPLETE — the Week-8 gate is met (superseded-tx excluded as out of scope). #2231/#2232 pending review.

--- a/x/token/services/network/evm/finality/logs.go
+++ b/x/token/services/network/evm/finality/logs.go
@@ -8,6 +8,7 @@ package finality
 
 import (
 	"context"
+	"slices"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 
@@ -52,6 +53,10 @@ func (m *Manager) TxHashByAnchor(ctx context.Context, anchor [32]byte) (client.H
 	if err != nil {
 		return client.Hash{}, false, errors.Wrap(err, "finality: failed to search for the commit event")
 	}
+
+	// A log the node marks removed was mined in a block a reorg has since undone: it is no longer
+	// part of the canonical chain and must not be treated as evidence the anchor was applied.
+	logs = slices.DeleteFunc(logs, func(l client.Log) bool { return l.Removed })
 	if len(logs) == 0 {
 		return client.Hash{}, false, nil
 	}

--- a/x/token/services/network/evm/finality/logs.go
+++ b/x/token/services/network/evm/finality/logs.go
@@ -43,12 +43,15 @@ func (m *Manager) TxHashByAnchor(ctx context.Context, anchor [32]byte) (client.H
 		return client.Hash{}, false, errors.New("finality: no token state address configured for log lookups")
 	}
 
-	// ToBlock is left at zero, which the filter reads as "latest": the anchor may have been applied at
-	// any point up to the head, and this avoids a second round trip just to learn the block number.
+	// ToBlockTag mirrors the configured tag every other reader in this module uses (finalized/safe by
+	// default in production), so a search here cannot see a block state reads elsewhere are configured
+	// not to trust yet. Left empty it reads as "latest": the anchor may have been applied at any point
+	// up to the head, and this avoids a second round trip just to learn the block number.
 	logs, err := m.client.GetLogs(ctx, client.LogFilter{
-		Address:   m.tokenState,
-		FromBlock: m.fromBlock,
-		Topics:    [][]client.Hash{{StateCommittedTopic()}, {anchor}},
+		Address:    m.tokenState,
+		FromBlock:  m.fromBlock,
+		ToBlockTag: m.blockTag,
+		Topics:     [][]client.Hash{{StateCommittedTopic()}, {anchor}},
 	})
 	if err != nil {
 		return client.Hash{}, false, errors.Wrap(err, "finality: failed to search for the commit event")

--- a/x/token/services/network/evm/finality/logs_test.go
+++ b/x/token/services/network/evm/finality/logs_test.go
@@ -104,6 +104,36 @@ func TestTxHashByAnchorRejectsDuplicates(t *testing.T) {
 	assert.Contains(t, err.Error(), "replay guard")
 }
 
+// TestTxHashByAnchorIgnoresARemovedLog is the reorg regression test: a log the node reports as
+// removed was mined in a block that is no longer canonical and must not be trusted as evidence the
+// anchor was applied, nor counted against the replay-guard duplicate check.
+func TestTxHashByAnchorIgnoresARemovedLog(t *testing.T) {
+	want, err := client.HexToHash("0x853f272fffc6efc284fc16a254decca742d2347e05703e501c59968f78f81ffa")
+	require.NoError(t, err)
+
+	t.Run("a removed log alone is not found", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.GetLogsReturns([]client.Log{{TxHash: want, BlockNumber: 12, Removed: true}}, nil)
+
+		_, found, err := logManager(evm).TxHashByAnchor(t.Context(), anchor(0x01))
+		require.NoError(t, err)
+		assert.False(t, found, "a reorged-out log is not evidence the anchor was applied")
+	})
+
+	t.Run("a removed log alongside the real one does not trip the duplicate guard", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.GetLogsReturns([]client.Log{
+			{TxHash: want, BlockNumber: 12},
+			{TxHash: want, BlockNumber: 7, Removed: true},
+		}, nil)
+
+		got, found, err := logManager(evm).TxHashByAnchor(t.Context(), anchor(0x01))
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, want, got)
+	})
+}
+
 func TestTxHashByAnchorSurfacesQueryFailure(t *testing.T) {
 	evm := &mock.EVMClient{}
 	evm.GetLogsReturns(nil, errors.New("node unavailable"))

--- a/x/token/services/network/evm/finality/logs_test.go
+++ b/x/token/services/network/evm/finality/logs_test.go
@@ -27,7 +27,7 @@ func testAddress(low byte) client.Address {
 }
 
 func logManager(evm client.EVMClient) *Manager {
-	return NewManager(evm, &stubState{}, testAddress(0xAA), 0, 5*time.Millisecond, time.Second)
+	return NewManager(evm, &stubState{}, testAddress(0xAA), 0, "", 5*time.Millisecond, time.Second)
 }
 
 // TestStateCommittedTopic pins topic 0 against the value any Ethereum tooling computes
@@ -63,7 +63,7 @@ func TestTxHashByAnchorFiltersCorrectly(t *testing.T) {
 	evm := &mock.EVMClient{}
 	evm.GetLogsReturns(nil, nil)
 
-	m := NewManager(evm, &stubState{}, testAddress(0xAA), 100, 5*time.Millisecond, time.Second)
+	m := NewManager(evm, &stubState{}, testAddress(0xAA), 100, "", 5*time.Millisecond, time.Second)
 	_, _, err := m.TxHashByAnchor(t.Context(), anchor(0x42))
 	require.NoError(t, err)
 
@@ -79,6 +79,21 @@ func TestTxHashByAnchorFiltersCorrectly(t *testing.T) {
 	assert.Equal(t, StateCommittedTopic(), filter.Topics[0][0])
 	require.Len(t, filter.Topics[1], 1)
 	assert.Equal(t, client.Hash(anchor(0x42)), filter.Topics[1][0], "the anchor is the indexed topic")
+}
+
+// TestTxHashByAnchorHonoursTheConfiguredBlockTag is the regression test for the finding that this
+// search always reached the chain head regardless of the operator's configured reorg-safety tag,
+// unlike every other reader in the module. A non-empty blockTag must reach the filter as ToBlockTag.
+func TestTxHashByAnchorHonoursTheConfiguredBlockTag(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.GetLogsReturns(nil, nil)
+
+	m := NewManager(evm, &stubState{}, testAddress(0xAA), 0, client.BlockTagFinalized, 5*time.Millisecond, time.Second)
+	_, _, err := m.TxHashByAnchor(t.Context(), anchor(0x01))
+	require.NoError(t, err)
+
+	_, filter := evm.GetLogsArgsForCall(0)
+	assert.Equal(t, client.BlockTagFinalized, filter.ToBlockTag)
 }
 
 // TestTxHashByAnchorNotFound covers the ordinary case for a recipient still waiting: no event yet.
@@ -146,7 +161,7 @@ func TestTxHashByAnchorSurfacesQueryFailure(t *testing.T) {
 // querying the zero address, which would match nothing and look like "not committed yet".
 func TestTxHashByAnchorNeedsTheContract(t *testing.T) {
 	evm := &mock.EVMClient{}
-	m := NewManager(evm, &stubState{}, client.Address{}, 0, 5*time.Millisecond, time.Second)
+	m := NewManager(evm, &stubState{}, client.Address{}, 0, "", 5*time.Millisecond, time.Second)
 
 	_, _, err := m.TxHashByAnchor(t.Context(), anchor(0x01))
 	require.Error(t, err)

--- a/x/token/services/network/evm/finality/manager.go
+++ b/x/token/services/network/evm/finality/manager.go
@@ -48,6 +48,7 @@ type Manager struct {
 	state        StateReader
 	tokenState   client.Address
 	fromBlock    uint64
+	blockTag     string
 	pollInterval time.Duration
 	timeout      time.Duration
 
@@ -57,13 +58,15 @@ type Manager struct {
 
 // NewManager returns a finality manager. Non-positive intervals fall back to sane defaults so a
 // partially filled configuration cannot produce a busy loop.
-// The tokenState address and fromBlock are only needed by the log-based lookup (TxHashByAnchor); the
-// status paths work without them.
+// The tokenState address, fromBlock and blockTag are only needed by the log-based lookup
+// (TxHashByAnchor); the status paths work without them. An empty blockTag searches up to the chain
+// head, matching client.LogFilter's own default.
 func NewManager(
 	evmClient client.EVMClient,
 	state StateReader,
 	tokenState client.Address,
 	fromBlock uint64,
+	blockTag string,
 	pollInterval, timeout time.Duration,
 ) *Manager {
 	if pollInterval <= 0 {
@@ -78,6 +81,7 @@ func NewManager(
 		state:        state,
 		tokenState:   tokenState,
 		fromBlock:    fromBlock,
+		blockTag:     blockTag,
 		pollInterval: pollInterval,
 		timeout:      timeout,
 		pending:      map[string]struct{}{},

--- a/x/token/services/network/evm/finality/manager_test.go
+++ b/x/token/services/network/evm/finality/manager_test.go
@@ -101,7 +101,7 @@ func anchor(low byte) [32]byte {
 }
 
 func fastManager(evm client.EVMClient, state StateReader, timeout time.Duration) *Manager {
-	return NewManager(evm, state, testAddress(0xAA), 0, 5*time.Millisecond, timeout)
+	return NewManager(evm, state, testAddress(0xAA), 0, "", 5*time.Millisecond, timeout)
 }
 
 // --- resolution by eth transaction hash ------------------------------------------------------------

--- a/x/token/services/network/evm/keys/fuzz_test.go
+++ b/x/token/services/network/evm/keys/fuzz_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package keys
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// FuzzAnchorFromTxID fuzzes the anchor decoder. The string comes from a token request's TxId, which
+// an endorser decodes before it has validated the request that carries it (endorsement/delta.go), and
+// which a node also decodes straight off an envelope it received (network.go). Neither caller trusts
+// its input yet, so the property is that decoding either fails cleanly or succeeds; it must never
+// panic on malformed, truncated, or oversized hex.
+func FuzzAnchorFromTxID(f *testing.F) {
+	a := anchor(0x11)
+	valid := hex.EncodeToString(a[:])
+
+	f.Add(valid)                // a well-formed anchor
+	f.Add("")                   // empty
+	f.Add("zz")                 // non-hex
+	f.Add(valid[:AnchorLength]) // truncated, still valid hex
+	f.Add(valid + "ab")         // over-long, still valid hex
+	f.Add("0x" + valid)         // 0x-prefixed, not accepted by hex.DecodeString
+
+	f.Fuzz(func(t *testing.T, txID string) {
+		_, _ = AnchorFromTxID(txID)
+	})
+}

--- a/x/token/services/network/evm/keystore.go
+++ b/x/token/services/network/evm/keystore.go
@@ -45,9 +45,9 @@ func LoadKey(path string) (*secp256k1.PrivateKey, error) {
 		return nil, errors.Wrapf(err, "evm keystore: invalid key material at [%s]", path)
 	}
 
-	key := secp256k1.PrivKeyFromBytes(scalar)
-	if key.Key.IsZero() {
-		return nil, errors.Errorf("evm keystore: the key at [%s] is the zero scalar", path)
+	key, err := eip712.DecodePrivateKeyScalar(scalar)
+	if err != nil {
+		return nil, errors.Wrapf(err, "evm keystore: the key at [%s] is invalid: %v", path, err)
 	}
 
 	return key, nil

--- a/x/token/services/network/evm/keystore_test.go
+++ b/x/token/services/network/evm/keystore_test.go
@@ -74,6 +74,14 @@ func TestLoadKeyRejectsBadMaterial(t *testing.T) {
 		_, err := LoadKey(writeKey(t, "00000000000000000000000000000000000000000000000000000000000000"+"00"))
 		require.Error(t, err, "the zero scalar has no valid public key")
 	})
+
+	t.Run("scalar exceeds the curve order", func(t *testing.T) {
+		// Must be rejected outright, not silently reduced modulo the curve order into a different,
+		// unrelated key that the rest of the file's hex bytes gave no hint of.
+		overflowing := "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+		_, err := LoadKey(writeKey(t, overflowing))
+		require.Error(t, err, "a scalar at or above the curve order must be rejected")
+	})
 }
 
 // TestLoadKeyForAddressCatchesMismatch is the configuration guard: pairing a key with the wrong

--- a/x/token/services/network/evm/multitms_cross_contamination_test.go
+++ b/x/token/services/network/evm/multitms_cross_contamination_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+// Round 4, target #4: multi-TMS cross-contamination, built and observed live.
+//
+// This is the regression test for deferred finding #3 (BUG_HUNT_PROMPT.md's "known, deliberately
+// deferred" list): configNetworkResolver.ConfigFor (driver.go:479-492) picks one *Config for the
+// first TMS to declare an EVM network/channel, and token/services/network/network.go's Provider
+// memoizes one *Network per (network, channel) with the namespace NOT part of the memoization key
+// (network.go:344-357, 365, 428-448 in the repo root module). Every other TMS sharing that
+// network/channel is therefore routed, silently, through the first TMS's Contracts.TokenState,
+// EndorsementVerifier/EIP-712 domain, Submitter and Gas policy.
+//
+// KEEP THIS TEST. It is not a throwaway: it is meant to start failing (RED) the moment the
+// eventual fix splits Config into network-shared vs. per-TMS parts, at which point it should be
+// updated to assert isolation instead of contamination.
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	token2 "github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/services/config"
+	"github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client/mock"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/eip712"
+)
+
+// crossTMSResolver simulates configNetworkResolver's real behavior (driver.go:431-497) for two TMS
+// sharing one network/channel, each carrying its own EVM configuration with a distinct TokenState.
+//
+// ConfigFor mirrors configNetworkResolver.ConfigFor's loop exactly: it walks the TMS in declared
+// order and returns the FIRST one's *Config for the network/channel -- there is no way for it to
+// take a TMS/namespace as input at all, which is the root of the bug. configForCalls counts how many
+// times it was asked, so the test can prove Driver.New resolves configuration exactly once for the
+// pair, not once per TMS.
+type crossTMSResolver struct {
+	network, channel string
+	// order lists the TMS ids in the order configNetworkResolver.ConfigFor would encounter them
+	// while walking config.Service.Configurations(); order[0] is "the first TMS to declare it".
+	order          []token2.TMSID
+	configs        map[token2.TMSID]*Config
+	configForCalls int
+}
+
+func (r *crossTMSResolver) IsEVMNetwork(network, channel string) bool {
+	return network == r.network && channel == r.channel
+}
+
+func (r *crossTMSResolver) TMSIDsFor(network, channel string) []token2.TMSID {
+	if !r.IsEVMNetwork(network, channel) {
+		return nil
+	}
+
+	return append([]token2.TMSID(nil), r.order...)
+}
+
+func (r *crossTMSResolver) ConfigFor(network, channel string) (*Config, error) {
+	r.configForCalls++
+	if !r.IsEVMNetwork(network, channel) {
+		return nil, errors.Errorf("no evm configuration for [%s:%s]", network, channel)
+	}
+
+	return r.configs[r.order[0]], nil
+}
+
+func (r *crossTMSResolver) ConfigurationFor(tmsID token2.TMSID) (*config.Configuration, error) {
+	return nil, errors.Errorf("no configuration for [%s]", tmsID)
+}
+
+// driverNewWithClient reproduces Driver.New's body (driver.go:144-180) line for line, with exactly
+// one substitution: the real client.NewJSONRPCClient(config.Endpoint, nil) call is replaced with an
+// already-constructed client.EVMClient (a *mock.EVMClient in this test).
+//
+// New has no seam to inject a client -- it always dials config.Endpoint for real -- and this test
+// needs to observe every chain-facing call the constructed Network, Submitter and endorsement
+// factory make, which a live TCP dial cannot give it. Every other line -- resolving configuration
+// through the resolver, newSubmitter, NewNetwork, installEndorsement, watchPublicParams, the
+// recovery-starter wiring -- is copied unchanged from New, and it is exactly that part the test
+// exercises; only the transport, which the cross-TMS routing bug has nothing to do with, differs.
+func driverNewWithClient(d *Driver, network, channel string, evmClient client.EVMClient) (*Network, error) {
+	if !d.resolver.IsEVMNetwork(network, channel) {
+		return nil, errors.Errorf("evm: no evm network configuration for [%s:%s]", network, channel)
+	}
+	config, err := d.resolver.ConfigFor(network, channel)
+	if err != nil {
+		return nil, err
+	}
+	submitter, err := d.newSubmitter(config, evmClient)
+	if err != nil {
+		return nil, err
+	}
+	n, err := NewNetwork(network, config, evmClient, nil, submitter, d.membership)
+	if err != nil {
+		return nil, err
+	}
+	if err := d.installEndorsement(n, config, evmClient, network, channel); err != nil {
+		return nil, err
+	}
+	d.watchPublicParams(network, channel, config, evmClient)
+	n.SetRecoveryStarter(func(ns string) error {
+		return d.startRecovery(token2.TMSID{Network: network, Channel: channel, Namespace: ns}, n)
+	})
+
+	return n, nil
+}
+
+// extractDomain reads the live, unexported eip712.Domain field off a *endorsement.Service returned
+// through the EndorsementService interface, via reflection. This is test-only introspection -- no
+// production code is touched or needs to be -- used because endorsement.Service.domain has no
+// exported accessor and the point of this test is to observe the actual object the driver built for
+// TMS B, not to re-derive what it "should" contain.
+func extractDomain(t *testing.T, svc EndorsementService) eip712.Domain {
+	t.Helper()
+	v := reflect.ValueOf(svc)
+	require.Equal(t, reflect.Pointer, v.Kind(), "expected a pointer-backed *endorsement.Service")
+	v = v.Elem()
+	f := v.FieldByName("domain")
+	require.True(t, f.IsValid(), "endorsement.Service is expected to carry an unexported 'domain' field")
+	f = reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem()
+	domain, ok := f.Interface().(eip712.Domain)
+	require.True(t, ok, "domain field was not an eip712.Domain")
+
+	return domain
+}
+
+// TestMultiTMSCrossContamination_Live builds two TMS on one EVM network/channel, each with its own,
+// different TokenState clone, drives them through the actual production entry points (Driver.New
+// once, Network.Connect per TMS -- confirmed below by call-counting rather than assumed), and
+// observes -- live, on the constructed objects, not by re-reading source -- which TokenState address
+// ends up backing TMS B's reads, its submitter, and its EIP-712 signing domain.
+func TestMultiTMSCrossContamination_Live(t *testing.T) {
+	const network = "evm-net"
+	const channel = ""
+
+	tmsA := token2.TMSID{Network: network, Channel: channel, Namespace: "tms-a"}
+	tmsB := token2.TMSID{Network: network, Channel: channel, Namespace: "tms-b"}
+
+	// Two TMS, two genuinely different TokenState clones. If Config were split per TMS the way the
+	// eventual fix needs to, these would never be conflated.
+	addrA, err := client.HexToAddress("0x" + repeat("aa", 20))
+	require.NoError(t, err)
+	addrB, err := client.HexToAddress("0x" + repeat("bb", 20))
+	require.NoError(t, err)
+
+	configA := validConfig()
+	configA.Contracts.TokenState = addrA.Hex()
+	configA.Submitter = SubmitterConfig{Keystore: writeKey(t, testKeyHex), Address: testKeyAddress}
+	configA.applyDefaults()
+	require.NoError(t, configA.Validate())
+
+	configB := validConfig()
+	configB.Contracts.TokenState = addrB.Hex()
+	// Give B a materially different endorsement policy too (a config for a totally independent
+	// deployment, not a typo of A's), so nothing about this test depends on A and B being
+	// accidentally similar.
+	configB.Endorsement.Endorsers = []EndorserBinding{
+		{Address: "0x9e5f4552091a69125d5dfcb7b8c2659029395bde", FSCIdentity: "endorser-b"},
+	}
+	configB.applyDefaults()
+	require.NoError(t, configB.Validate())
+
+	resolver := &crossTMSResolver{
+		network: network,
+		channel: channel,
+		order:   []token2.TMSID{tmsA, tmsB}, // tms-a declares the network first
+		configs: map[token2.TMSID]*Config{tmsA: configA, tmsB: configB},
+	}
+
+	evmClient := &mock.EVMClient{}
+	evmClient.ChainIDReturns(big.NewInt(testChainID), nil)
+
+	d := &Driver{
+		resolver:    resolver,
+		identities:  fakeIdentityProvider{},
+		viewManager: fakeViewManager{},
+	}
+
+	// --- Step 1: the real per-(network,channel) entry point --------------------------------------
+	//
+	// token/services/network/network.go's Provider memoizes one *Network per (network,channel) via
+	// lazy.NewProviderWithKeyMapper(key, ms.newNetwork), keyed on netId{network,channel} alone (see
+	// Provider.networks / netId / key() in that file) -- the TMS/namespace is not part of the key. So
+	// networkProvider.newNetwork calls d.New(network, channel) exactly ONCE for this pair, no matter
+	// how many TMS share it, and the resulting *Network is reused by every one of them.
+	//
+	// Reproduce that here and confirm it: Driver.New must resolve configuration exactly once.
+	n, err := driverNewWithClient(d, network, channel, evmClient)
+	require.NoError(t, err)
+	require.NotNil(t, n)
+	assert.Equal(t, 1, resolver.configForCalls,
+		"Driver.New must resolve the network's configuration exactly once: in production this call "+
+			"happens once per (network,channel), memoized, regardless of how many TMS share it -- there "+
+			"is no per-TMS resolution to observe here because none exists")
+
+	// --- Step 2: the real per-TMS entry point -----------------------------------------------------
+	//
+	// Provider.Connect walks every configured TMS and, for each, calls GetNetwork(tmsID.Network,
+	// tmsID.Channel).Connect(tmsID.Namespace) -- GetNetwork returns the SAME memoized *Network for
+	// both TMS A and TMS B, so Connect is what runs per TMS, on one shared object. Network.Connect
+	// (network.go:140-164) only checks reachability/chain id and starts recovery; it does not
+	// rebuild, re-scope or namespace anything about the reader, submitter or endorsement factory.
+	_, err = n.Connect(tmsA.Namespace)
+	require.NoError(t, err)
+	_, err = n.Connect(tmsB.Namespace)
+	require.NoError(t, err)
+
+	// --- Observation 1: reads --------------------------------------------------------------------
+	//
+	// QueryTokens takes a namespace argument (network.go:359) but never uses it to pick a
+	// TokenState: it reads through n.reader, built once in NewNetwork from whichever config ConfigFor
+	// resolved. Ask for TMS B's namespace and see whose contract actually gets called.
+	evmClient.CallReturns(abiBytes([]byte("owned-by-a")), nil)
+	out, err := n.QueryTokens(t.Context(), tmsB.Namespace, []*token.ID{{TxId: anchorHex(0x01), Index: 0}})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, []byte("owned-by-a"), out[0])
+
+	require.Equal(t, 1, evmClient.CallCallCount())
+	_, calledTo, _, _ := evmClient.CallArgsForCall(0)
+	assert.Equal(t, addrA, calledTo,
+		"QueryTokens for the tms-b namespace silently reads through TMS A's TokenState clone")
+	assert.NotEqual(t, addrB, calledTo, "it must not be tms-b's own configured TokenState")
+
+	// --- Observation 2: the submitter --------------------------------------------------------------
+	//
+	// There is exactly one Submitter for the whole Network, built once in Driver.New/newSubmitter
+	// from the same single config. Broadcast (network.go:264) does not even take a TMS/namespace
+	// argument, so there is structurally no way for it to route TMS B's transaction anywhere but
+	// through that one submitter, targeting whatever TokenState it was built with.
+	evmClient.PendingNonceAtReturns(3, nil)
+	evmClient.EstimateGasReturns(100_000, nil)
+	evmClient.SuggestGasFeesReturns(client.GasFees{
+		MaxFeePerGas:         big.NewInt(20_000_000_000),
+		MaxPriorityFeePerGas: big.NewInt(1_000_000_000),
+	}, nil)
+	evmClient.SendRawTransactionReturns(client.Hash{}, nil)
+
+	env := &Envelope{
+		Anchor:       anchorHex(0xA1),
+		Delta:        testDelta(),
+		Endorsements: [][]byte{make([]byte, 65)},
+	}
+	require.NoError(t, n.Broadcast(t.Context(), env)) // this stands in for TMS B's own broadcast
+
+	require.Equal(t, 1, evmClient.EstimateGasCallCount())
+	_, estimateMsg := evmClient.EstimateGasArgsForCall(0)
+	require.NotNil(t, estimateMsg.To)
+	assert.Equal(t, addrA, *estimateMsg.To,
+		"the shared submitter targets TMS A's TokenState for a transaction that has nothing to do with TMS A")
+	assert.NotEqual(t, addrB, *estimateMsg.To)
+
+	// --- Observation 3: the EIP-712 domain ----------------------------------------------------------
+	//
+	// installEndorsement (driver.go:266-320) builds ONE endorsement.ServiceFactory carrying ONE
+	// eip712.Domain{VerifyingContract: <config.TokenStateAddress()>} (driver.go:277-285), from the
+	// exact same config object NewNetwork used. ServiceFactory.ForTMS (endorsement/esp.go:104-141)
+	// only varies the resolved RequestValidator per TMS id; domain, tokenState, client, registry and
+	// threshold are all single fields on the factory, reused unchanged for every TMS it ever builds a
+	// Service for. Get the actual *endorsement.Service the driver built for TMS B and read its live
+	// domain rather than re-deriving what it "should" be.
+	svcB, err := n.endorsementForID(tmsB)
+	require.NoError(t, err)
+	domainB := extractDomain(t, svcB)
+	assert.Equal(t, addrA, domainB.VerifyingContract,
+		"TMS B's endorsement service signs and verifies EIP-712 digests against TMS A's TokenState address")
+	assert.NotEqual(t, addrB, domainB.VerifyingContract)
+	assert.Equal(t, configA.ChainIDBig().String(), domainB.ChainID.String())
+}
+
+// repeat returns s repeated n times, a tiny local helper so the two test addresses above are
+// visibly-constructed, easy-to-eyeball hex strings instead of opaque literals.
+func repeat(s string, n int) string {
+	out := make([]byte, 0, len(s)*n)
+	for range n {
+		out = append(out, s...)
+	}
+
+	return string(out)
+}

--- a/x/token/services/network/evm/network.go
+++ b/x/token/services/network/evm/network.go
@@ -91,8 +91,11 @@ func NewNetwork(
 		submitter:   submitter,
 		reader:      reader,
 		membership:  membership,
-		finality:    finality.NewManager(evmClient, reader, tokenState, config.Finality.FromBlock, config.Finality.PollInterval, config.Finality.Timeout),
-		tokenState:  tokenState,
+		finality: finality.NewManager(
+			evmClient, reader, tokenState, config.Finality.FromBlock, config.Finality.BlockTag,
+			config.Finality.PollInterval, config.Finality.Timeout,
+		),
+		tokenState: tokenState,
 	}, nil
 }
 

--- a/x/token/services/network/evm/nwo/backend.go
+++ b/x/token/services/network/evm/nwo/backend.go
@@ -23,8 +23,12 @@ type TMSRef struct {
 // and the initial public parameters (version 0). Endorsers are Ethereum addresses here; the address
 // to FSC identity binding the driver's config carries is assembled by the harness alongside this.
 type DeploySpec struct {
-	TMS          TMSRef
-	Endorsers    []client.Address
+	TMS       TMSRef
+	Endorsers []client.Address
+	// Threshold is the quorum size the EndorsementVerifier is constructed with, baked into the
+	// contract for its whole life. Unlike SetupUpdaterConfig.Threshold in this same package, zero is
+	// not "use every endorser" here: a concrete Backend must reject it, since a deploy-time threshold
+	// is a security parameter that has to be stated explicitly, not defaulted.
 	Threshold    uint
 	GraphHiding  bool
 	PublicParams []byte

--- a/x/token/services/network/evm/nwo/setup.go
+++ b/x/token/services/network/evm/nwo/setup.go
@@ -69,6 +69,9 @@ func NewSetupUpdater(config SetupUpdaterConfig) (*SetupUpdater, error) {
 	if config.Client == nil {
 		return nil, errors.New("evm nwo: setup updater needs a client")
 	}
+	if config.TokenState == (client.Address{}) {
+		return nil, errors.New("evm nwo: setup updater needs the deployed TokenState address")
+	}
 	if config.Submitter == nil {
 		return nil, errors.New("evm nwo: setup updater needs a submitter to broadcast with")
 	}

--- a/x/token/services/network/evm/nwo/setup_test.go
+++ b/x/token/services/network/evm/nwo/setup_test.go
@@ -190,9 +190,13 @@ func TestUpdateRejectsEmptyParameters(t *testing.T) {
 }
 
 func TestNewSetupUpdaterValidatesItsInput(t *testing.T) {
+	validTokenState, err := client.HexToAddress("0x5FbDB2315678afecb367f032d93F642f64180aa3")
+	require.NoError(t, err)
+
 	base := func() SetupUpdaterConfig {
 		return SetupUpdaterConfig{
 			Client:       &mock.EVMClient{},
+			TokenState:   validTokenState,
 			ChainID:      big.NewInt(testChainID),
 			EndorserKeys: [][]byte{testKey(1)},
 			Submitter:    &evm.Submitter{},
@@ -200,11 +204,12 @@ func TestNewSetupUpdaterValidatesItsInput(t *testing.T) {
 	}
 
 	for name, broken := range map[string]func(*SetupUpdaterConfig){
-		"no client":    func(c *SetupUpdaterConfig) { c.Client = nil },
-		"no submitter": func(c *SetupUpdaterConfig) { c.Submitter = nil },
-		"no chain id":  func(c *SetupUpdaterConfig) { c.ChainID = nil },
-		"no endorsers": func(c *SetupUpdaterConfig) { c.EndorserKeys = nil },
-		"unusable key": func(c *SetupUpdaterConfig) { c.EndorserKeys = [][]byte{{0x01}} },
+		"no client":      func(c *SetupUpdaterConfig) { c.Client = nil },
+		"no token state": func(c *SetupUpdaterConfig) { c.TokenState = client.Address{} },
+		"no submitter":   func(c *SetupUpdaterConfig) { c.Submitter = nil },
+		"no chain id":    func(c *SetupUpdaterConfig) { c.ChainID = nil },
+		"no endorsers":   func(c *SetupUpdaterConfig) { c.EndorserKeys = nil },
+		"unusable key":   func(c *SetupUpdaterConfig) { c.EndorserKeys = [][]byte{{0x01}} },
 	} {
 		t.Run(name, func(t *testing.T) {
 			config := base()

--- a/x/token/services/network/evm/statedelta/translator.go
+++ b/x/token/services/network/evm/statedelta/translator.go
@@ -162,8 +162,13 @@ func (t *Translator) writeIssue(action translator.IssueAction) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to get issue outputs")
 	}
+	// Read once, outside the loop: every output of one action shares one graph-hiding mode, and a
+	// per-output re-query would let an action whose IsGraphHiding answer isn't perfectly idempotent
+	// (an interface method, not a guaranteed-pure field) split its own outputs across both marker
+	// styles. Matches the Fabric reference translator's own cache-before-the-loop pattern.
+	graphHiding := action.IsGraphHiding()
 	for i, output := range outputs {
-		t.appendOutput(t.counter+uint64(i), output, action.IsGraphHiding()) // #nosec G115 -- i is a small slice index
+		t.appendOutput(t.counter+uint64(i), output, graphHiding) // #nosec G115 -- i is a small slice index
 	}
 	t.counter += uint64(len(outputs))
 
@@ -183,6 +188,8 @@ func (t *Translator) writeTransfer(action translator.TransferAction) error {
 	}
 	// Redeem outputs are skipped but their slot still consumes an output index, exactly as the
 	// Fabric translator enumerates them.
+	// Read once, outside the loop: see the matching comment in writeIssue.
+	graphHiding := action.IsGraphHiding()
 	for i := range action.NumOutputs() {
 		if action.IsRedeemAt(i) {
 			continue
@@ -191,7 +198,7 @@ func (t *Translator) writeTransfer(action translator.TransferAction) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to serialize transfer output at index %d", i)
 		}
-		t.appendOutput(t.counter+uint64(i), output, action.IsGraphHiding()) // #nosec G115 -- i is a small output index
+		t.appendOutput(t.counter+uint64(i), output, graphHiding) // #nosec G115 -- i is a small output index
 	}
 	t.counter += uint64(action.NumOutputs()) // #nosec G115 -- output counts are small
 

--- a/x/token/services/network/evm/statedelta/translator_test.go
+++ b/x/token/services/network/evm/statedelta/translator_test.go
@@ -103,6 +103,40 @@ func TestIssueMapping(t *testing.T) {
 	assert.False(t, d.IsSetup)
 }
 
+// TestIssueGraphHidingReadOncePerAction guards against re-querying IsGraphHiding per output: if it
+// isn't idempotent across calls (nothing in the interface guarantees a pure getter), a per-output
+// re-query would let one action's outputs split across both marker styles, silently losing the real
+// SNMarker for whichever outputs saw the "wrong" answer.
+func TestIssueGraphHidingReadOncePerAction(t *testing.T) {
+	a := issueAction([][]byte{[]byte("out-0"), []byte("out-1")}, nil)
+	a.IsGraphHidingReturnsOnCall(0, false)
+	a.IsGraphHidingReturnsOnCall(1, true)
+
+	tr := NewTranslator(testAnchor(0x44), testPP, 0)
+	require.NoError(t, tr.Write(context.Background(), a))
+	d := finish(t, tr)
+
+	require.Len(t, d.Outputs, 2)
+	assert.Equal(t, d.Outputs[0].SNMarker == [32]byte{}, d.Outputs[1].SNMarker == [32]byte{},
+		"both outputs of one action must agree on graph-hiding mode")
+}
+
+// TestTransferGraphHidingReadOncePerAction is the transfer-side counterpart of
+// TestIssueGraphHidingReadOncePerAction.
+func TestTransferGraphHidingReadOncePerAction(t *testing.T) {
+	a := transferAction(nil, nil, [][]byte{[]byte("keep-0"), []byte("keep-1")}, nil, nil)
+	a.IsGraphHidingReturnsOnCall(0, false)
+	a.IsGraphHidingReturnsOnCall(1, true)
+
+	tr := NewTranslator(testAnchor(0x55), testPP, 0)
+	require.NoError(t, tr.Write(context.Background(), a))
+	d := finish(t, tr)
+
+	require.Len(t, d.Outputs, 2)
+	assert.Equal(t, d.Outputs[0].SNMarker == [32]byte{}, d.Outputs[1].SNMarker == [32]byte{},
+		"both outputs of one action must agree on graph-hiding mode")
+}
+
 // TestTransferMapping covers the content-bound spend refs and the redeem slot semantics: a redeem
 // output is skipped but its index is consumed, exactly as the Fabric translator enumerates outputs.
 func TestTransferMapping(t *testing.T) {

--- a/x/token/services/network/evm/statedelta/types.go
+++ b/x/token/services/network/evm/statedelta/types.go
@@ -12,6 +12,19 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
+// Size bounds Validate enforces on a StateDelta. They exist so that a delta received from an
+// untrusted party (an endorser's reply, over the wire, before its signature has been checked - see
+// endorsement.Initiator) cannot force unbounded decoding and EIP-712 hashing work on the receiver.
+// They are set generously above anything a real translated token request produces, not as a business
+// rule on transaction shape.
+const (
+	// maxDeltaEntries bounds SpentRefs, Outputs and the metadata key/value pairs, each independently.
+	maxDeltaEntries = 4096
+	// maxFieldBytes bounds each variable-length byte field: one output's TokenData, one metadata
+	// value, or SetupParameters.
+	maxFieldBytes = 1 << 20 // 1 MiB
+)
+
 // OutputToken is a newly created token. It carries two keys (both derived off-chain; the contract
 // treats them as opaque): the addressable id and the content-bound marker.
 type OutputToken struct {
@@ -76,7 +89,33 @@ type StateDelta struct {
 //   - MetadataKeys are strictly ascending (the frozen §4.4 canonicalization). Unsorted keys mean the
 //     emitting translator is broken (endorsers would produce different bytes and signatures would
 //     not assemble); duplicate keys would make the on-chain write order ambiguous.
+//
+// It also enforces the size bounds above before doing any per-element work, so a delta built from
+// untrusted bytes is rejected before it can force unbounded comparison or hashing work downstream.
 func (d *StateDelta) Validate() error {
+	if len(d.SpentRefs) > maxDeltaEntries {
+		return errors.Errorf("too many spent refs: %d exceeds the %d limit", len(d.SpentRefs), maxDeltaEntries)
+	}
+	if len(d.Outputs) > maxDeltaEntries {
+		return errors.Errorf("too many outputs: %d exceeds the %d limit", len(d.Outputs), maxDeltaEntries)
+	}
+	for i, out := range d.Outputs {
+		if len(out.TokenData) > maxFieldBytes {
+			return errors.Errorf("output %d token data too large: %d bytes exceeds the %d limit", i, len(out.TokenData), maxFieldBytes)
+		}
+	}
+	if len(d.MetadataKeys) > maxDeltaEntries {
+		return errors.Errorf("too many metadata entries: %d exceeds the %d limit", len(d.MetadataKeys), maxDeltaEntries)
+	}
+	for i, val := range d.MetadataVals {
+		if len(val) > maxFieldBytes {
+			return errors.Errorf("metadata value %d too large: %d bytes exceeds the %d limit", i, len(val), maxFieldBytes)
+		}
+	}
+	if len(d.SetupParameters) > maxFieldBytes {
+		return errors.Errorf("setup parameters too large: %d bytes exceeds the %d limit", len(d.SetupParameters), maxFieldBytes)
+	}
+
 	if len(d.MetadataKeys) != len(d.MetadataVals) {
 		return errors.Errorf("metadata keys/values length mismatch: %d != %d", len(d.MetadataKeys), len(d.MetadataVals))
 	}

--- a/x/token/services/network/evm/statedelta/types.go
+++ b/x/token/services/network/evm/statedelta/types.go
@@ -86,8 +86,8 @@ func (d *StateDelta) Validate() error {
 		}
 	}
 	if d.IsSetup {
-		if len(d.SpentRefs) != 0 || len(d.Outputs) != 0 {
-			return errors.Errorf("setup delta must carry no spent refs or outputs")
+		if len(d.SpentRefs) != 0 || len(d.Outputs) != 0 || len(d.MetadataKeys) != 0 {
+			return errors.Errorf("setup delta must carry no spent refs, outputs, or metadata")
 		}
 		if len(d.SetupParameters) == 0 {
 			return errors.Errorf("setup delta must carry the new public parameters")

--- a/x/token/services/network/evm/statedelta/types_test.go
+++ b/x/token/services/network/evm/statedelta/types_test.go
@@ -85,4 +85,51 @@ func TestStateDeltaValidate(t *testing.T) {
 		}
 		assert.Error(t, d.Validate())
 	})
+
+	// These are the regression tests for the DoS finding: a delta from an untrusted source (an
+	// endorser's reply, before its signature is checked) must be rejected before Validate or the
+	// EIP-712 digest does unbounded per-element work over it.
+	t.Run("too many outputs", func(t *testing.T) {
+		d := &StateDelta{Outputs: make([]OutputToken, maxDeltaEntries+1)}
+		assert.ErrorContains(t, d.Validate(), "too many outputs")
+	})
+
+	t.Run("too many spent refs", func(t *testing.T) {
+		d := &StateDelta{SpentRefs: make([][32]byte, maxDeltaEntries+1)}
+		assert.ErrorContains(t, d.Validate(), "too many spent refs")
+	})
+
+	t.Run("too many metadata entries", func(t *testing.T) {
+		d := &StateDelta{
+			MetadataKeys: make([][32]byte, maxDeltaEntries+1),
+			MetadataVals: make([][]byte, maxDeltaEntries+1),
+		}
+		assert.ErrorContains(t, d.Validate(), "too many metadata entries")
+	})
+
+	t.Run("output token data too large", func(t *testing.T) {
+		d := &StateDelta{Outputs: []OutputToken{{TokenData: make([]byte, maxFieldBytes+1)}}}
+		assert.ErrorContains(t, d.Validate(), "token data too large")
+	})
+
+	t.Run("metadata value too large", func(t *testing.T) {
+		d := &StateDelta{
+			MetadataKeys: [][32]byte{{0x01}},
+			MetadataVals: [][]byte{make([]byte, maxFieldBytes+1)},
+		}
+		assert.ErrorContains(t, d.Validate(), "metadata value 0 too large")
+	})
+
+	t.Run("setup parameters too large", func(t *testing.T) {
+		d := &StateDelta{IsSetup: true, SetupParameters: make([]byte, maxFieldBytes+1)}
+		assert.ErrorContains(t, d.Validate(), "setup parameters too large")
+	})
+
+	t.Run("at the bound is still valid", func(t *testing.T) {
+		d := &StateDelta{
+			SpentRefs: make([][32]byte, maxDeltaEntries),
+			Outputs:   []OutputToken{{TokenData: make([]byte, maxFieldBytes)}},
+		}
+		require.NoError(t, d.Validate())
+	})
 }

--- a/x/token/services/network/evm/statedelta/types_test.go
+++ b/x/token/services/network/evm/statedelta/types_test.go
@@ -44,6 +44,18 @@ func TestStateDeltaValidate(t *testing.T) {
 		assert.Error(t, d.Validate())
 	})
 
+	t.Run("setup delta with metadata", func(t *testing.T) {
+		// TokenState.sol's _applySetup reverts MalformedSetupDelta on non-empty metadataKeys too;
+		// Validate must refuse this before an endorser ever signs it, not leave it to the contract.
+		d := &StateDelta{
+			IsSetup:         true,
+			SetupParameters: []byte("pp"),
+			MetadataKeys:    [][32]byte{{0x01}},
+			MetadataVals:    [][]byte{[]byte("v")},
+		}
+		assert.Error(t, d.Validate())
+	})
+
 	t.Run("non-setup delta smuggling setup parameters", func(t *testing.T) {
 		// SetupParameters is digest-covered: endorsers would sign bytes the contract ignores.
 		d := &StateDelta{SpentRefs: [][32]byte{{0x01}}, SetupParameters: []byte("pp")}


### PR DESCRIPTION
Follow-up to #2231. That one came from an unstructured first pass. This one is five separate, targeted adversarial reviews, one per trust-critical area, plus two more once the first five turned up clean enough to ask what was still unreviewed. Same process: verify every finding against the real code before touching anything, one commit per fix.

Builds on evm-bugfix-hunt-findings (#2231), so this stacks on that branch until it merges.

Crypto and wire format (crypto/, eip712/, keys/, statedelta/):
- keys.AnchorFromTxID decodes attacker-influenced hex from a request's own anchor, a transfer input's TxId, and an envelope off the wire, with zero fuzz coverage while its siblings all had it. Added FuzzAnchorFromTxID.

JSON-RPC client and ABI:
- baseFee read a null eth_getBlockByNumber result as a legitimate zero base fee (unmarshaling JSON null into a non-pointer struct is a silent no-op), which fed straight into every transaction's fee pricing. Fixed by making the target a pointer, same pattern GetTransactionReceipt already uses.
- Call didn't classify reverts the way EstimateGas does, an asymmetry in the same client for the same kind of RPC call.
- Hex-prefix parsing disagreed between files in the same package (0x/0X tolerated in one, 0x only in three others). Consolidated into one helper.
- eth_getLogs/eth_getTransactionReceipt decoders had no fuzz coverage despite parsing node-supplied bytes. Added it.

Endorsement trust boundary (endorsement/):
- Core safety properties held up under tracing: no blind signing, full EIP-712 digest binding, signature-recovery dedup, fail-closed authorization ordering, threshold enforcement. No HIGH findings.
- Fixed a stale doc comment claiming the allowlist is per TMS. Traced it through configNetworkResolver.ConfigFor: it isn't, the whole Config (allowlist included) comes from whichever TMS declares the network first.
- Two real findings need bigger design work than a single commit and are intentionally not fixed here: Ledger.GetState reads a floating block tag per call instead of a pinned block number, which can make two honest endorsers build non-identical deltas within one validation pass; and two TMS on one network structurally cannot have different endorser allowlists or thresholds, since Config bundles genuinely network-shared fields with per-TMS policy fields.

Solidity contracts (contracts/src/):
- 55/55 (now 56/56) Foundry tests passing, no HIGH findings.
- isSpent/areTokensSpent on a graph-hiding TokenState clone always answered false, including for tokens that were actually spent, because that mode never populates the marker those functions look up. On-chain enforcement in applyStateDelta was never affected, but any external caller (wallet, explorer, monitor) got a confidently wrong answer. Now reverts instead.
- Left alone: the EIP-712 domain separator has no rebuild-on-chain-id-change fallback (the standard OZ pattern), but the scenario it guards against doesn't apply to a permissioned network the TMS operator controls.

Test suite quality:
- The suite is unusually strong overall (golden vectors cross-checked with external tooling, independently recomputed digests, real concurrency tests). Found three fuzz harnesses that discarded their result and so verified nothing beyond "did not panic," including two added in this same PR's earlier commits. Proved the gap was real by injecting the exact bug the doc comment claimed each property caught and confirming the mutation was undetected before the fix, and caught after.

nwo/ (never independently reviewed before):
- Zero unit tests anywhere in the repo drove a setup/public-parameters-update request through the real endorsement pipeline (Responder.endorse, DeltaFactory.Build, Translator.writeSetup). The integration harness's own way of bumping public parameters mid-test hand-assembles and signs a delta directly instead. Added a real unit test driving one through the actual pipeline; it passed on the first try, which closes the coverage gap rather than a live bug. The deeper part, that the integration harness itself still bypasses the real pipeline, is not fixed here.
- NewSetupUpdater didn't fail fast on a zero TokenState address.
- DeploySpec.Threshold and SetupUpdaterConfig.Threshold silently disagree on what zero means, in the same package.

statedelta/ (previously treated as an already-correct precondition, first real review here):
- Validate() didn't reject a setup delta carrying metadata, even though TokenState.sol's _applySetup does.
- IsGraphHiding() was read once per output instead of once per action, a latent divergence from the Fabric reference translator this package mirrors. Not reachable by either shipped driver today, both hardcode it false, confirmed real with a mutation test using a mock that varies its answer across calls.

Round 3: every directory had already had a dedicated pass by round 2, so this time five subagents split by bug class instead (nonce handling, JSON-RPC/fee/finality robustness, crypto and signing correctness, Solidity contract risk, driver orchestration), plus a fresh look at the endorsement trust boundary since endorsers now build their own delta (#2229) instead of the initiator.

- NonceManager.Reset could reassign a nonce a concurrent, not-yet-broadcast caller was still holding, so one of two submissions could silently lose its transaction. Already closed by this PR's own WithNonce redesign (holds the lock across the whole allocate-and-use step instead of giving nonces back individually), independently rediscovered by round 3, confirmed already fixed. Nothing more to do.
- registerEndorser swallowed every failure past the empty-allowlist and second-network checks (unusable signing key, allowlist resolution, authorizer or responder construction, view-registry registration) as a log line. installEndorsement and Driver.New always reported success regardless, so a node explicitly configured to endorse could come up looking healthy while never answering a request, discoverable only once a quorum it was needed for timed out. Now returns an error that propagates.
- An endorser's reply carries the StateDelta it built. The initiator JSON-decodes and EIP-712-hashes it before it has any reason to trust the signature over it, and StateDelta.Validate had no upper bound on entry counts or field sizes. A single dishonest registered endorser could force real CPU and memory cost per request with an oversized delta. Validate now rejects one before doing any per-element work.
- NewSignerFromBytes and LoadKey both went through secp256k1.PrivKeyFromBytes, which silently reduces an out-of-range key scalar modulo the curve order instead of erroring. A key file at or above the order would load as a different, unrelated key with no error. Both now check the overflow flag.
- Log had no field for eth_getLogs's removed flag, so a log from a block a reorg undid was indistinguishable from a canonical one. TxHashByAnchor could report a transaction hash off one, or trip its own duplicate-commit guard on one. Removed is now decoded and reorged-out logs are dropped before deciding.
- TxHashByAnchor always searched up to "latest" regardless of the operator's configured block tag, unlike every other reader in the module. Now takes and uses the same tag.
- Solidity contracts and Go/Solidity crypto parity got a fresh adversarial pass (EIP-1167 clone risk in TokenStateFactory, EIP-712 domain/type-hash parity, signature malleability, address checksums). Both came back clean, no new findings. 55/55 Foundry tests still passing.

One more finding needs the same fix Ledger.GetState from round 2 still needs (resolve a block tag to a concrete block number, not currently possible with EVMClient): a multi-token query can straddle a finalization boundary the same way, reading a mix of pre- and post-finalization state across a batch. Not fixed here, deferred alongside Ledger.GetState. (A third candidate in this class, ChainProvider.PublicParams reading bytes and version as two unsynchronized calls, was already independently fixed earlier in this same PR by the torn-read retry commit, confirmed before writing this up.)

Also, the per-TMS allowlist/threshold sharing bug from round 2 turns out to be bigger than scoped there: two TMS on one network/channel share the whole Config, including Contracts.TokenState, not just the endorsement policy, because Network is memoized per (network, channel) with the namespace left out of the key. Still not fixed here, needs splitting Config into network-shared and per-TMS parts.

Round 4: rounds 1-3 were static review. This one is adversarial and PoC-driven instead: for each trust boundary already reviewed, actually try to break it with a constructed exploit or a live reproduction, not just re-read the code. Four targets, one subagent each.

- Endorsement quorum coercion: tried a malicious endorser signing a divergent delta, a signature replayed from a different anchor, double-counting one key toward threshold (via malleability and via duplicate registration), and timing manipulation of which of two diverging honest deltas wins. All four failed. Cross-checked against the real EndorsementVerifier.sol through forge too, no Go/Solidity disagreement in either direction. The harness itself was mutation-tested first (broke the dedup check on purpose, confirmed the suite catches it) before trusting any of this.
- Nonce/submitter concurrency: 300 goroutines hammering Submit with 70% randomized failure injection across every network call, under -race, nonce read back from the actual signed transaction bytes rather than internal state. Zero races, zero duplicate or gapped nonces across around 65 runs. The WithNonce fix holds under real stress, not just under reasoning about the lock scope.
- EIP-712 signatures: real reverted transactions against real deployed TokenState clones through forge. Flipped a signature to its malleable form (mathematically impossible to pass here, not just empirically clean on this fixture, since the signer only ever emits low-s), replayed a signature across two different clones and across chain ids, and tried three near-miss encodings looking for a digest collision. All rejected.
- Multi-TMS cross-contamination: built it instead of just reading it. Two TMS on one network, each with its own TokenState address, driven through the real Driver.New/Network.Connect/QueryTokens/Broadcast path with only the transport mocked. Confirms the finding above live: TMS B's reads, its broadcast, and its actual EIP-712 signing domain (read off the running object) all target TMS A's TokenState. Kept as the regression test for whenever the Config split lands.

No new bugs. Every boundary held under an actual attempt to break it.


