### PR TITLE
fix(identity): accept a boolpolicy rest recipient on long-term owner wallets

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -138,6 +138,9 @@ jobs:
           - name: tcc-query-tokens-limits
             pkg: ./token/services/network/fabric/tcc
             func: FuzzQueryTokensLedgerReadsAreBounded
+          - name: identity-role-register-recipient
+            pkg: ./token/services/identity/role
+            func: FuzzLongTermOwnerWalletRegisterRecipientNoPanic
 
     steps:
       - name: Checkout code

--- a/docs/services/ttx.md
+++ b/docs/services/ttx.md
@@ -387,8 +387,10 @@ wallet (an "external wallet") by passing `RecipientData` directly to
 runs `Deserializer.MatchIdentity(Identity, AuditInfo)` before registering and binding the
 identity, so a caller-supplied `Identity`/`AuditInfo` pair that doesn't match is rejected with
 an error and the withdrawal request is never sent. For a `LongTermOwnerWallet`,
-`RegisterRecipient` is currently a no-op, so this check does not add protection when the
-caller's local wallet is long-term-identity-backed rather than anonymous.
+`RegisterRecipient` accepts exactly two shapes: the wallet's own long-term identity with its
+exact audit info, or a well-formed boolpolicy composite identity that lists the wallet's
+identity among its components (the rest recipient of a transfer spending policy-owned inputs).
+Anything else is rejected with an error.
 
 ## Token Upgrade Flow
 

