### PR TITLE
fix(tcc): reject null token ids in queryTokens

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -123,6 +123,9 @@ jobs:
           - name: driver-config-key-field-round-trip
             pkg: ./token/driver
             func: FuzzConfigKeyFieldRoundTrip
+          - name: tcc-query-tokens
+            pkg: ./token/services/network/fabric/tcc
+            func: FuzzQueryTokensNoPanic
 
     steps:
       - name: Checkout code

--- a/docs/services/network-fabric.md
+++ b/docs/services/network-fabric.md
@@ -48,6 +48,27 @@ The chaincode exposes the following functions:
 | `areTokensSpent` | Check if tokens are spent | Token IDs, metadata      | Boolean array |
 | `queryStates` | Query arbitrary state keys | State keys               | State values |
 
+### Input Validation
+
+The query functions are reachable by any client that can query the channel, so their
+arguments are treated as untrusted input:
+
+- `queryTokens` expects a JSON array of token ids (`{"tx_id": ..., "index": ...}`). Each
+  element is validated before any state is read:
+  - a `null` element decodes to a nil token id and is rejected with
+    `invalid token id at position [i]: null`, rather than being passed on to the translator,
+    which dereferences each id. `translator.QueryTokens` rejects nil ids as well, so an id
+    list assembled elsewhere in the codebase cannot panic it either;
+  - an element with an empty `tx_id` is rejected with
+    `invalid token id at position [i]: empty tx id`. It is not a valid token id, and letting
+    it through would spend a state read on a key that cannot exist.
+- `areTokensSpent` and `queryStates` expect a JSON array of strings; anything else fails to
+  unmarshal and returns an error response.
+
+Malformed arguments always produce an ordinary error response (status 500). `Invoke`'s
+top-level `recover()` remains as a last resort, but no supported input is expected to reach
+it.
+
 ### Chaincode Deployment
 
 The Token Chaincode must be deployed to the Fabric network before Panurus can operate:

--- a/token/services/network/common/rws/translator/query_tokens_test.go
+++ b/token/services/network/common/rws/translator/query_tokens_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package translator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/services/network/common/rws/keys"
+	"github.com/LFDT-Panurus/panurus/token/services/network/common/rws/translator"
+	"github.com/LFDT-Panurus/panurus/token/services/network/common/rws/translator/mock"
+	"github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/stretchr/testify/require"
+)
+
+// TestQueryTokensNilID makes sure a nil id is reported as an error instead of being
+// dereferenced. See https://github.com/LFDT-Panurus/panurus/issues/2051.
+func TestQueryTokensNilID(t *testing.T) {
+	fakeRWSet := &mock.RWSet{}
+	fakeRWSet.GetStateReturns([]byte("token"), nil)
+	w := translator.New("0", translator.NewRWSetWrapper(fakeRWSet, tokenNameSpace, "0"), &keys.Translator{})
+
+	for _, ids := range [][]*token.ID{
+		{nil},
+		{nil, nil},
+		{{TxId: "tx1", Index: 0}, nil},
+	} {
+		require.NotPanics(t, func() {
+			res, err := w.QueryTokens(context.Background(), ids)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "nil token id at position")
+			require.Nil(t, res)
+		})
+	}
+}

--- a/token/services/network/common/rws/translator/translator.go
+++ b/token/services/network/common/rws/translator/translator.go
@@ -131,10 +131,17 @@ func (t *Translator) AddPublicParamsDependency() error {
 	return nil
 }
 
