### PR TITLE
fix(fabtoken): guard nil transfer inputs and outputs in TransferSignatureValidate

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -78,6 +78,9 @@ jobs:
           - name: fabtoken-transfer-htlc-validate
             pkg: ./token/core/fabtoken/v1/validator
             func: FuzzTransferHTLCValidateNoPanic
+          - name: fabtoken-transfer-validation-steps
+            pkg: ./token/core/fabtoken/v1/validator
+            func: FuzzTransferValidationStepsNoPanic
           - name: zkatdlog-issue-bulletproof-verifier
             pkg: ./token/core/zkatdlog/nogh/v1/issue
             func: FuzzBulletProofVerifierNoPanic

--- a/docs/drivers/extending_validator.md
+++ b/docs/drivers/extending_validator.md
@@ -74,6 +74,25 @@ fields that earlier steps populate (`validator.Context.InputTokens`, `Context.Si
 may be empty or shorter than expected, so bound-check them and return an error instead of
 indexing blindly.
 
+The same applies to the action itself. Deserializing attacker-controlled bytes can yield an action
+whose input/output slices contain `nil` entries (a `nil` token inside a protobuf input or output is
+preserved as a `nil` entry), and the action-level `Validate()` step — which rejects those — is just
+one step of the pipeline: a pipeline that reorders the steps, adds an alternate entry point, or omits
+`Validate()` sees the raw shape. Every step must therefore nil-check the entries it touches. The
+built-in transfer steps of both drivers do, so they cannot panic in any pipeline order, and custom
+steps are expected to follow suit.
+
+Watch out for Go's typed-nil gotcha when a step reads outputs through the `driver.Output` interface:
+an interface value holding a *typed-nil* pointer still satisfies a type assertion with `ok == true`,
+so `ok` alone does not prove the value is usable. Check both:
+
+```go
+out, ok := o.(*actions.Output)
+if !ok || out == nil {
+	return errors.Errorf("invalid output at index [%d]", i)
+}
+```
+
 ### 2. Create a custom Validator Driver
 
 Implement the `driver.ValidatorDriver` interface by wrapping the standard one.

--- a/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzTransferValidationStepsNoPanic/nil-input-token-signature-step-first
+++ b/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzTransferValidationStepsNoPanic/nil-input-token-signature-step-first
@@ -1,0 +1,3 @@
+go test fuzz v1
+byte('\x06')
+[]byte("\b\x01\x12\x040000")

--- a/token/core/fabtoken/v1/validator/validator_fuzz_test.go
+++ b/token/core/fabtoken/v1/validator/validator_fuzz_test.go
@@ -15,14 +15,18 @@ import (
 
 	fbactions "github.com/LFDT-Panurus/panurus/token/core/fabtoken/protos-go/v1/actions"
 	"github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/actions"
+	"github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/setup"
 	"github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/validator"
 	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/driver/mock"
 	driverv1 "github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1"
 	"github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1/request"
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/x509"
 	"github.com/LFDT-Panurus/panurus/token/services/interop/encoding"
 	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/stretchr/testify/require"
 )
@@ -233,4 +237,105 @@ func FuzzTransferHTLCValidateNoPanic(f *testing.F) {
 			require.Error(t, err, "multi-input transfer with an htlc-owned input must be rejected")
 		}
 	})
+}
+
+// FuzzTransferValidationStepsNoPanic deserializes a transfer action from fuzzed bytes and runs the
+// four transfer validation steps in a fuzz-chosen order, asserting that no ordering of the steps
+// can panic. Deserializing attacker-controlled bytes can legitimately produce an action carrying
+// nil input tokens and nil output entries (a nil token inside a protobuf input or output is
+// preserved as a nil entry), so every step must guard those on its own rather than rely on
+// TransferActionValidate — which rejects them — having run first.
+func FuzzTransferValidationStepsNoPanic(f *testing.F) {
+	transferRaw, err := (&actions.TransferAction{
+		Inputs: []*actions.TransferActionInput{
+			{ID: &token.ID{TxId: "tx1"}, Input: &actions.Output{Owner: []byte("owner1"), Type: "ABC", Quantity: "0x64"}},
+		},
+		Outputs: []*actions.Output{{Owner: []byte("owner2"), Type: "ABC", Quantity: "0x64"}},
+	}).Serialize()
+	require.NoError(f, err)
+	f.Add(uint8(0), transferRaw)
+	f.Add(uint8(1), transferRaw)
+	// an input and an output both carrying a nil token: both deserialize to nil entries
+	f.Add(uint8(0), marshalFuzzedNilEntriesTransferAction())
+	f.Add(uint8(0), []byte{})
+	f.Add(uint8(0), []byte("malformed"))
+
+	// every permutation of the four transfer steps of the default pipeline, so that no step can
+	// assume any other one ran before it
+	steps := []validator.ValidateTransferFunc{
+		validator.TransferActionValidate,
+		validator.TransferSignatureValidate,
+		validator.TransferBalanceValidate,
+		validator.TransferHTLCValidate,
+	}
+	orders := permutations(len(steps))
+	logger := logging.MustGetLogger("fuzz")
+	limits := driver.DefaultResourceLimits()
+
+	f.Fuzz(func(t *testing.T, orderIdx uint8, raw []byte) {
+		if len(raw) > limits.MaxActionBytes {
+			t.Skip()
+		}
+		ta := &actions.TransferAction{}
+		ta.SetLimits(limits)
+		if err := ta.Deserialize(raw); err != nil {
+			t.Skip()
+		}
+
+		deserializer := &mock.Deserializer{}
+		deserializer.GetOwnerVerifierReturns(&mock.Verifier{}, nil)
+		deserializer.GetIssuerVerifierReturns(&mock.Verifier{}, nil)
+		sigProvider := &mock.SignatureProvider{}
+		sigProvider.HasBeenSignedByReturns([]byte("sig"), nil)
+		c := &validator.Context{
+			TransferAction:    ta,
+			Deserializer:      deserializer,
+			SignatureProvider: sigProvider,
+			Logger:            logger,
+			PP:                &setup.PublicParams{QuantityPrecision: 64, IssuerIDs: []driver.Identity{[]byte("issuer1")}},
+			MetadataCounter:   make(map[string]int),
+		}
+
+		order := orders[int(orderIdx)%len(orders)]
+		require.NotPanics(t, func() {
+			for _, i := range order {
+				if err := steps[i](context.Background(), c); err != nil {
+					// a validation error is a valid outcome for any step at any position
+					return
+				}
+			}
+		})
+	})
+}
+
+// marshalFuzzedNilEntriesTransferAction builds the raw bytes of a transfer action whose input and
+// output both carry a nil token, which Deserialize turns into nil entries in the action.
+func marshalFuzzedNilEntriesTransferAction() []byte {
+	ta := &fbactions.TransferAction{
+		Version: actions.ProtocolV1,
+		Inputs:  []*fbactions.TransferActionInput{{TokenId: &driverv1.TokenID{TxId: "tx1"}}},
+		Outputs: []*fbactions.TransferActionOutput{{}},
+	}
+	raw, _ := proto.Marshal(ta)
+
+	return raw
+}
+
+// permutations returns every permutation of the indices [0, n).
+func permutations(n int) [][]int {
+	if n <= 1 {
+		return [][]int{make([]int, n)}
+	}
+	var res [][]int
+	for _, sub := range permutations(n - 1) {
+		for pos := range n {
+			p := make([]int, 0, n)
+			p = append(p, sub[:pos]...)
+			p = append(p, n-1)
+			p = append(p, sub[pos:]...)
+			res = append(res, p)
+		}
+	}
+
+	return res
 }

--- a/token/core/fabtoken/v1/validator/validator_test.go
+++ b/token/core/fabtoken/v1/validator/validator_test.go
@@ -549,6 +549,92 @@ func TestTransferSignatureValidate(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed signature verification")
 	})
+	t.Run("NilInputEntry_NoPanic", func(t *testing.T) {
+		ta := &actions.TransferAction{
+			Inputs: []*actions.TransferActionInput{nil},
+		}
+		c := &validator.Context{
+			TransferAction: ta,
+			Deserializer:   &mock.Deserializer{},
+			Logger:         logger,
+			PP:             pp,
+		}
+		err := validator.TransferSignatureValidate(ctx, c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid input at index [0]: nil input or nil token")
+	})
+
+	t.Run("NilInputTokenInEntry_NoPanic", func(t *testing.T) {
+		// the nil token sits at index 1, so the guard must hold for every input, not just the first
+		ta := &actions.TransferAction{
+			Inputs: []*actions.TransferActionInput{
+				{Input: &actions.Output{Owner: []byte("owner1")}},
+				{ID: &token.ID{TxId: "tx1", Index: 0}, Input: nil},
+			},
+		}
+		deserializer := &mock.Deserializer{}
+		deserializer.GetOwnerVerifierReturns(&mock.Verifier{}, nil)
+		sigProvider := &mock.SignatureProvider{}
+		sigProvider.HasBeenSignedByReturns([]byte("sig"), nil)
+		c := &validator.Context{
+			TransferAction:    ta,
+			Deserializer:      deserializer,
+			SignatureProvider: sigProvider,
+			Logger:            logger,
+			PP:                pp,
+		}
+		err := validator.TransferSignatureValidate(ctx, c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid input at index [1]: nil input or nil token")
+	})
+
+	t.Run("NilOutput_NoPanic", func(t *testing.T) {
+		// the redeem-detection scan reads output.Owner, so a nil output entry must be rejected
+		deserializer := &mock.Deserializer{}
+		deserializer.GetOwnerVerifierReturns(&mock.Verifier{}, nil)
+		sigProvider := &mock.SignatureProvider{}
+		sigProvider.HasBeenSignedByReturns([]byte("sig"), nil)
+		ta := &actions.TransferAction{
+			Inputs: []*actions.TransferActionInput{
+				{Input: &actions.Output{Owner: []byte("owner1")}},
+			},
+			Outputs: []*actions.Output{{Owner: []byte("owner2")}, nil},
+		}
+		c := &validator.Context{
+			TransferAction:    ta,
+			Deserializer:      deserializer,
+			SignatureProvider: sigProvider,
+			Logger:            logger,
+			PP:                pp,
+		}
+		err := validator.TransferSignatureValidate(ctx, c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid output at index [1]")
+	})
+	t.Run("EmptyButNonNilOwnerIsRedeem", func(t *testing.T) {
+		// Output.IsRedeem() tests len(Owner) == 0, so an empty but non-nil owner is a redeem
+		// everywhere else in the code; the redeem scan must agree and demand the issuer signature
+		deserializer := &mock.Deserializer{}
+		deserializer.GetOwnerVerifierReturns(&mock.Verifier{}, nil)
+		sigProvider := &mock.SignatureProvider{}
+		sigProvider.HasBeenSignedByReturns([]byte("sig"), nil)
+		ta := &actions.TransferAction{
+			Inputs: []*actions.TransferActionInput{
+				{Input: &actions.Output{Owner: []byte("owner1")}},
+			},
+			Outputs: []*actions.Output{{Owner: []byte{}}},
+		}
+		c := &validator.Context{
+			TransferAction:    ta,
+			Deserializer:      deserializer,
+			SignatureProvider: sigProvider,
+			Logger:            logger,
+			PP:                pp,
+		}
+		err := validator.TransferSignatureValidate(ctx, c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must have at least one issuer")
+	})
 }
 
 func TestTransferBalanceValidate(t *testing.T) {

--- a/token/core/fabtoken/v1/validator/validator_transfer.go
+++ b/token/core/fabtoken/v1/validator/validator_transfer.go
@@ -27,7 +27,10 @@ func TransferActionValidate(c context.Context, ctx *Context) error {
 	return ctx.TransferAction.Validate()
 }
 
-// TransferSignatureValidate validates the signatures for the inputs spent by an action
+// TransferSignatureValidate validates the signatures for the inputs spent by an action.
+// A nil input entry, a nil token inside an input, or a nil output entry yields a validation
+// error rather than a panic, regardless of the order in which the validation steps of the
+// pipeline are executed.
 func TransferSignatureValidate(c context.Context, ctx *Context) error {
 	if len(ctx.TransferAction.Inputs) == 0 {
 		return errors.Errorf("invalid number of token inputs, expected at least 1")
@@ -36,6 +39,10 @@ func TransferSignatureValidate(c context.Context, ctx *Context) error {
 	verifierCache := make(map[string]driver.Verifier)
 	var inputToken []*actions.Output
 	for i, in := range ctx.TransferAction.Inputs {
+		// guard: a nil input entry, or a nil token inside it, must return an error, not panic
+		if in == nil || in.Input == nil {
+			return errors.Errorf("invalid input at index [%d]: nil input or nil token", i)
+		}
 		tok := in.Input
 
 		inputToken = append(inputToken, tok)
@@ -65,8 +72,15 @@ func TransferSignatureValidate(c context.Context, ctx *Context) error {
 	if len(ctx.PP.Issuers()) > 0 {
 		// In this case we must ensure that an issuer signed as well if the action redeems tokens as well
 		var isRedeem bool
-		for _, output := range ctx.TransferAction.Outputs {
-			if output.Owner == nil {
+		for i, output := range ctx.TransferAction.Outputs {
+			// guard: a nil output entry must return an error, not panic
+			if output == nil {
+				return errors.Errorf("invalid output at index [%d]", i)
+			}
+			// use the same definition of a redeem as the rest of the code (Output.IsRedeem,
+			// which tests len(Owner) == 0): an empty but non-nil owner is a redeem too, and
+			// checking `Owner == nil` here would let it skip the issuer signature
+			if output.IsRedeem() {
 				isRedeem = true
 
 				break


### PR DESCRIPTION
Fixes #2027

## What was broken, in plain words

One validation step (`TransferSignatureValidate`) trusted that the pieces of a transfer were always there. If a piece was missing (empty instead of a real value), the code reached into it anyway and crashed instead of saying "this transfer is invalid".

**Steps that cause it**

1. Someone sends a transfer whose input has **no token inside it** (or whose output slot is **empty**).
2. Validation is asked to check the signatures on that transfer.
3. The code reads the owner *out of the missing piece*.
4. 💥 Crash (nil-pointer panic), instead of a clean "invalid transfer" error.

Today the crash is not reachable in practice: an earlier step in the standard order already throws such transfers out, and a top-level safety net turns any crash into a rejected transaction. It becomes reachable the moment the steps run in a different order, or a step is skipped — so this is a defensive fix, not an active incident.

**Steps after the fix**

1. Same malformed transfer arrives.
2. Validation checks the signatures.
3. Before reading anything, it asks: *is this piece actually there?*
4. It isn't → return the error `invalid input at index [1]: nil input or nil token` (or `invalid output at index [1]`). No crash, regardless of which step ran first.

## Second, related fix in the same scan

While checking what "empty" means here, the redeem test itself turned out to be inconsistent. An output with **no owner** means "these tokens are being destroyed" (a redeem), which requires the issuer's signature. But this step asked *"is the owner missing?"* as `Owner == nil`, while the rest of the code asks it as `len(Owner) == 0` (`Output.IsRedeem()`).

Those two answers differ for an owner that is **empty but present**: the rest of the code calls it a redeem, this step did not — so such an action would be accepted **without the issuer's signature**.

Not reachable over the network today (the protobuf decoder turns an empty byte field into a missing one, so an owner arriving from the wire is either missing or non-empty), but the check should not depend on that detail. It now calls `IsRedeem()`, so it agrees with everything else by construction. One extra test covers it.

## The change

- `validator_transfer.go`: two nil checks — one on each input entry and its token, one on each output entry in the redeem scan. Both return a validation error, matching the style already used by the neighbouring steps.
- The other sites named in the issue were already fixed on `main` by #2025's follow-up work, so nothing was needed there.

## How it's tested

- 3 unit tests, one per malformed shape. Each one **panics against the current `main` code** and passes with the fix.
- New fuzz test `FuzzTransferValidationStepsNoPanic`: it builds a transfer from random bytes and runs the four validation steps **in a random one of all 24 possible orders**, asserting nothing ever crashes. Without the fix it finds a crashing input in under a second — that input is committed as a named seed so it can never regress. Added to the nightly fuzz matrix.
- `docs/drivers/extending_validator.md`: short note for anyone writing a custom validation step — don't assume another step ran first, and beware Go's typed-nil type assertion.

Full package tests, `-race`, `make checks`, and lint are clean.