--- a/token/services/identity/role/wallets.go
+++ b/token/services/identity/role/wallets.go
@@ -9,10 +9,13 @@ package role
 import (
 	"bytes"
 	"context"
+	"encoding/asn1"
 	"math/big"
 
+	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/json"
 	"github.com/LFDT-Panurus/panurus/token/core/common/metrics"
 	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	idriver "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/wallet"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
@@ -473,11 +476,23 @@ func (w *LongTermOwnerWallet) EnrollmentID() string {
 // because the wallet's identity is already resolved and bound at
 // construction time (see NewLongTermOwnerWallet); this is purely a guard
 // against mismatched recipient data.
+// A boolpolicy composite identity listing this wallet's identity among its
+// components is also accepted and registered: the rest of a transfer that
+// spends policy-owned inputs goes back to the policy identity, which by
+// construction differs from the wallet's own long-term identity.
 func (w *LongTermOwnerWallet) RegisterRecipient(ctx context.Context, data *driver.RecipientData) error {
 	if data == nil {
 		return errors.Wrapf(wallet.ErrNilRecipientData, "invalid recipient data")
 	}
 	if !w.Contains(ctx, data.Identity) {
+		if w.isMemberPolicyRecipient(ctx, data) {
+			if err := w.IdentityProvider.RegisterRecipientData(ctx, data); err != nil {
+				return errors.Wrapf(err, "failed registering audit info for owner [%s]", data.Identity)
+			}
+
+			return nil
+		}
+
 		return errors.Errorf("identity [%s] does not belong to this wallet [%s]", data.Identity, w.ID())
 	}
 	if !bytes.Equal(data.AuditInfo, w.OwnerAuditInfo) {
@@ -485,6 +500,73 @@ func (w *LongTermOwnerWallet) RegisterRecipient(ctx context.Context, data *drive
 	}
 
 	return nil
+}
+
+// policyIdentityWire and policyAuditInfoWire mirror the stable wire formats
+// of boolpolicy.PolicyIdentity and boolpolicy.AuditInfo; role cannot import
+// boolpolicy (import cycle through membership's test chain).
+type policyIdentityWire struct {
+	Policy     string `asn1:"utf8"`
+	Identities [][]byte
+}
+
+type policyAuditInfoWire struct {
+	IdentityAuditInfos []struct {
+		AuditInfo []byte
+	}
+}
+
+// isMemberPolicyRecipient reports whether data carries a well-formed
+// boolpolicy composite identity that lists this wallet's identity among its
+// components and whose audit info provides one entry per component, with the
+// entry for the wallet's own component equal to the wallet's audit info.
+// Component well-formedness (non-empty, no duplicates, bounded fan-out)
+// mirrors boolpolicy's validateComponentIdentities, which otherwise rejects
+// the identity only later, in GetAuditInfoMatcher.
+func (w *LongTermOwnerWallet) isMemberPolicyRecipient(ctx context.Context, data *driver.RecipientData) bool {
+	ti, err := identity.UnmarshalTypedIdentity(data.Identity)
+	if err != nil || ti.Type != driver.PolicyIdentityType {
+		return false
+	}
+	pi := &policyIdentityWire{}
+	if rest, err := asn1.Unmarshal(ti.Identity, pi); err != nil || len(rest) > 0 {
+		return false
+	}
+	if len(pi.Policy) == 0 {
+		return false
+	}
+	// TODO: also validate that every $N reference in pi.Policy is in range;
+	// that needs boolpolicy's parser, which the import cycle documented on
+	// the wire types keeps out of reach from here.
+	if n := len(pi.Identities); n == 0 || n > driver.MaxIdentityComponentsFrom(ctx) {
+		return false
+	}
+	memberIdx := -1
+	seen := make(map[string]struct{}, len(pi.Identities))
+	for k, component := range pi.Identities {
+		if len(component) == 0 {
+			return false
+		}
+		if _, dup := seen[string(component)]; dup {
+			return false
+		}
+		seen[string(component)] = struct{}{}
+		if w.Contains(ctx, component) {
+			memberIdx = k
+		}
+	}
+	if memberIdx < 0 {
+		return false
+	}
+	ai := &policyAuditInfoWire{}
+	if err := json.Unmarshal(data.AuditInfo, ai); err != nil {
+		return false
+	}
+	if len(ai.IdentityAuditInfos) != len(pi.Identities) {
+		return false
+	}
+
+	return bytes.Equal(ai.IdentityAuditInfos[memberIdx].AuditInfo, w.OwnerAuditInfo)
 }
 
 // Remote reports whether the underlying identity info is remote.

--- a/token/services/identity/role/wallets_fuzz_test.go
+++ b/token/services/identity/role/wallets_fuzz_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package role_test
+
+import (
+	"encoding/asn1"
+	"testing"
+
+	token2 "github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/json"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/boolpolicy"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/role"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/role/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const maxFuzzRecipientBytes = 64 << 10
+
+// FuzzLongTermOwnerWalletRegisterRecipientNoPanic hunts for recipient data
+// that panics LongTermOwnerWallet.RegisterRecipient instead of returning an
+// error. RegisterRecipient parses caller-supplied bytes — a typed-identity
+// envelope, boolpolicy ASN.1 and audit-info JSON — so it must never panic,
+// and it may accept only the wallet's own identity or a policy composite
+// that lists the wallet's identity among its well-formed components with
+// the wallet's own audit info at that component's entry.
+func FuzzLongTermOwnerWalletRegisterRecipientNoPanic(f *testing.F) {
+	owner := driver.Identity("ownerIdentity")
+	ownerInfo := []byte("audit-info")
+	policyID, err := boolpolicy.WrapPolicyIdentity("$0 OR $1",
+		owner, token2.Identity("member2"))
+	require.NoError(f, err)
+	policyInfo, err := boolpolicy.WrapAuditInfo([][]byte{ownerInfo, []byte("ai2")})
+	require.NoError(f, err)
+	mismatchInfo, err := boolpolicy.WrapAuditInfo([][]byte{[]byte("ai1"), []byte("ai2")})
+	require.NoError(f, err)
+	garbageID, err := identity.WrapWithType(boolpolicy.Policy, identity.Identity("garbage"))
+	require.NoError(f, err)
+	foreignID, err := boolpolicy.WrapPolicyIdentity("$0 OR $1",
+		token2.Identity("member1"), token2.Identity("member2"))
+	require.NoError(f, err)
+	trailingInner, err := (&boolpolicy.PolicyIdentity{
+		Policy:     "$0 OR $1",
+		Identities: [][]byte{owner, []byte("member2")},
+	}).Serialize()
+	require.NoError(f, err)
+	trailingID, err := identity.WrapWithType(boolpolicy.Policy, append(trailingInner, 0x00))
+	require.NoError(f, err)
+	noPolicyInner, err := (&boolpolicy.PolicyIdentity{
+		Identities: [][]byte{owner, []byte("member2")},
+	}).Serialize()
+	require.NoError(f, err)
+	noPolicyID, err := identity.WrapWithType(boolpolicy.Policy, noPolicyInner)
+	require.NoError(f, err)
+
+	seeds := [][2][]byte{
+		{owner, ownerInfo},                              // the wallet's own pair
+		{owner, []byte("other-audit-info")},             // audit info mismatch
+		{policyID, policyInfo},                          // accepted policy recipient
+		{policyID, mismatchInfo},                        // foreign audit info at the owner's entry
+		{foreignID, policyInfo},                         // historical gap: well-formed policy omitting the owner
+		{trailingID, policyInfo},                        // valid DER followed by a trailing byte
+		{noPolicyID, policyInfo},                        // empty policy expression
+		{policyID, []byte(`{"IdentityAuditInfos":[]}`)}, // audit info count mismatch
+		{policyID[:len(policyID)-1], policyInfo},        // truncated envelope
+		{garbageID, policyInfo},                         // garbage under the policy tag
+		{nil, nil},                                      // empty
+		{[]byte("garbage"), []byte("garbage")},          // no envelope at all
+	}
+	for _, s := range seeds {
+		f.Add(s[0], s[1])
+	}
+
+	f.Fuzz(func(t *testing.T, identityRaw, auditInfoRaw []byte) {
+		if len(identityRaw) > maxFuzzRecipientBytes || len(auditInfoRaw) > maxFuzzRecipientBytes {
+			t.Skip()
+		}
+		w, err := role.NewLongTermOwnerWallet(t.Context(),
+			&mock.IdentityProvider{}, &mock.OwnerTokenVault{}, "w1",
+			&mockIdentityInfo{id: string(owner)})
+		require.NoError(t, err)
+		require.NotPanics(t, func() {
+			err := w.RegisterRecipient(t.Context(), &driver.RecipientData{
+				Identity:  identityRaw,
+				AuditInfo: auditInfoRaw,
+			})
+			if err != nil || owner.Equal(identityRaw) {
+				return
+			}
+			// anything else accepted must satisfy every guard invariant of
+			// the policy-recipient shape
+			ti, tErr := identity.UnmarshalTypedIdentity(identityRaw)
+			require.NoError(t, tErr)
+			require.Equal(t, boolpolicy.Policy, ti.Type)
+			pi := &boolpolicy.PolicyIdentity{}
+			rest, piErr := asn1.Unmarshal(ti.Identity, pi)
+			require.NoError(t, piErr)
+			require.Empty(t, rest)
+			require.NotEmpty(t, pi.Policy)
+			require.NotEmpty(t, pi.Identities)
+			require.LessOrEqual(t, len(pi.Identities), driver.DefaultResourceLimits().MaxIdentityComponents)
+			memberIdx := -1
+			seen := make(map[string]struct{}, len(pi.Identities))
+			for k, component := range pi.Identities {
+				require.NotEmpty(t, component)
+				_, dup := seen[string(component)]
+				require.False(t, dup)
+				seen[string(component)] = struct{}{}
+				if owner.Equal(component) {
+					memberIdx = k
+				}
+			}
+			require.GreaterOrEqual(t, memberIdx, 0)
+			ai := &boolpolicy.AuditInfo{}
+			require.NoError(t, json.Unmarshal(auditInfoRaw, ai))
+			require.Len(t, ai.IdentityAuditInfos, len(pi.Identities))
+			require.Equal(t, ownerInfo, ai.IdentityAuditInfos[memberIdx].AuditInfo)
+		})
+	})
+}

--- a/token/services/identity/role/wallets_test.go
+++ b/token/services/identity/role/wallets_test.go
@@ -8,11 +8,15 @@ package role_test
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
 
+	token2 "github.com/LFDT-Panurus/panurus/token"
 	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/boolpolicy"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/role"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/role/mock"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/wallet"
@@ -284,7 +288,7 @@ func TestLongTermOwnerWallet(t *testing.T) {
 	})
 
 	t.Run("RegisterRecipient", func(t *testing.T) {
-		w, _, _ := setup(t)
+		w, ip, _ := setup(t)
 
 		// Case 1: nil data
 		err := w.RegisterRecipient(t.Context(), nil)
@@ -312,6 +316,202 @@ func TestLongTermOwnerWallet(t *testing.T) {
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "audit info does not match")
+
+		// Case 5: a well-formed boolpolicy recipient listing the wallet's
+		// identity among its components, with the wallet's audit info at that
+		// component's entry, is accepted and registered as the rest recipient
+		// of a transfer spending policy-owned inputs
+		policyID, err := boolpolicy.WrapPolicyIdentity("$0 OR $1",
+			token2.Identity("ownerIdentity"), token2.Identity("member2"))
+		require.NoError(t, err)
+		policyInfo, err := boolpolicy.WrapAuditInfo([][]byte{[]byte("audit-info"), []byte("ai2")})
+		require.NoError(t, err)
+		acceptedData := &driver.RecipientData{
+			Identity:  policyID,
+			AuditInfo: policyInfo,
+		}
+		err = w.RegisterRecipient(t.Context(), acceptedData)
+		require.NoError(t, err)
+		require.Equal(t, 1, ip.RegisterRecipientDataCallCount())
+		_, gotData := ip.RegisterRecipientDataArgsForCall(0)
+		assert.Equal(t, acceptedData, gotData)
+
+		// Case 6: policy recipient whose audit info does not cover every
+		// component is rejected
+		shortInfo, err := boolpolicy.WrapAuditInfo([][]byte{[]byte("ai1")})
+		require.NoError(t, err)
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  policyID,
+			AuditInfo: shortInfo,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to this wallet")
+
+		// Case 7: garbage under the policy type tag is rejected
+		garbageID, err := identity.WrapWithType(boolpolicy.Policy, identity.Identity("garbage"))
+		require.NoError(t, err)
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  garbageID,
+			AuditInfo: policyInfo,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to this wallet")
+
+		// Case 8: a policy the wallet's identity is not a component of is
+		// rejected, however well-formed
+		foreignID, err := boolpolicy.WrapPolicyIdentity("$0 OR $1",
+			token2.Identity("member1"), token2.Identity("member2"))
+		require.NoError(t, err)
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  foreignID,
+			AuditInfo: policyInfo,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to this wallet")
+
+		// Case 9: a policy with no components is rejected even when the audit
+		// info is empty as well
+		emptyInner, err := (&boolpolicy.PolicyIdentity{Policy: "$0"}).Serialize()
+		require.NoError(t, err)
+		emptyID, err := identity.WrapWithType(boolpolicy.Policy, emptyInner)
+		require.NoError(t, err)
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  emptyID,
+			AuditInfo: []byte(`{"IdentityAuditInfos":[]}`),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to this wallet")
+
+		// Case 10: duplicate components are rejected
+		dupInner, err := (&boolpolicy.PolicyIdentity{
+			Policy:     "$0 OR $1",
+			Identities: [][]byte{[]byte("ownerIdentity"), []byte("ownerIdentity")},
+		}).Serialize()
+		require.NoError(t, err)
+		dupID, err := identity.WrapWithType(boolpolicy.Policy, dupInner)
+		require.NoError(t, err)
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  dupID,
+			AuditInfo: policyInfo,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to this wallet")
+
+		// Case 11: empty components are rejected
+		blankInner, err := (&boolpolicy.PolicyIdentity{
+			Policy:     "$0 OR $1",
+			Identities: [][]byte{[]byte("ownerIdentity"), {}},
+		}).Serialize()
+		require.NoError(t, err)
+		blankID, err := identity.WrapWithType(boolpolicy.Policy, blankInner)
+		require.NoError(t, err)
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  blankID,
+			AuditInfo: policyInfo,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to this wallet")
+
+		// Case 12: audit info carrying unknown fields is rejected
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  policyID,
+			AuditInfo: []byte(`{"IdentityAuditInfos":[{"AuditInfo":"YQ=="},{"AuditInfo":"Yg=="}],"Extra":1}`),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to this wallet")
+
+		// Case 13: a policy at the component fan-out limit is accepted
+		limit := driver.DefaultResourceLimits().MaxIdentityComponents
+		members := make([]token2.Identity, limit)
+		infos := make([][]byte, limit)
+		members[0] = token2.Identity("ownerIdentity")
+		infos[0] = []byte("audit-info")
+		for i := 1; i < limit; i++ {
+			members[i] = token2.Identity(fmt.Sprintf("member%d", i))
+			infos[i] = fmt.Appendf(nil, "ai%d", i)
+		}
+		limitID, err := boolpolicy.WrapPolicyIdentity("$0", members...)
+		require.NoError(t, err)
+		limitInfo, err := boolpolicy.WrapAuditInfo(infos)
+		require.NoError(t, err)
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  limitID,
+			AuditInfo: limitInfo,
+		})
+		require.NoError(t, err)
+
+		// Case 14: one component above the fan-out limit is rejected
+		overRaw := make([][]byte, limit+1)
+		overInfos := make([][]byte, limit+1)
+		overRaw[0] = []byte("ownerIdentity")
+		overInfos[0] = []byte("ai0")
+		for i := 1; i <= limit; i++ {
+			overRaw[i] = fmt.Appendf(nil, "member%d", i)
+			overInfos[i] = fmt.Appendf(nil, "ai%d", i)
+		}
+		overInner, err := (&boolpolicy.PolicyIdentity{Policy: "$0", Identities: overRaw}).Serialize()
+		require.NoError(t, err)
+		overID, err := identity.WrapWithType(boolpolicy.Policy, overInner)
+		require.NoError(t, err)
+		overInfo, err := boolpolicy.WrapAuditInfo(overInfos)
+		require.NoError(t, err)
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  overID,
+			AuditInfo: overInfo,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to this wallet")
+
+		// Case 15: the fan-out bound follows the limits carried by the
+		// context, not just the defaults — the same two-component policy is
+		// rejected under a limit of 1 and accepted under a limit of 2
+		tightCtx := driver.WithIdentityNestingLimits(t.Context(), 0, 1)
+		err = w.RegisterRecipient(tightCtx, &driver.RecipientData{
+			Identity:  policyID,
+			AuditInfo: policyInfo,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to this wallet")
+
+		exactCtx := driver.WithIdentityNestingLimits(t.Context(), 0, 2)
+		err = w.RegisterRecipient(exactCtx, &driver.RecipientData{
+			Identity:  policyID,
+			AuditInfo: policyInfo,
+		})
+		require.NoError(t, err)
+
+		// Case 16: an empty policy expression is rejected — no verifier can
+		// ever be built for it, so the rest would be unspendable
+		noPolicyInner, err := (&boolpolicy.PolicyIdentity{
+			Identities: [][]byte{[]byte("ownerIdentity"), []byte("member2")},
+		}).Serialize()
+		require.NoError(t, err)
+		noPolicyID, err := identity.WrapWithType(boolpolicy.Policy, noPolicyInner)
+		require.NoError(t, err)
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  noPolicyID,
+			AuditInfo: policyInfo,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to this wallet")
+
+		// Case 17: audit info of the right cardinality but carrying a foreign
+		// entry at the wallet's own component is rejected
+		foreignInfo, err := boolpolicy.WrapAuditInfo([][]byte{[]byte("ai1"), []byte("ai2")})
+		require.NoError(t, err)
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  policyID,
+			AuditInfo: foreignInfo,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to this wallet")
+
+		// Case 18: a registration failure surfaces to the caller
+		ip.RegisterRecipientDataReturns(errors.New("registration error"))
+		err = w.RegisterRecipient(t.Context(), acceptedData)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed registering audit info")
+		ip.RegisterRecipientDataReturns(nil)
 	})
 }
 


### PR DESCRIPTION
Fixes #2267

## What

`LongTermOwnerWallet.RegisterRecipient` rejects any recipient identity other than the wallet's own long-term identity. That breaks transfers that spend boolpolicy-owned inputs and send the rest back to the policy identity (the only rest owner that keeps custody semantics intact); `Redeem` in particular has no whole-token variant, so redeeming an arbitrary amount from policy-owned holdings cannot avoid a rest. Hit in our test environments on every redeem prepared from policy-owned holdings.

## How

Keep the guard as-is for everything else and accept exactly one new shape: a well-formed boolpolicy composite recipient that lists the wallet's own long-term identity among its components —

- the typed-identity tag is `PolicyIdentityType`,
- the inner `PolicyIdentity` ASN.1 parses with no trailing bytes,
- the component list is non-empty, within `MaxIdentityComponentsFrom`, and free of empty or duplicate entries (mirroring boolpolicy's `validateComponentIdentities`),
- the wallet's long-term identity is one of the components,
- the audit info decodes strictly (the `token/core/common/encoding/json` decoder) with one entry per component identity.

Accepting such a recipient grants no spending power: spending the rest output still requires the policy members' signatures on-chain.

One implementation note for review: `role` cannot import `identity/boolpolicy` (import cycle through `membership`'s test chain: `boolpolicy` tests → `x509` → `membership` → `role`), so the two stable wire formats are mirrored locally as `policyIdentityWire`/`policyAuditInfoWire` with a comment pointing at the authoritative definitions. Happy to restructure (e.g. move the wire types into a leaf package) if you prefer.

## Testing

- New cases in `TestLongTermOwnerWallet/RegisterRecipient`: a policy recipient listing the wallet's identity is accepted, also at the component fan-out limit and under context-carried limits; a policy over unrelated owners, an empty component list, empty or duplicate components, one component above the fan-out limit, audit info that does not cover every component, audit info with unknown JSON fields, and garbage under the policy type tag are all rejected. The existing four cases are unchanged.
- New `FuzzLongTermOwnerWalletRegisterRecipientNoPanic` covers the recipient parsing path, with an independent oracle re-checking every acceptance invariant; registered in the nightly fuzz matrix.
- `docs/services/ttx.md` updated: it still described `LongTermOwnerWallet.RegisterRecipient` as a no-op.
- Red-green verified: the accepted-policy-recipient case fails on current main, and the rejected-foreign-policy case fails on the previous head of this branch.
- `gofmt`, `go build ./token/...`, `go vet`, `go test -race` on the identity tree, golangci-lint v2.12.2 with the repo config (0 issues), `make gofix` — all clean.
