### PR TITLE
tokens: AppendValid rolls back a transaction it does not own, discarding the caller's writes and double-rolling-back

### DIFF
--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -126,21 +126,18 @@ func (t *Service) AppendValid(ctx context.Context, tx dbdriver.Transaction, txID
 	}
 	defer t.removeCachedTokenRequest(string(txID))
 
-	logger.DebugfContext(ctx, "transaction [%s] start db transaction", txID)
+	logger.DebugfContext(ctx, "transaction [%s] continue db transaction", txID)
+	// ContinueTransaction wraps the caller's own transaction (the same underlying
+	// *sql.Tx the caller started); it does NOT open a new one. Ownership therefore
+	// stays with the caller: on failure we only stop and propagate the error, and
+	// the caller commits or rolls back exactly once. Rolling back here would tear
+	// down the caller's transaction — discarding writes we do not own — and leave
+	// the caller's own deferred finish running against an already-finished
+	// transaction. See issue #2184.
 	ts, err := t.Storage.ContinueTransaction(tx)
 	if err != nil {
-		return errors.WithMessagef(err, "transaction [%s], failed to start db transaction", txID)
+		return errors.WithMessagef(err, "transaction [%s], failed to continue db transaction", txID)
 	}
-	defer func() {
-		if err == nil {
-			return
-		}
-		if err1 := ts.Rollback(); err1 != nil {
-			logger.ErrorfContext(ctx, "error rolling back [%s][%s]", err1, string(debug.Stack()))
-		} else {
-			logger.InfofContext(ctx, "transaction [%s] rolled back", txID)
-		}
-	}()
 
 	logger.DebugfContext(ctx, "append tokens")
 	for _, tta := range toAppend {

--- a/token/services/tokens/tokens_test.go
+++ b/token/services/tokens/tokens_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token"
 	"github.com/LFDT-Panurus/panurus/token/driver"
+	dbdriver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/tokendb"
 	"github.com/LFDT-Panurus/panurus/token/services/tokens"
 	"github.com/LFDT-Panurus/panurus/token/services/tokens/mock"
@@ -219,6 +220,67 @@ func TestAppendValid_TransactionExistsError(t *testing.T) {
 	req := &token.Request{Anchor: "tx1", Metadata: &driver.TokenRequestMetadata{}}
 	err := ts.AppendValid(ctx, nil, "tx1", req)
 	assert.ErrorIs(t, err, assert.AnError)
+}
+
+// borrowedTx stands in for the caller's own transaction handed to AppendValid.
+// AppendValid continues (wraps) this transaction rather than opening its own, so
+// it must never finish it: it records commit/rollback so the test can assert none
+// happen on the failure path.
+type borrowedTx struct {
+	committed  int
+	rolledBack int
+}
+
+func (b *borrowedTx) Impl() dbdriver.TransactionImpl { return nil }
+func (b *borrowedTx) Commit() error {
+	b.committed++
+
+	return nil
+}
+func (b *borrowedTx) Rollback() { b.rolledBack++ }
+
+// TestAppendValid_DoesNotRollBackBorrowedTransaction is the regression test for
+// issue #2184. When an operation inside AppendValid fails, AppendValid must
+// propagate the error WITHOUT rolling back the transaction it was handed: that
+// transaction belongs to the caller (ContinueTransaction wraps the caller's own
+// *sql.Tx rather than opening a new one), so finishing it here would discard the
+// caller's writes and leave the caller's own deferred finish double-rolling-back.
+func TestAppendValid_DoesNotRollBackBorrowedTransaction(t *testing.T) {
+	ctx := context.Background()
+	tmsID := token.TMSID{Network: "net", Channel: "ch", Namespace: "ns"}
+
+	// The continued transaction fails on the first storage operation (the token
+	// lookup during delete), driving AppendValid into its error path.
+	mockTx := &mock.FakeTokenStoreTransaction{}
+	mockTx.GetTokenReturns(nil, nil, assert.AnError)
+
+	mockDB := &mock.FakeTokenStore{}
+	mockDB.TransactionExistsReturns(false, nil)
+	mockDB.ContinueTokenDBTransactionReturns(mockTx, nil)
+
+	// Prime the cache so getActions returns a token to spend without needing a full
+	// TMS; deleting it exercises the failing GetToken above.
+	cache := &mock.FakeCache{}
+	cache.GetReturns(&tokens.CacheEntry{ToSpend: []*token2.ID{{TxId: "in", Index: 0}}}, true)
+
+	storage := &tokens.DBStorage{TokenDB: &tokendb.StoreService{TokenStore: mockDB}, TMSID: tmsID}
+	ts := &tokens.Service{Storage: storage, RequestsCache: cache}
+
+	borrowed := &borrowedTx{}
+	req := &token.Request{Anchor: "tx1", Metadata: &driver.TokenRequestMetadata{}}
+
+	err := ts.AppendValid(ctx, borrowed, "tx1", req)
+
+	// The failure is surfaced to the caller...
+	require.ErrorIs(t, err, assert.AnError)
+	// ...the transaction AppendValid continued is the caller's own borrowed one...
+	require.Equal(t, 1, mockDB.ContinueTokenDBTransactionCallCount())
+	assert.Same(t, dbdriver.Transaction(borrowed), mockDB.ContinueTokenDBTransactionArgsForCall(0))
+	// ...and AppendValid did NOT finish it — neither directly nor via the continued
+	// wrapper. The caller alone commits or rolls back, exactly once.
+	assert.Equal(t, 0, borrowed.rolledBack, "AppendValid must not roll back the caller's transaction")
+	assert.Equal(t, 0, borrowed.committed, "AppendValid must not commit the caller's transaction")
+	assert.Equal(t, 0, mockTx.RollbackCallCount(), "AppendValid must not roll back via the continued wrapper")
 }
 
 // TestGetCachedTokenRequest verifies that a cached request is returned together with its


### PR DESCRIPTION
Fixes #2184

### Summary
`AppendValid` rolls back a transaction it does not own. `Storage.ContinueTransaction(tx)` wraps the *caller's own* `dbdriver.Transaction` — the same underlying `*sql.Tx` the caller started and still owns — rather than starting a new one. When appending fails, `AppendValid`'s deferred cleanup rolls back that continued transaction, i.e. it rolls back the caller's transaction out from under it. The caller (the finality listener) also has its own deferred rollback/commit for the same borrowed transaction, so it runs a second, redundant finish call against an already-finished `*sql.Tx`.

### Where
`token/services/tokens/tokens.go:129-142`:
```go
ts, err := t.Storage.ContinueTransaction(tx)
...
defer func() {
	if err == nil {
		return
	}
	if err1 := ts.Rollback(); err1 != nil {
		logger.ErrorfContext(ctx, "error rolling back [%s][%s]", err1, string(debug.Stack()))
	} else {
		logger.InfofContext(ctx, "transaction [%s] rolled back", txID)
	}
}()
```
`ts.Rollback()` is `DBTransaction.Rollback` (`storage.go:252-254`), which delegates to `t.Tx.Rollback()` — the caller's own transaction object.

The two `Rollback` signatures compound the problem: the caller-owned interface, `dbdriver.Transaction.Rollback()` (`token/services/storage/db/driver/transaction.go:18`), has **no error return at all**, while the store-level `DBTransaction.Rollback() error` (`storage.go:252`) does. So when the caller later calls its own `Rollback()` on the now-already-finished transaction, any resulting error (`sql.ErrTxDone` in the standard driver) has nowhere to go — the interface it implements can't even express it.

### Impact
A single append failure inside `AppendValid` (e.g. a unique-key error not otherwise excluded, a context cancellation, a transient DB error) discards **all** of the caller's writes in that transaction, not just the tokens-package delta, and the caller's own subsequent finish call fails silently.

### Reproduction
```go
borrowed := &borrowedTx{} // stands in for the caller's own dbdriver.Transaction
err = svc.AppendValid(ctx, borrowed, txID, request) // AppendToken fails inside
require.Error(t, err)

assert.Same(t, borrowed, mockDB.ContinueTokenDBTransactionArgsForCall(0),
	"ContinueTransaction was given the caller's own borrowed transaction")

// BUG: AppendValid rolled back the continued transaction, which shares the
// caller's underlying transaction
assert.Equal(t, 1, mockTx.RollbackCallCount())

// the caller has not yet tried to finish its own transaction
assert.Equal(t, 0, borrowed.rolledBack)
```
```
=== RUN   TestAppendValid_RollsBackTransactionItDoesNotOwn
--- PASS: TestAppendValid_RollsBackTransactionItDoesNotOwn (0.00s)
PASS
```

### Severity
Medium — requires an append failure to trigger, but when it does, the caller's own transaction bookkeeping is left inconsistent with no observable error.

Part of #2112.