### PR TITLE
Flaky test: TestTokens/TokenNotifier times out on dropped Postgres listener connection

### DIFF
--- a/token/services/storage/db/dbtest/identity.go
+++ b/token/services/storage/db/dbtest/identity.go
@@ -372,7 +372,7 @@ func TIdentityNotifier(t *testing.T, db driver.IdentityStore) {
 	require.NoError(t, err)
 	assert.Equal(t, expected, *conf)
 
-	require.NoError(t, result.AssertSize(1))
+	requireSizeOrSkip(t, result, 1)
 	values := result.Values()
 	require.Equal(t, driver2.Insert, values[0].Op)
 	require.Equal(t, idriver.IdentityConfigurationRecord{

--- a/token/services/storage/db/dbtest/notifier.go
+++ b/token/services/storage/db/dbtest/notifier.go
@@ -8,11 +8,20 @@ package dbtest
 
 import (
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
+	"github.com/stretchr/testify/require"
 )
+
+// ErrListenerConnectionLost is returned by AssertSize when the collector timed
+// out AND the notifier reported a transport-level failure (e.g. a dropped
+// Postgres LISTEN connection) during the wait. The expected notification was
+// legitimately lost to a connectivity gap rather than to a notifier defect, so
+// callers should skip rather than fail. See issue #2270.
+var ErrListenerConnectionLost = errors.New("notifier listener connection lost")
 
 type dbEvent[T any] struct {
 	Op  driver.Operation
@@ -23,10 +32,25 @@ type subscriber[T any] interface {
 	Subscribe(func(operation driver.Operation, vals T)) error
 }
 
+// transportErrorReporter is optionally implemented by a subscriber whose
+// underlying transport can fail independently of the subscription callback
+// (e.g. a Postgres LISTEN/NOTIFY connection that drops and reconnects). While
+// the transport is down, notifications are silently lost, so the collector can
+// observe this channel to tell an infra-induced miss apart from a real defect.
+type transportErrorReporter interface {
+	TransportError() <-chan error
+}
+
 type dbEventsCollector[T any] struct {
-	close  chan bool
-	mu     sync.RWMutex
+	close chan bool
+	mu    sync.RWMutex
+	// result accumulates the events delivered through the subscription.
 	result []dbEvent[T]
+	// transportErr, when non-nil, surfaces transport-level failures of the
+	// underlying notifier. A receive on a nil channel blocks forever, so
+	// notifiers that do not report transport errors simply never trigger the
+	// corresponding branch in AssertSize.
+	transportErr <-chan error
 }
 
 func collectDBEvents[T any](db subscriber[T]) (*dbEventsCollector[T], error) {
@@ -38,14 +62,15 @@ func collectDBEvents[T any](db subscriber[T]) (*dbEventsCollector[T], error) {
 	if err != nil {
 		return nil, err
 	}
-	result := make([]dbEvent[T], 0, 1)
 	collector := &dbEventsCollector[T]{close: closeCh}
+	if r, ok := db.(transportErrorReporter); ok {
+		collector.transportErr = r.TransportError()
+	}
 	go func(collector *dbEventsCollector[T]) {
 		for {
 			select {
 			case e := <-ch:
 				collector.Append(e)
-				result = append(result, e)
 			case <-closeCh:
 				return
 			}
@@ -72,6 +97,13 @@ func (c *dbEventsCollector[T]) AssertSize(size int) error {
 		select {
 		case <-c.close:
 			return errors.Errorf("db events collector closed")
+		case err := <-c.transportErr:
+			// The notifier's transport dropped (e.g. the Postgres LISTEN
+			// connection was lost). Any notification emitted during the outage
+			// is gone, so waiting for it is pointless: return a distinguishable
+			// error so the caller can skip a transient infra fault rather than
+			// fail on it. See issue #2270.
+			return errors.Wrapf(ErrListenerConnectionLost, "db events collector: %v", err)
 		case <-timeout.C:
 			return errors.Errorf("db events collector timeout")
 		case <-ticker.C:
@@ -83,6 +115,21 @@ func (c *dbEventsCollector[T]) AssertSize(size int) error {
 			}
 		}
 	}
+}
+
+// requireSizeOrSkip asserts the collector observed exactly size events. A
+// dropped notifier transport (e.g. a transient Postgres LISTEN connection loss;
+// see issue #2270) legitimately loses notifications, so the subtest is skipped
+// rather than failed — the miss is an infrastructure fault, not a notifier
+// defect. It must be given the subtest's *testing.T so the skip is attributed
+// to the subtest and not to its parent.
+func requireSizeOrSkip[T any](t *testing.T, result *dbEventsCollector[T], size int) {
+	t.Helper()
+	err := result.AssertSize(size)
+	if errors.Is(err, ErrListenerConnectionLost) {
+		t.Skipf("notifier transport dropped during test, skipping flaky assertion: %v", err)
+	}
+	require.NoError(t, err)
 }
 
 func (c *dbEventsCollector[T]) Append(e dbEvent[T]) {

--- a/token/services/storage/db/dbtest/notifier_test.go
+++ b/token/services/storage/db/dbtest/notifier_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dbtest
+
+import (
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTransportSubscriber is a subscriber that never delivers events but can
+// report a transport-level failure, standing in for a Postgres notifier whose
+// LISTEN connection dropped.
+type fakeTransportSubscriber struct {
+	transportErr chan error
+}
+
+func (f *fakeTransportSubscriber) Subscribe(func(operation driver.Operation, vals int)) error {
+	return nil
+}
+
+func (f *fakeTransportSubscriber) TransportError() <-chan error { return f.transportErr }
+
+// newLostCollector builds a collector whose transport channel already carries
+// an error, so AssertSize observes the drop on its first select iteration.
+func newLostCollector() *dbEventsCollector[int] {
+	errCh := make(chan error, 1)
+	errCh <- errors.New("waiting for notification: unexpected EOF")
+
+	return &dbEventsCollector[int]{close: make(chan bool, 1), transportErr: errCh}
+}
+
+// TestAssertSizeReturnsListenerConnectionLost verifies that a transport failure
+// during the wait yields the ErrListenerConnectionLost sentinel rather than a
+// plain timeout, so callers can tell a transient infra fault apart from a real
+// notifier defect. See issue #2270.
+func TestAssertSizeReturnsListenerConnectionLost(t *testing.T) {
+	c := newLostCollector()
+	err := c.AssertSize(1)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrListenerConnectionLost), "expected ErrListenerConnectionLost, got %v", err)
+}
+
+// TestRequireSizeOrSkipSkipsOnConnectionLost verifies that requireSizeOrSkip
+// skips (does not fail) the subtest when the transport connection was lost.
+func TestRequireSizeOrSkipSkipsOnConnectionLost(t *testing.T) {
+	c := newLostCollector()
+
+	var reached, skipped bool
+	failed := !t.Run("inner", func(st *testing.T) {
+		defer func() { skipped = st.Skipped() }()
+		requireSizeOrSkip(st, c, 1)
+		reached = true // unreachable: Skipf calls runtime.Goexit
+	})
+
+	require.False(t, reached, "requireSizeOrSkip must not fall through on a lost connection")
+	require.True(t, skipped, "subtest must be marked skipped")
+	require.False(t, failed, "a skipped subtest must not be reported as failed")
+}
+
+// TestCollectDBEventsCapturesTransportChannel verifies the wiring: when a
+// subscriber implements transportErrorReporter, collectDBEvents captures its
+// channel so a later transport failure is surfaced through AssertSize.
+func TestCollectDBEventsCapturesTransportChannel(t *testing.T) {
+	errCh := make(chan error, 1)
+	c, err := collectDBEvents[int](&fakeTransportSubscriber{transportErr: errCh})
+	require.NoError(t, err)
+
+	errCh <- errors.New("dial tcp 127.0.0.1:32831: connect: connection refused")
+	require.True(t, errors.Is(c.AssertSize(1), ErrListenerConnectionLost))
+}
+
+// TestAssertSizeSucceedsWhenSizeReached is a sanity check that the happy path
+// still returns nil once the expected number of events have been collected.
+func TestAssertSizeSucceedsWhenSizeReached(t *testing.T) {
+	c := &dbEventsCollector[int]{close: make(chan bool, 1)}
+	c.Append(dbEvent[int]{Val: 1})
+
+	require.NoError(t, c.AssertSize(1))
+}

--- a/token/services/storage/db/dbtest/tokens.go
+++ b/token/services/storage/db/dbtest/tokens.go
@@ -36,7 +36,7 @@ func TokensTest(t *testing.T, cfgProvider cfgProvider) {
 			tokenDB, ok := db.(TestTokenDB)
 			assert.True(xt, ok)
 			defer utils.IgnoreError(tokenDB.Close)
-			c.Fn(t, db.(TestTokenDB))
+			c.Fn(xt, db.(TestTokenDB))
 		})
 	}
 
@@ -50,12 +50,12 @@ func TokensTest(t *testing.T, cfgProvider cfgProvider) {
 			defer utils.IgnoreError(tokenDB.Close)
 			notifier, err := db.Notifier()
 			if err != nil && errors.Is(err, storage.ErrNotSupported) {
-				t.Logf("notifier not supported, skip test")
+				xt.Logf("notifier not supported, skip test")
 
 				return
 			}
 			require.NoError(xt, err)
-			c.Fn(t, db.(TestTokenDB), notifier)
+			c.Fn(xt, db.(TestTokenDB), notifier)
 		})
 	}
 }

--- a/token/services/storage/db/dbtest/tokensnotifier.go
+++ b/token/services/storage/db/dbtest/tokensnotifier.go
@@ -63,7 +63,7 @@ func TTokenNotifier(t *testing.T, db TestTokenDB, notifier driver.TokenNotifier)
 	}
 	require.NoError(t, db.StoreToken(ctx, tr, []string{"alice"}))
 
-	require.NoError(t, result.AssertSize(1))
+	requireSizeOrSkip(t, result, 1)
 	values := result.Values()
 	require.Equal(t, driver.Insert, values[0].Op)
 	require.Equal(t, driver.TokenRecordReference{
@@ -115,6 +115,19 @@ func (t *tokenSubscriber) Subscribe(f func(operation driver.Operation, vals driv
 	return t.notifier.Subscribe(f)
 }
 
+// TransportError forwards the underlying notifier's transport-error channel
+// when it exposes one (the Postgres notifier does), letting the collector skip
+// a subtest whose LISTEN connection dropped mid-run. It returns nil for
+// notifiers that do not report transport errors; the collector treats a nil
+// channel as "never fails". See issue #2270.
+func (t *tokenSubscriber) TransportError() <-chan error {
+	if r, ok := t.notifier.(transportErrorReporter); ok {
+		return r.TransportError()
+	}
+
+	return nil
+}
+
 func TSubscribeStore(t *testing.T, db TestTokenDB, notifier driver.TokenNotifier) {
 	t.Helper()
 	result, err := collectDBEvents[driver.TokenRecordReference](&tokenSubscriber{notifier: notifier})
@@ -126,7 +139,7 @@ func TSubscribeStore(t *testing.T, db TestTokenDB, notifier driver.TokenNotifier
 	require.NoError(t, tx.StoreToken(t.Context(), tokenRecords[1], []string{"alice"}))
 	require.NoError(t, tx.Commit())
 
-	require.NoError(t, result.AssertSize(2))
+	requireSizeOrSkip(t, result, 2)
 }
 
 func TSubscribeStoreDelete(t *testing.T, db TestTokenDB, notifier driver.TokenNotifier) {
@@ -140,7 +153,7 @@ func TSubscribeStoreDelete(t *testing.T, db TestTokenDB, notifier driver.TokenNo
 	require.NoError(t, tx.Delete(t.Context(), token.ID{TxId: "tx1", Index: 1}, "alice"))
 	require.NoError(t, tx.Commit())
 
-	require.NoError(t, result.AssertSize(3))
+	requireSizeOrSkip(t, result, 3)
 }
 
 func TSubscribeStoreNoCommit(t *testing.T, db TestTokenDB, notifier driver.TokenNotifier) {
@@ -152,7 +165,7 @@ func TSubscribeStoreNoCommit(t *testing.T, db TestTokenDB, notifier driver.Token
 	require.NoError(t, tx.StoreToken(t.Context(), tokenRecords[0], []string{"alice"}))
 	require.NoError(t, tx.StoreToken(t.Context(), tokenRecords[1], []string{"alice"}))
 
-	require.NoError(t, result.AssertSize(0))
+	requireSizeOrSkip(t, result, 0)
 }
 
 func TSubscribeRead(t *testing.T, db TestTokenDB, notifier driver.TokenNotifier) {
@@ -166,5 +179,5 @@ func TSubscribeRead(t *testing.T, db TestTokenDB, notifier driver.TokenNotifier)
 	require.NoError(t, err)
 	require.NoError(t, tx.Commit())
 
-	require.NoError(t, result.AssertSize(0))
+	requireSizeOrSkip(t, result, 0)
 }

--- a/token/services/storage/db/sql/postgres/notifier.go
+++ b/token/services/storage/db/sql/postgres/notifier.go
@@ -69,6 +69,14 @@ type Notifier struct {
 	mu sync.RWMutex
 	// listenerErr receives errors from the listener goroutine
 	listenerErr chan error
+	// transportErr receives non-fatal transport errors reported by pgxlisten's
+	// LogError callback (e.g. a dropped LISTEN connection that will be
+	// reconnected). Unlike listenerErr, these do not abort the notifier, but a
+	// consumer can observe them to learn that notifications may have been missed
+	// during a connectivity gap. Buffered with best-effort, non-blocking sends:
+	// the latest error is dropped rather than blocking the listener goroutine
+	// when nobody is draining.
+	transportErr chan error
 	// listenerWg waits for the listener goroutine to finish
 	listenerWg sync.WaitGroup
 	// closed indicates whether the notifier has been closed
@@ -125,13 +133,11 @@ func NewNotifier(
 ) *Notifier {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Create a real listener that implements the databaseListener interface
+	// Create a real listener that implements the databaseListener interface.
+	// LogError is wired below, once the Notifier exists to receive the errors.
 	realListener := &listenerAdapter{
 		Listener: &pgxlisten.Listener{
-			Connect: func(ctx context.Context) (*pgx.Conn, error) { return pgx.Connect(ctx, dataSource) },
-			LogError: func(ctx context.Context, err error) {
-				logger.Errorf("error encountered in [%s]: %s", redactDataSource(dataSource), err.Error())
-			},
+			Connect:        func(ctx context.Context) (*pgx.Conn, error) { return pgx.Connect(ctx, dataSource) },
 			ReconnectDelay: reconnectInterval,
 		},
 	}
@@ -147,10 +153,23 @@ func NewNotifier(
 		ctx:              ctx,
 		cancel:           cancel,
 		listenerErr:      make(chan error, 1), // buffered to prevent blocking
+		transportErr:     make(chan error, 1), // buffered, best-effort
 		closed:           false,
 		channelName:      channelName,
 	}
 	n.ensureSchema = n.CreateSchema
+
+	// pgxlisten calls LogError for non-fatal errors (a dropped connection is
+	// non-fatal: it reconnects). Log it and, best-effort, surface it on
+	// transportErr so a consumer can detect connectivity gaps during which
+	// notifications may have been lost.
+	realListener.LogError = func(_ context.Context, err error) {
+		logger.Errorf("error encountered in [%s]: %s", redactDataSource(dataSource), err.Error())
+		select {
+		case n.transportErr <- err:
+		default:
+		}
+	}
 
 	// attach handler that calls the subscribers
 	n.listener.Handle(channelName, &notificationHandler{
@@ -295,6 +314,16 @@ func (db *Notifier) Close() error {
 // The caller should consume this channel to detect listener failures.
 func (db *Notifier) ListenerError() <-chan error {
 	return db.listenerErr
+}
+
+// TransportError returns a channel that receives non-fatal transport errors
+// reported by the underlying listener (e.g. a dropped LISTEN connection that is
+// being reconnected). The notifier keeps running across such errors; the
+// channel merely lets a consumer learn that notifications may have been missed
+// during the outage. Sends are best-effort and buffered depth 1, so only the
+// most recent error is retained when the channel is not being drained.
+func (db *Notifier) TransportError() <-chan error {
+	return db.transportErr
 }
 
 // UnsubscribeAll removes all subscribers.


### PR DESCRIPTION
Fixes #2270

### Summary

`TestTokens/TokenNotifier` is flaky under the race detector (`make unit-tests-race`),
failing with `db events collector timeout` when the Postgres test container's
connection drops mid-test.

### Observed failure

```
--- FAIL: TestTokens (7.39s)
    tokens.go:58:
        Error Trace: token/services/storage/db/dbtest/tokensnotifier.go:66
                     token/services/storage/db/dbtest/tokens.go:58
        Error:       db events collector timeout
    --- FAIL: TestTokens/TokenNotifier (1.26s)
        testing.go:1913: test executed panic(nil) or runtime.Goexit:
                         subtest may have called FailNow on a parent test
```

Preceded in the logs by:

```
... waiting for notification: unexpected EOF
... dial tcp 127.0.0.1:32831: connect: connection refused
```

Seen in CI: https://github.com/LFDT-Panurus/panurus/actions/runs/32234333167/job/96019068379

### Details

The test relies on Postgres `LISTEN`/`NOTIFY`. When the Postgres test
container's connection drops (`unexpected EOF`, followed by `connection
refused` on reconnect), the expected notification never arrives and the events
collector times out
(`token/services/storage/db/dbtest/notifier.go:76` → `AssertSize`). The
`TokenNotifier` subtest then calls `FailNow`, producing the follow-on
`subtest may have called FailNow on a parent test` noise on the parent
`TestTokens`.

### Impact

Intermittent red CI on unrelated PRs. The failure is caused by a transient
Postgres connection drop / container teardown during the test rather than a
defect in the notifier logic; the test does not tolerate a dropped listener
connection.