+// QueryTokens returns the raw state of each of the passed token ids. It fails if any id is
+// nil, cannot be turned into an output key, or refers to a state that does not exist.
 func (t *Translator) QueryTokens(ctx context.Context, ids []*token.ID) ([][]byte, error) {
 	var res [][]byte
 	var errs []error
-	for _, id := range ids {
+	for i, id := range ids {
+		if id == nil {
+			errs = append(errs, errors.Errorf("nil token id at position [%d]", i))
+
+			continue
+		}
 		outputID, err := t.KeyTranslator.CreateOutputKey(id.TxId, id.Index)
 		if err != nil {
 			errs = append(errs, errors.Errorf("error creating output ID: %s", err))

--- a/token/services/network/fabric/tcc/query_tokens_test.go
+++ b/token/services/network/fabric/tcc/query_tokens_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tcc_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	chaincode2 "github.com/LFDT-Panurus/panurus/token/services/network/fabric/tcc"
+	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/tcc/mock"
+	token2 "github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/stretchr/testify/require"
+)
+
+// newQueryStub returns a stub usable by the query entry points, which need neither public
+// parameters nor a validator.
+func newQueryStub() *mock.ChaincodeStubInterface {
+	stub := &mock.ChaincodeStubInterface{}
+	stub.GetTxIDReturns("txid")
+
+	return stub
+}
+
+// TestQueryTokensNullID covers https://github.com/LFDT-Panurus/panurus/issues/2051: a null
+// element in the ids array decodes to a nil *token.ID and used to be dereferenced by the
+// translator.
+func TestQueryTokensNullID(t *testing.T) {
+	cc := &chaincode2.TokenChaincode{}
+
+	require.NotPanics(t, func() {
+		resp := cc.QueryTokens([]byte(`[null]`), newQueryStub())
+		require.Equal(t, int32(500), resp.Status)
+		require.Contains(t, resp.Message, "invalid token id at position [0]: null")
+	})
+}
+
+func TestQueryTokensNullIDAmongValidOnes(t *testing.T) {
+	cc := &chaincode2.TokenChaincode{}
+
+	require.NotPanics(t, func() {
+		resp := cc.QueryTokens([]byte(`[{"tx_id":"tx1","index":0},null]`), newQueryStub())
+		require.Equal(t, int32(500), resp.Status)
+		require.Contains(t, resp.Message, "invalid token id at position [1]: null")
+	})
+}
+
+// TestQueryTokensEmptyID covers the neighbouring case: an id that is present but carries no
+// tx id. It never panicked, but it used to reach the ledger and come back as a missing
+// composite key; it is now rejected before any state read.
+func TestQueryTokensEmptyID(t *testing.T) {
+	cc := &chaincode2.TokenChaincode{}
+
+	for position, raw := range map[int]string{
+		0: `[{}]`,
+		1: `[{"tx_id":"tx1","index":0},{"tx_id":"","index":3}]`,
+	} {
+		stub := newQueryStub()
+		resp := cc.QueryTokens([]byte(raw), stub)
+		require.Equal(t, int32(500), resp.Status, "input [%s]", raw)
+		require.Contains(t, resp.Message, fmt.Sprintf("invalid token id at position [%d]: empty tx id", position))
+		require.Zero(t, stub.GetStateCallCount(), "input [%s] must be rejected before any state read", raw)
+	}
+}
+
+// TestInvokeQueryTokensNullID exercises the same input through the chaincode dispatcher, to
+// make sure the response is a plain validation error and not a recovered panic.
+func TestInvokeQueryTokensNullID(t *testing.T) {
+	cc := &chaincode2.TokenChaincode{}
+	stub := newQueryStub()
+	stub.GetArgsReturns([][]byte{[]byte(chaincode2.QueryTokensFunctions), []byte(`[null]`)})
+
+	resp := cc.Invoke(stub)
+	require.Equal(t, int32(500), resp.Status)
+	require.Contains(t, resp.Message, "invalid token id at position [0]: null")
+	require.NotContains(t, resp.Message, "failed responding")
+}
+
+func TestQueryTokensMalformedJSON(t *testing.T) {
+	cc := &chaincode2.TokenChaincode{}
+
+	for _, raw := range []string{``, `[`, `{}`, `[{"tx_id":`, `["not-an-id"]`} {
+		require.NotPanics(t, func() {
+			resp := cc.QueryTokens([]byte(raw), newQueryStub())
+			require.Equal(t, int32(500), resp.Status, "input [%s]", raw)
+		})
+	}
+}
+
+// FuzzQueryTokensNoPanic fuzzes the raw, caller-controlled argument of the queryTokens
+// chaincode function. QueryTokens must always answer with a response, never panic.
+func FuzzQueryTokensNoPanic(f *testing.F) {
+	valid, err := json.Marshal([]*token2.ID{{TxId: "tx1", Index: 0}, {TxId: "tx2", Index: 1}})
+	require.NoError(f, err)
+
+	f.Add(valid)
+	f.Add([]byte(``))
+	f.Add([]byte(`[]`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`[null]`))
+	f.Add([]byte(`[null,null]`))
+	f.Add([]byte(`[{"tx_id":"tx1","index":0},null]`))
+	f.Add([]byte(`[{"tx_id":"tx1","index":0}`))
+	f.Add([]byte(`[{"tx_id":"tx1","index":-1}]`))
+	f.Add([]byte(`[{"tx_id":"tx1","index":18446744073709551616}]`))
+	f.Add([]byte(`{"tx_id":"tx1","index":0}`))
+	f.Add([]byte(`["tx1"]`))
+	f.Add([]byte(`[{}]`))
+	f.Add([]byte(`[{"tx_id":""}]`))
+	f.Add([]byte("[{\"tx_id\":\"a\u0000b\"}]"))
+
+	f.Fuzz(func(t *testing.T, idsRaw []byte) {
+		cc := &chaincode2.TokenChaincode{}
+		resp := cc.QueryTokens(idsRaw, newQueryStub())
+		require.NotNil(t, resp)
+	})
+}

--- a/token/services/network/fabric/tcc/tcc.go
+++ b/token/services/network/fabric/tcc/tcc.go
@@ -282,12 +282,30 @@ func (cc *TokenChaincode) QueryPublicParams(stub shim.ChaincodeStubInterface) *p
 	return shim.Success(raw)
 }
 
+// QueryTokens returns the raw state of the tokens whose ids are JSON-encoded in idsRaw.
+// idsRaw is caller-controlled: it must be a JSON array of token ids, each of them non-null
+// and carrying a non-empty tx id, otherwise a validation error is returned.
 func (cc *TokenChaincode) QueryTokens(idsRaw []byte, stub shim.ChaincodeStubInterface) *pb.Response {
 	var ids []*token2.ID
 	if err := json.Unmarshal(idsRaw, &ids); err != nil {
 		logger.Errorf("failed unmarshalling tokens ids: [%s]", err)
 
 		return shim.Error(err.Error())
+	}
+
+	// A JSON array can carry null elements, which decode into nil *token2.ID pointers without
+	// error. The translator dereferences every element, so reject them here with a plain
+	// validation error instead of relying on Invoke's top-level recover. An empty tx id is
+	// never a valid token id either: it does not panic, but it costs a pointless state read
+	// and reports itself as a missing composite key, so reject it up front too.
+	// Invoke logs every non-200 response, so these do not log on their own.
+	for i, id := range ids {
+		switch {
+		case id == nil:
+			return shim.Error(fmt.Sprintf("invalid token id at position [%d]: null", i))
+		case len(id.TxId) == 0:
+			return shim.Error(fmt.Sprintf("invalid token id at position [%d]: empty tx id", i))
+		}
 	}
 
 	logger.Debugf("query tokens [%v]...", ids)


### PR DESCRIPTION
Fixes #2051

## The problem, in one line

Anyone who can query the token chaincode could make it crash on demand by asking for a token id that is `null`.

## What happened before (the bug)

```
1. Caller asks the chaincode: queryTokens  [null]
2. Chaincode turns that text into a list of token ids
   -> "null" becomes an empty slot (no id at all), and no error is raised
3. Chaincode passes the list on, empty slot included
4. The next layer reads "the transaction id of this token" from the empty slot
   -> nothing there -> CRASH (nil pointer panic)
5. A safety net higher up catches the crash and returns an error 500
```

So nothing was stolen and the peer stayed up — but every such request cost a
crash-and-recover plus a stack trace in the logs, and it could be repeated as
often as the caller liked.

## What happens now (the fix)

```
1. Caller asks the chaincode: queryTokens  [null]
2. Chaincode turns that text into a list of token ids
3. NEW: chaincode checks every entry in the list
   -> finds the empty slot and stops right there
4. Caller gets a plain error: "invalid token id at position [0]: null"
   -> no crash, no stack trace, safety net never needed
```

A second check was added one layer deeper (in the translator), so the crash
cannot happen even if an empty slot reaches it from somewhere else in the code.

## What about an id that is *present but empty*?

Worth asking, so it was checked: `[{}]` (an id with no transaction id in it) never
crashed. It went all the way to the ledger, looked up a key that cannot exist, and
came back as an error. Harmless — but it wasted one ledger lookup per bogus id and
the error it produced was confusing.

An empty transaction id is never a real token id, so it is now rejected in the same
place as `null`, before any ledger lookup:

```
Caller asks for [{}]  ->  "invalid token id at position [0]: empty tx id"
```

## Changes

- `token/services/network/fabric/tcc/tcc.go` — reject `null` ids and ids with an empty `tx_id` in `queryTokens`.
- `token/services/network/common/rws/translator/translator.go` — treat a nil id as an error instead of reading from it.
- Tests for both layers, reproducing the original crash before the fix.
- A fuzz test that throws random/broken input at `queryTokens` and requires it never to crash, added to the nightly fuzz job.
- `docs/services/network-fabric.md` — short section on what the query functions accept.

## Verification

`make checks` clean, `make lint` 0 issues, `go test -race` green on both packages, 25s fuzz run with no findings.
