### PR TITLE
Flaky test: TestIdentityCache_Close fails under -race (timing tolerance too tight)

### DIFF
--- a/token/services/identity/idemix/cache/cache_test.go
+++ b/token/services/identity/idemix/cache/cache_test.go
@@ -239,16 +239,20 @@ func TestIdentityCache_Close(t *testing.T) {
 	// Close the cache
 	c.Close()
 
-	// Capture the count after close
-	countAfterClose := callCount.Load()
+	// Close must stop the background provisioning goroutine. Assert on the goroutine
+	// actually exiting rather than on a fixed bound of extra iterations: the fast
+	// provisioning loop (1ms timeout) may complete an arbitrary number of in-flight
+	// iterations before observing the stop signal on a loaded/slow runner (notably
+	// under -race), so any fixed margin is inherently timing-dependent and flaky.
+	assert.Eventually(t, func() bool {
+		return provisioningGoroutines() == 0
+	}, time.Second, 10*time.Millisecond)
 
-	// Wait a bit to ensure no more calls are made
-	time.Sleep(100 * time.Millisecond)
-
-	// Count should not have increased significantly after close.
-	// Allow a small margin because the fast provisioning loop (1ms timeout)
-	// may complete a few in-flight iterations before observing the stop signal.
-	assert.LessOrEqual(t, callCount.Load(), countAfterClose+3)
+	// Once the goroutine has exited, the call count must be stable: no further calls
+	// happen after provisioning has stopped.
+	countAfterStop := callCount.Load()
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, countAfterStop, callCount.Load())
 }
 
 // provisionGoroutineName is the symbol appearing in the stack trace of the background


### PR DESCRIPTION
Fixes #2269

### Summary

`TestIdentityCache_Close` is flaky under the race detector (`make unit-tests-race`).

### Observed failure

```
--- FAIL: TestIdentityCache_Close (0.10s)
    cache_test.go:251:
        Error: "8" is not less than or equal to "7"
        Test:  TestIdentityCache_Close
FAIL github.com/LFDT-Panurus/panurus/token/services/identity/idemix/cache
```

Seen in CI: https://github.com/LFDT-Panurus/panurus/actions/runs/32234333167/job/96019068379

### Details

`token/services/identity/idemix/cache/cache_test.go:251` asserts that the
background provisioning loop performs no more than a small fixed number of
additional iterations after `Close()` is called
(`callCount.Load() <= countAfterClose+3`). The provisioning loop uses a 1ms
timeout, so on a loaded/slow runner — especially under `-race` — more in-flight
iterations complete before the stop signal is observed than the fixed margin
allows, and the assertion fails.

### Impact

Intermittent red CI on unrelated PRs; the failure is timing-dependent and does
not reproduce reliably. It is a test-tolerance/timing issue rather than a defect
in the cache implementation.