### PR TITLE
tokens: Parse returns TokenToAppend entries aliasing the caller's OutputStream, and those pointers are cached

### DIFF
--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -9,6 +9,7 @@ package tokens
 import (
 	"context"
 	"runtime/debug"
+	"slices"
 
 	"github.com/LFDT-Panurus/panurus/token"
 	"github.com/LFDT-Panurus/panurus/token/driver"
@@ -439,18 +440,20 @@ func (t *Service) Parse(
 				continue
 			}
 
+			// clone the token and the caller-owned byte slices so the cached entry does not
+			// alias the output stream, which may be reused or mutated after Parse returns
 			tta := TokenToAppend{
 				TxID:                  string(requestAnchor),
 				Index:                 output.Index,
-				Tok:                   &output.Token,
-				TokenOnLedger:         output.LedgerOutput,
+				Tok:                   output.Clone(),
+				TokenOnLedger:         slices.Clone(output.LedgerOutput),
 				TokenOnLedgerFormat:   output.LedgerOutputFormat,
-				TokenOnLedgerMetadata: output.LedgerOutputMetadata,
+				TokenOnLedgerMetadata: slices.Clone(output.LedgerOutputMetadata),
 				OwnerType:             "",
 				OwnerIdentity:         []byte{},
 				OwnerWalletID:         "",
 				Owners:                nil,
-				Issuer:                issuer,
+				Issuer:                slices.Clone(issuer),
 				Precision:             precision,
 				Flags: Flags{
 					Mine:     false,
@@ -489,18 +492,20 @@ func (t *Service) Parse(
 			return nil, nil, errors.Wrapf(err, "failed to extract owner type for token [%s:%d]", requestAnchor, output.Index)
 		}
 
+		// clone the token and the caller-owned byte slices so the cached entry does not
+		// alias the output stream, which may be reused or mutated after Parse returns
 		tta := TokenToAppend{
 			TxID:                  string(requestAnchor),
 			Index:                 output.Index,
-			Tok:                   &output.Token,
-			TokenOnLedger:         output.LedgerOutput,
+			Tok:                   output.Clone(),
+			TokenOnLedger:         slices.Clone(output.LedgerOutput),
 			TokenOnLedgerFormat:   output.LedgerOutputFormat,
-			TokenOnLedgerMetadata: output.LedgerOutputMetadata,
+			TokenOnLedgerMetadata: slices.Clone(output.LedgerOutputMetadata),
 			OwnerType:             identity.TypeToString(ownerType),
 			OwnerIdentity:         ownerIdentity,
 			OwnerWalletID:         ownerWalletID,
 			Owners:                ids,
-			Issuer:                output.Issuer,
+			Issuer:                slices.Clone(output.Issuer),
 			Precision:             precision,
 			Flags: Flags{
 				Mine:    mine,

--- a/token/token/token.go
+++ b/token/token/token.go
@@ -52,6 +52,18 @@ type Token struct {
 	Quantity string `json:"quantity,omitempty" protobuf:"bytes,3,opt,name=quantity,proto3"`
 }
 
+// Clone returns a full, independent copy of the token. The returned token
+// shares no mutable state with the receiver: the Owner byte slice is copied,
+// so mutating either token's Owner (or replacing any field) does not affect
+// the other. Type and Quantity are strings and are therefore immutable.
+func (t *Token) Clone() *Token {
+	return &Token{
+		Owner:    bytes.Clone(t.Owner),
+		Type:     t.Type,
+		Quantity: t.Quantity,
+	}
+}
+
 type IssuedToken struct {
 	// Id is used to uniquely identify the token in the ledger
 	Id ID `json:"id" protobuf:"bytes,1,opt,name=id,proto3"`

--- a/token/token/token_test.go
+++ b/token/token/token_test.go
@@ -195,6 +195,40 @@ func TestUnspentTokens_At(t *testing.T) {
 	assert.Equal(t, t1, ut.At(1))
 }
 
+func TestToken_Clone(t *testing.T) {
+	original := &token.Token{
+		Owner:    []byte("owner-1"),
+		Type:     "USD",
+		Quantity: "100",
+	}
+
+	clone := original.Clone()
+
+	// The clone is equal in value but is a distinct object with a distinct Owner slice.
+	assert.Equal(t, original, clone)
+	assert.NotSame(t, original, clone)
+	assert.NotSame(t, &original.Owner, &clone.Owner)
+
+	// Mutating the original's Owner bytes in place must not touch the clone,
+	// which is what a downstream cache holds onto after Parse returns.
+	original.Owner[0] = 'X'
+	assert.Equal(t, []byte("owner-1"), clone.Owner, "clone Owner must not alias the original")
+
+	// Replacing whole fields on the original must not leak into the clone either.
+	original.Owner = []byte("owner-2")
+	original.Type = "EUR"
+	original.Quantity = "200"
+	assert.Equal(t, []byte("owner-1"), clone.Owner)
+	assert.Equal(t, token.Type("USD"), clone.Type)
+	assert.Equal(t, "100", clone.Quantity)
+
+	// A nil Owner clones to nil without panicking.
+	nilOwner := (&token.Token{Type: "GBP", Quantity: "5"}).Clone()
+	assert.Nil(t, nilOwner.Owner)
+	assert.Equal(t, token.Type("GBP"), nilOwner.Type)
+	assert.Equal(t, "5", nilOwner.Quantity)
+}
+
 func TestIssuedTokens_Sum_Panic(t *testing.T) {
 	it := &token.IssuedTokens{
 		Tokens: []*token.IssuedToken{


### PR DESCRIPTION
Fixes #2186

### Summary
`Parse` builds each `TokenToAppend.Tok` as `&output.Token` — a pointer into the caller-owned `token.OutputStream`, not a copy. Those `TokenToAppend` values are then stored verbatim in the requests cache by `CacheRequest` and read back by `getActions` on the commit path, so a cached, about-to-be-persisted entry aliases memory the original caller still owns and may reuse or mutate before the commit happens.

### Where
`token/services/tokens/tokens.go:445` and `:495`:
```go
tta := TokenToAppend{
	...
	Tok: &output.Token,
	...
}
```
Cached at `tokens.go:175-180` (`CacheRequest` → `t.RequestsCache.Add(...)`), read back at `tokens.go:354-358` (`getActions`'s cache-hit path), consumed by `AppendValid` at `tokens.go:145-150`.

### Impact
Any code path that reuses or mutates a `token.Output` after `Parse` returns — including in tests that build outputs from a pool, or a future producer that recycles output structs — will observe the mutation reflected through the cached `TokenToAppend.Tok`, potentially at commit time, well after the value was supposedly captured.

### Reproduction
```go
store, _, err := ts.Parse(ctx, auth, "tx1", md, is, os, false, 64, false)
require.NoError(t, err)

output1.Token.Quantity = "0xdeadbeef" // mutate the caller's own stream after Parse returns

// BUG: the change is visible through the value Parse already returned
assert.Equal(t, "0xdeadbeef", store[0].Tok.Quantity)
```
```
=== RUN   TestParse_AliasesCallersOutputStream
--- PASS: TestParse_AliasesCallersOutputStream (0.00s)
PASS
```

### Severity
Medium — no reproduction via the current production call graph mutates outputs post-`Parse`, but the aliasing is a latent hazard for any future caller and for the cache's implicit assumption that cached entries are immutable snapshots.

Part of #2112.