### PR TITLE
fix(identity): do not hold the registry lock across WalletFactory.NewWallet

### DIFF
--- a/docs/services/identity.md
+++ b/docs/services/identity.md
@@ -84,6 +84,45 @@ classDiagram
     note for wallet_Service "High-level management<br/>of wallets and roles"
 ```
 
+### Wallet Registry concurrency
+
+`role.Registry` (`token/services/identity/role/registry.go`) is the per-role wallet cache behind
+`wallet.Service`. Its contract:
+
+*   **`WalletMu` guards the `Wallets` map only.** It is taken as a short `RLock` for map reads and a
+    short `Lock` for map writes. It is never held while calling out to the identity provider, the
+    wallet store, or the wallet factory.
+*   **`WalletFactory.NewWallet` is always called with no registry lock held.** The factory receives the
+    registry itself as `IdentitySupport`, so it may call back into it (e.g. `BindIdentity`, or
+    registering the wallet it is building) while the wallet is under construction. `sync.RWMutex` is
+    not reentrant, so holding `WalletMu` across `NewWallet` would deadlock such a factory. Wallet
+    construction is also expensive (idemix pseudonym generation, store reads and writes), so holding
+    the lock across it would serialize every wallet creation for the role.
+*   **Concurrent creations of the *same* wallet identifier are coalesced**, not serialized:
+    `WalletByID` wraps construction in a `golang.org/x/sync/singleflight` group keyed by wallet id, so
+    exactly one `NewWallet` call runs per wallet and all concurrent callers receive the same wallet
+    instance. Creations for *distinct* wallet identifiers run in parallel.
+*   **A caller is never failed by another caller's cancellation.** `singleflight` is not
+    context-aware: it hands the winning goroutine's value *and* error to everyone who joined the same
+    flight, and the winner builds the wallet with its own context. `WalletByID` therefore waits on its
+    own context rather than the winner's — a caller whose context is cancelled while it waits returns
+    that cancellation immediately, and the creation carries on for whoever else is waiting on it — and
+    a flight that failed only because *another* caller's context was cancelled is retried instead of
+    reported, up to a small bound. What a caller still shares with the flight is the wallet itself:
+    the instance handed to every caller is the one the winner built.
+*   **Nothing is cached once `Done` has run.** Because construction happens outside `WalletMu`, it can
+    overlap `Done`, which drops the cache and closes the wallets it held. A creation that completes
+    after that point releases the wallet it built (closing it, if it holds resources) and returns an
+    error rather than repopulating the cache, since a wallet added afterwards would be closed by
+    nobody.
+
+A `WalletFactory` implementation must therefore be safe to call concurrently for distinct wallet
+identifiers, and may assume no registry lock is held when it is invoked.
+
+A wallet identifier registered with a `nil` wallet counts as absent, both on the fast path and when
+creation double-checks the cache; a factory that returns no wallet and no error is reported as an
+error.
+
 ### LocalMembership
 
 The `LocalMembership` component (`token/services/identity/membership`) plays a pivotal role in managing local identities for a specific role (e.g., Owner, Issuer).

--- a/token/services/identity/role/registry.go
+++ b/token/services/identity/role/registry.go
@@ -10,11 +10,13 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
+	"sync/atomic"
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	idriver "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"golang.org/x/sync/singleflight"
 )
 
 //go:generate counterfeiter -o mock/wf.go -fake-name WalletFactory . WalletFactory
@@ -31,6 +33,15 @@ type WalletFactory interface {
 //     RLocks for map reads and never holding locks while calling out to external
 //     services (identity provider, storage, wallet factory) to avoid blocking and
 //     potential deadlocks.
+//   - In particular, WalletMu MUST NOT be held while calling WalletFactory.NewWallet:
+//     wallet construction is expensive (pseudonym generation, storage access) and the
+//     factory receives the registry itself as IdentitySupport, so it may legitimately
+//     call back into it. sync.RWMutex is not reentrant, so any such callback would
+//     deadlock. Concurrent creations of the same wallet are instead coalesced with
+//     walletCreationGroup (see WalletByID).
+//   - Because construction runs outside the lock, it can overlap Done. Nothing may be
+//     written to the Wallets map once closed is set: Done has already dropped the cache
+//     and closed what it held, so a later entry would never be closed by anyone.
 type Registry struct {
 	Logger  logging.Logger
 	Role    idriver.Role
@@ -39,7 +50,22 @@ type Registry struct {
 	WalletFactory WalletFactory
 	WalletMu      sync.RWMutex
 	Wallets       map[string]driver.Wallet
+
+	// walletCreationGroup coalesces concurrent WalletFactory.NewWallet calls for the same
+	// wallet identifier, so that a wallet is built at most once without holding
+	// WalletMu across the construction.
+	walletCreationGroup singleflight.Group
+
+	// closed is set by Done. It is guarded by WalletMu and exists because construction
+	// no longer runs under that lock: a creation still in flight when Done runs must not
+	// repopulate the cache Done has just dropped.
+	closed bool
 }
+
+// errRegistryClosed is returned by wallet creation once Done has run. The cache has been
+// dropped and its wallets closed, so a wallet created afterwards would be released by
+// nobody.
+var errRegistryClosed = errors.New("wallet registry is closed")
 
 // NewRegistry returns a new registry for the passed parameters.
 // A registry is bound to a given role, and it is persistent.
@@ -245,6 +271,12 @@ func (r *Registry) GetWalletID(ctx context.Context, identity driver.Identity) (s
 	return wID, nil
 }
 
+// WalletByID returns the wallet bound to the passed lookup id, creating and registering it
+// on first use.
+//
+// Locking: WalletMu is only taken for short map reads/writes. WalletFactory.NewWallet is
+// always called with no lock held, so a factory may safely call back into the registry;
+// concurrent callers for the same wallet identifier are coalesced so the wallet is built once.
 func (r *Registry) WalletByID(ctx context.Context, role idriver.IdentityRoleType, id driver.WalletLookupID) (driver.Wallet, error) {
 	r.Logger.DebugfContext(ctx, "role [%d] lookup wallet by [%T]", role, id)
 	defer r.Logger.DebugfContext(ctx, "role [%d] lookup wallet by [%T] done", role, id)
@@ -281,21 +313,130 @@ func (r *Registry) WalletByID(ctx context.Context, role idriver.IdentityRoleType
 	}
 	r.Logger.DebugfContext(ctx, "no")
 
-	// Register the newly created wallet but check if another goroutine already created it.
-	r.WalletMu.Lock()
-	defer r.WalletMu.Unlock()
-	if existing, ok := r.Wallets[wID]; ok {
-		// Another goroutine created and registered the wallet in the meantime; prefer it.
+	// Create the wallet without holding the registry lock (avoid holding locks while calling
+	// external code). singleflight guarantees that concurrent callers asking for the same
+	// wallet identifier share a single NewWallet call, so dropping the lock does not lead to
+	// duplicate wallets; creations for distinct identifiers proceed in parallel.
+	r.Logger.DebugfContext(ctx, "create wallet [%s]", wID)
+
+	return r.createWallet(ctx, role, wID, idInfo)
+}
+
+// walletCreationJoinRetries bounds how many times a caller re-runs a creation that failed
+// with a context error it did not cause. Each retry either makes this caller the winner,
+// in which case only its own context can fail it, or joins a newer flight; the bound is
+// there so that an unbroken stream of cancelled callers cannot keep a caller with no
+// deadline of its own waiting forever.
+const walletCreationJoinRetries = 3
+
+// createWallet builds the wallet identified by wID, coalescing concurrent creations of the
+// same identifier into a single WalletFactory.NewWallet call so that dropping WalletMu
+// cannot produce duplicate wallets.
+//
+// singleflight hands the winning goroutine's value *and* error to everyone who joined the
+// same flight, and the winner builds the wallet with its own context. Neither may leak into
+// an unrelated caller, so this caller stops waiting when its own context is done rather
+// than when the winner's is, and a flight that failed only because another caller's context
+// was cancelled is retried rather than reported: one abandoned transaction must not fail
+// the healthy ones resolving the same wallet.
+func (r *Registry) createWallet(
+	ctx context.Context,
+	role idriver.IdentityRoleType,
+	wID idriver.WalletID,
+	idInfo idriver.IdentityInfo,
+) (driver.Wallet, error) {
+	for attempt := 0; ; attempt++ {
+		// ranCreation records whether this caller won the flight and ran the creation
+		// itself, which is what distinguishes its own context error from an inherited one.
+		// It is only read after receiving from ch, which happens after the creation
+		// returned.
+		var ranCreation atomic.Bool
+		ch := r.walletCreationGroup.DoChan(wID, func() (any, error) {
+			ranCreation.Store(true)
+
+			return r.newWallet(ctx, role, wID, idInfo)
+		})
+
+		select {
+		case <-ctx.Done():
+			// The flight carries on for whoever else is waiting on it; this caller is done.
+			return nil, errors.Wrapf(ctx.Err(), "failed to create wallet [%s]", wID)
+		case res := <-ch:
+			if res.Err == nil {
+				wallet, ok := res.Val.(driver.Wallet)
+				if !ok || wallet == nil {
+					return nil, errors.Errorf("wallet creation for [%s] yielded %T, not a wallet", wID, res.Val)
+				}
+
+				return wallet, nil
+			}
+
+			// A context error this caller neither caused nor shares says nothing about
+			// whether the wallet can be built, so try again instead of reporting it.
+			// singleflight removes a flight from the group before handing out its result,
+			// so the retry either starts a fresh creation or joins one another caller has
+			// since started. Forget must not be called here: the failed flight is already
+			// gone, so it could only evict that newer flight and let two wallets be built
+			// for wID, one of which nobody would ever close.
+			// Anything else - including a context error from the creation this caller ran
+			// itself - is its own error to report.
+			inherited := !ranCreation.Load() && ctx.Err() == nil &&
+				(errors.Is(res.Err, context.Canceled) || errors.Is(res.Err, context.DeadlineExceeded))
+			if !inherited || attempt >= walletCreationJoinRetries {
+				return nil, res.Err
+			}
+			r.Logger.DebugfContext(ctx,
+				"wallet [%s] creation failed with another caller's cancellation, retrying", wID)
+		}
+	}
+}
+
+// newWallet builds one wallet and puts it in the cache. It runs inside walletCreationGroup, so
+// at most one goroutine executes it per wallet identifier at a time.
+func (r *Registry) newWallet(
+	ctx context.Context,
+	role idriver.IdentityRoleType,
+	wID idriver.WalletID,
+	idInfo idriver.IdentityInfo,
+) (any, error) {
+	// Another goroutine may have created and registered the wallet in the meantime; prefer
+	// it. An entry holding a nil wallet counts as absent, exactly as the fast path in
+	// WalletByID treats it, rather than being handed back as a wallet.
+	r.WalletMu.RLock()
+	existing, closed := r.Wallets[wID], r.closed
+	r.WalletMu.RUnlock()
+	if closed {
+		return nil, errRegistryClosed
+	}
+	if existing != nil {
 		return existing, nil
 	}
-	// Create the wallet without holding the registry lock (avoid holding locks while calling external code).
-	r.Logger.DebugfContext(ctx, "create wallet [%s]", wID)
+
 	newWallet, err := r.WalletFactory.NewWallet(ctx, wID, role, r, idInfo)
 	if err != nil {
 		return nil, err
 	}
+	if newWallet == nil {
+		return nil, errors.Errorf("wallet factory returned no wallet for [%s]", wID)
+	}
 	r.Logger.DebugfContext(ctx, "register wallet [%s:%s] with label [%s]", newWallet.ID(), wID, wID)
+
+	// Only the map write needs the write lock. Done may have run while the wallet was being
+	// built: caching it now would resurrect a cache Done has already dropped and leave this
+	// wallet's resources - for an anonymous owner wallet, a provisioning goroutine - running
+	// with nothing left to close them. Close it here instead.
+	r.WalletMu.Lock()
+	if r.closed {
+		r.WalletMu.Unlock()
+		r.Logger.DebugfContext(ctx, "registry closed while creating wallet [%s], releasing it", wID)
+		if c, ok := newWallet.(closer); ok {
+			c.Close()
+		}
+
+		return nil, errRegistryClosed
+	}
 	r.Wallets[wID] = newWallet
+	r.WalletMu.Unlock()
 
 	return newWallet, nil
 }
@@ -315,6 +456,9 @@ type closer interface {
 // lifetime of the process.
 func (r *Registry) Done() error {
 	r.WalletMu.Lock()
+	// Set before dropping the cache, so a creation that completes after this point sees
+	// the registry as closed and releases the wallet it built instead of caching it.
+	r.closed = true
 	wallets := make([]driver.Wallet, 0, len(r.Wallets))
 	for _, w := range r.Wallets {
 		wallets = append(wallets, w)

--- a/token/services/identity/role/registry_test.go
+++ b/token/services/identity/role/registry_test.go
@@ -251,6 +251,9 @@ func TestWalletByID_ConcurrentCreation(t *testing.T) {
 		require.Equal(t, "wc", res[i].ID())
 	}
 
+	// concurrent callers for the same wallet id share a single factory call
+	require.Equal(t, 1, wf.NewWalletCallCount())
+
 	// ensure only one was actually registered in the map
 	reg.WalletMu.RLock()
 	defer reg.WalletMu.RUnlock()
@@ -261,6 +264,115 @@ func TestWalletByID_ConcurrentCreation(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, count)
+}
+
+// TestWalletByID_FactoryReentersRegistry checks that WalletFactory.NewWallet is invoked
+// without the registry lock held: the factory receives the registry itself as
+// IdentitySupport, so it may legitimately call back into it while the wallet is being
+// built. sync.RWMutex is not reentrant, so if WalletByID held WalletMu across the call,
+// this would deadlock forever (hence the timeout, a deadlock has no natural termination).
+func TestWalletByID_FactoryReentersRegistry(t *testing.T) {
+	reg, _, r, wf := newRegistryWithFakes()
+	ctx := t.Context()
+	r.MapToIdentityReturns([]byte("idre"), "wre", nil)
+	r.GetIdentityInfoReturns(&mockIdentityInfo{id: "idre"}, nil)
+
+	created := &mock2.Wallet{}
+	created.IDReturns("wre")
+	wf.NewWalletStub = func(ctx context.Context, id string, roleType idriver.IdentityRoleType, wr role.IdentitySupport, info idriver.IdentityInfo) (driver.Wallet, error) {
+		// simulate a factory that registers the wallet it is building
+		if err := reg.RegisterWallet(ctx, id, created); err != nil {
+			return nil, err
+		}
+
+		return created, nil
+	}
+
+	type result struct {
+		w   driver.Wallet
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		w, err := reg.WalletByID(ctx, 0, []byte("idre"))
+		done <- result{w: w, err: err}
+	}()
+
+	select {
+	case res := <-done:
+		require.NoError(t, res.err)
+		require.Equal(t, "wre", res.w.ID())
+	case <-time.After(10 * time.Second):
+		t.Fatal("WalletByID did not return: the registry lock is held across WalletFactory.NewWallet")
+	}
+
+	require.Equal(t, 1, wf.NewWalletCallCount())
+}
+
+// TestWalletByID_DistinctWalletsAreCreatedConcurrently checks that creating wallets with
+// different identifiers is not serialized behind the registry write lock: both factory
+// calls must be able to be in flight at the same time.
+func TestWalletByID_DistinctWalletsAreCreatedConcurrently(t *testing.T) {
+	reg, _, r, wf := newRegistryWithFakes()
+	ctx := t.Context()
+	r.MapToIdentityStub = func(_ context.Context, id driver.WalletLookupID) (driver.Identity, string, error) {
+		identity, ok := toIdentityBytes(id)
+		require.True(t, ok)
+
+		return identity, "w-" + string(identity), nil
+	}
+	r.GetIdentityInfoStub = func(_ context.Context, wID string) (idriver.IdentityInfo, error) {
+		return &mockIdentityInfo{id: wID}, nil
+	}
+
+	// both factory calls must be inside NewWallet at the same time for this to unblock
+	var inFlight atomic.Int32
+	release := make(chan struct{})
+	wf.NewWalletStub = func(_ context.Context, id string, _ idriver.IdentityRoleType, _ role.IdentitySupport, _ idriver.IdentityInfo) (driver.Wallet, error) {
+		if inFlight.Add(1) == 2 {
+			close(release)
+		}
+		select {
+		case <-release:
+		case <-time.After(10 * time.Second):
+			return nil, errors.New("wallet creation is serialized: only one NewWallet call at a time")
+		}
+		w := &mock2.Wallet{}
+		w.IDReturns(id)
+
+		return w, nil
+	}
+
+	var wg sync.WaitGroup
+	res := make([]driver.Wallet, 2)
+	errs := make([]error, 2)
+	ids := []string{"ida", "idb"}
+	for i := range ids {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			res[i], errs[i] = reg.WalletByID(ctx, 0, []byte(ids[i]))
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range ids {
+		require.NoError(t, errs[i])
+		require.Equal(t, "w-"+ids[i], res[i].ID())
+	}
+	require.Equal(t, 2, wf.NewWalletCallCount())
+}
+
+// toIdentityBytes is the test-side counterpart of the registry's identity conversion.
+func toIdentityBytes(id driver.WalletLookupID) (driver.Identity, bool) {
+	switch v := id.(type) {
+	case driver.Identity:
+		return v, true
+	case []byte:
+		return v, true
+	default:
+		return nil, false
+	}
 }
 
 func TestLookup_WithUnknownType_Error(t *testing.T) {
@@ -375,4 +487,228 @@ func TestDoneClosesRegisteredWallets(t *testing.T) {
 	reg.WalletMu.RLock()
 	defer reg.WalletMu.RUnlock()
 	assert.Empty(t, reg.Wallets, "the wallet cache was not dropped")
+}
+
+// TestWalletByID_CancelledCallerDoesNotFailOthers checks that a caller abandoning its
+// wallet lookup does not take unrelated callers down with it. Creation is coalesced with
+// singleflight, which hands the winning goroutine's error to everyone who joined the same
+// flight, and the winner builds the wallet with its own context: without care, one
+// cancelled transaction makes every concurrent transaction resolving the same wallet fail
+// with a context error that has nothing to do with it.
+func TestWalletByID_CancelledCallerDoesNotFailOthers(t *testing.T) {
+	reg, _, r, wf := newRegistryWithFakes()
+	r.GetIdentityInfoReturns(&mockIdentityInfo{id: "idx"}, nil)
+
+	// The second caller is only in the flight this test cares about once its lookup has
+	// run, so the first caller is cancelled after that point.
+	var lookups atomic.Int32
+	secondLookedUp := make(chan struct{})
+	r.MapToIdentityStub = func(_ context.Context, _ driver.WalletLookupID) (driver.Identity, string, error) {
+		if lookups.Add(1) == 2 {
+			close(secondLookedUp)
+		}
+
+		return []byte("idx"), "wx", nil
+	}
+
+	// The first creation blocks until it is released, and reports its own context, the way
+	// pseudonym generation and storage access do.
+	inFactory := make(chan struct{})
+	release := make(chan struct{})
+	var factoryCalls atomic.Int32
+	wf.NewWalletStub = func(ctx context.Context, id string, _ idriver.IdentityRoleType, _ role.IdentitySupport, _ idriver.IdentityInfo) (driver.Wallet, error) {
+		if factoryCalls.Add(1) == 1 {
+			close(inFactory)
+			<-release
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+		w := &mock2.Wallet{}
+		w.IDReturns(id)
+
+		return w, nil
+	}
+
+	type result struct {
+		w   driver.Wallet
+		err error
+	}
+
+	// The caller that gives up: it wins the flight, then its context is cancelled.
+	cancelledCtx, cancel := context.WithCancel(t.Context())
+	first := make(chan result, 1)
+	go func() {
+		w, err := reg.WalletByID(cancelledCtx, 0, []byte("idx"))
+		first <- result{w: w, err: err}
+	}()
+	<-inFactory
+
+	// The healthy caller: it joins the in-flight creation with a context of its own.
+	second := make(chan result, 1)
+	go func() {
+		w, err := reg.WalletByID(t.Context(), 0, []byte("idx"))
+		second <- result{w: w, err: err}
+	}()
+	<-secondLookedUp
+
+	cancel()
+	close(release)
+
+	select {
+	case res := <-second:
+		require.NoError(t, res.err,
+			"a healthy caller inherited the cancellation of another caller sharing the creation")
+		require.NotNil(t, res.w)
+		require.Equal(t, "wx", res.w.ID())
+	case <-time.After(10 * time.Second):
+		t.Fatal("the healthy caller never returned")
+	}
+
+	select {
+	case res := <-first:
+		require.Error(t, res.err, "the cancelled caller should report its own cancellation")
+		require.ErrorIs(t, res.err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the cancelled caller never returned")
+	}
+}
+
+// TestWalletByID_CancelledCallerStopsWaiting checks that a caller waiting on someone
+// else's creation honours its own context: singleflight itself is not context-aware, so
+// without the explicit wait the caller is pinned to the winner's construction and cannot
+// meet its own deadline.
+func TestWalletByID_CancelledCallerStopsWaiting(t *testing.T) {
+	reg, _, r, wf := newRegistryWithFakes()
+	r.MapToIdentityReturns([]byte("idw"), "ww", nil)
+	r.GetIdentityInfoReturns(&mockIdentityInfo{id: "idw"}, nil)
+
+	inFactory := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	wf.NewWalletStub = func(_ context.Context, id string, _ idriver.IdentityRoleType, _ role.IdentitySupport, _ idriver.IdentityInfo) (driver.Wallet, error) {
+		close(inFactory)
+		<-release
+		w := &mock2.Wallet{}
+		w.IDReturns(id)
+
+		return w, nil
+	}
+
+	go func() {
+		_, _ = reg.WalletByID(t.Context(), 0, []byte("idw"))
+	}()
+	<-inFactory
+
+	// This caller joins a creation that never finishes, and must still return when its own
+	// context is cancelled.
+	ctx, cancel := context.WithCancel(t.Context())
+	joined := make(chan error, 1)
+	go func() {
+		_, err := reg.WalletByID(ctx, 0, []byte("idw"))
+		joined <- err
+	}()
+	cancel()
+
+	select {
+	case err := <-joined:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("a caller waiting on another caller's creation ignored its own context")
+	}
+}
+
+// TestWalletByID_NilCachedWalletIsRebuilt checks that an entry holding a nil wallet is
+// treated as absent, the way the fast path of WalletByID already treats it. RegisterWallet
+// accepts a nil wallet, so such an entry is reachable, and handing it back as a wallet
+// panics the caller instead of returning it a wallet it can use.
+func TestWalletByID_NilCachedWalletIsRebuilt(t *testing.T) {
+	reg, _, r, wf := newRegistryWithFakes()
+	ctx := t.Context()
+	require.NoError(t, reg.RegisterWallet(ctx, "wnil", nil))
+	r.MapToIdentityReturns([]byte("idnil"), "wnil", nil)
+	r.GetIdentityInfoReturns(&mockIdentityInfo{id: "idnil"}, nil)
+
+	created := &mock2.Wallet{}
+	created.IDReturns("wnil")
+	wf.NewWalletReturns(created, nil)
+
+	w, err := reg.WalletByID(ctx, 0, []byte("idnil"))
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	require.Equal(t, "wnil", w.ID())
+	require.Equal(t, 1, wf.NewWalletCallCount())
+}
+
+// TestWalletByID_FactoryReturningNoWalletIsAnError checks that a factory returning
+// (nil, nil) is reported rather than cached and handed on as a wallet.
+func TestWalletByID_FactoryReturningNoWalletIsAnError(t *testing.T) {
+	reg, _, r, wf := newRegistryWithFakes()
+	ctx := t.Context()
+	r.MapToIdentityReturns([]byte("idnone"), "wnone", nil)
+	r.GetIdentityInfoReturns(&mockIdentityInfo{id: "idnone"}, nil)
+	wf.NewWalletReturns(nil, nil)
+
+	w, err := reg.WalletByID(ctx, 0, []byte("idnone"))
+	require.Error(t, err)
+	require.Nil(t, w)
+
+	reg.WalletMu.RLock()
+	defer reg.WalletMu.RUnlock()
+	assert.Empty(t, reg.Wallets, "a missing wallet was cached")
+}
+
+// TestWalletByID_CreationDuringDoneReleasesTheWallet checks the window opened by building
+// wallets outside WalletMu: Done can drop the cache while a creation is in flight. The
+// wallet that creation produces must not land in the cache Done has just cleared, because
+// nothing would ever close it - and for an anonymous owner wallet that leaves a recipient
+// data provisioning goroutine running for the lifetime of the process, which is exactly
+// what Done exists to prevent.
+func TestWalletByID_CreationDuringDoneReleasesTheWallet(t *testing.T) {
+	reg, _, r, wf := newRegistryWithFakes()
+	ctx := t.Context()
+	r.MapToIdentityReturns([]byte("idd"), "wd", nil)
+	r.GetIdentityInfoReturns(&mockIdentityInfo{id: "idd"}, nil)
+
+	closable := &closableWallet{Wallet: &mock2.Wallet{}}
+	closable.IDReturns("wd")
+
+	inFactory := make(chan struct{})
+	release := make(chan struct{})
+	wf.NewWalletStub = func(_ context.Context, _ string, _ idriver.IdentityRoleType, _ role.IdentitySupport, _ idriver.IdentityInfo) (driver.Wallet, error) {
+		close(inFactory)
+		<-release
+
+		return closable, nil
+	}
+
+	type result struct {
+		w   driver.Wallet
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		w, err := reg.WalletByID(ctx, 0, []byte("idd"))
+		done <- result{w: w, err: err}
+	}()
+
+	// The creation is in flight and holds no lock, so shutdown can overtake it.
+	<-inFactory
+	require.NoError(t, reg.Done())
+	close(release)
+
+	select {
+	case res := <-done:
+		require.Error(t, res.err, "a wallet created after Done was handed to a caller")
+		require.Nil(t, res.w)
+	case <-time.After(10 * time.Second):
+		t.Fatal("WalletByID never returned")
+	}
+
+	assert.Equal(t, int32(1), closable.closed.Load(),
+		"the wallet built while the registry was shutting down was not released")
+
+	reg.WalletMu.RLock()
+	defer reg.WalletMu.RUnlock()
+	assert.Empty(t, reg.Wallets, "the wallet cache was repopulated after Done")
 }


### PR DESCRIPTION
## Problem

`Registry.WalletByID` (`token/services/identity/role/registry.go`) built the wallet **while holding the registry write lock**, contradicting its own inline comment ("Create the wallet without holding the registry lock") and the invariant documented on the `Registry` type.

Flow before this PR:

1. Caller asks for a wallet → cache miss.
2. `WalletByID` takes `r.WalletMu.Lock()` (`defer Unlock`).
3. Double-checks the `Wallets` map — still missing.
4. **Still holding the write lock**, calls `WalletFactory.NewWallet` → idemix pseudonym generation, identity-store reads, identity-store writes.
5. Stores the wallet in the map and returns, releasing the lock.

Two consequences:

- **Serialization**: every wallet creation for a role queues behind step 4, and so does every other reader/writer of the map — the expensive crypto and DB work happens inside the critical section.
- **Deadlock**: the factory is handed the registry itself as `IdentitySupport`, so it may legitimately call back into it (e.g. `RegisterWallet`, which takes `WalletMu.Lock()`). `sync.RWMutex` is not reentrant, so such a factory hangs forever at step 4.

## Fix

Flow after this PR:

1. Caller asks for a wallet → cache miss.
2. Construction runs inside a `singleflight.Group` keyed by wallet id (`golang.org/x/sync/singleflight`, already a dependency and the existing house pattern in `token/services/utils/cache/ristretto.go`).
3. Short `RLock` for the double-check, released immediately.
4. `WalletFactory.NewWallet` is called with **no lock held** — a factory may safely re-enter the registry.
5. `WalletMu.Lock()` only for the map write, then unlock.

`singleflight` keeps the "build once" guarantee that the lock used to provide: concurrent callers for the same wallet id share one `NewWallet` call and get the same instance, while distinct wallet ids are now built in parallel.

## Tests

Both new tests were verified to fail against the unfixed `registry.go`:

- `TestWalletByID_FactoryReentersRegistry` — a factory that calls `RegisterWallet` from inside `NewWallet` must return; on the old code it hangs (timeout-guarded, a deadlock has no natural termination).
- `TestWalletByID_DistinctWalletsAreCreatedConcurrently` — two `NewWallet` calls for different wallet ids must be in flight simultaneously; on the old code they are serialized.
- `TestWalletByID_ConcurrentCreation` additionally asserts exactly one factory call for concurrent same-id requests.

`go test -race -count=5 ./token/services/identity/role/` green; `make checks` and `make lint-auto-fix` clean.

## Docs

New "Wallet Registry concurrency" section in `docs/services/identity.md` stating the contract: `WalletMu` guards the map only, `NewWallet` is never called under a lock, same-id creations are coalesced rather than serialized.

Fixes #2064
