### PR TITLE
fix(core): resolve the first usable public parameters, not the first retrievable

### DIFF
--- a/docs/public_parameters.md
+++ b/docs/public_parameters.md
@@ -49,6 +49,35 @@ When an FSC node starts or connects to a TMS, it must fetch the current public p
 - **Fetching**: The node uses the `PublicParamsFetcher` (provided by the **Network Service**) to query the ledger (via TCC or the Query Service).
 - **Local Cache**: Fetched parameters are cached in the node's local `PublicParametersStorage` to ensure they are available even if the network is temporarily unreachable.
 
+### Resolution Order
+
+`TMSProvider` (`token/core/tms.go`) resolves the public parameters of a TMS from four sources, in priority order:
+
+| # | Source | Description |
+| :--- | :--- | :--- |
+| 1 | `options` | The public parameters passed by the caller in `driver.ServiceOptions.PublicParams` (for example, the new parameters delivered by an update event). |
+| 2 | `storage` | The node's local `PublicParametersStorage`. |
+| 3 | `configuration` | The file referenced by `publicParameters.path` in the TMS configuration. |
+| 4 | `fetcher` | The `PublicParamsFetcher`, which reads the parameters from the ledger. This is the authoritative source. |
+
+For each source, the provider retrieves the parameters **and immediately tries to instantiate the token service with them**. The first source whose parameters the driver accepts wins, and its parameters become the ones the TMS runs with. A source is skipped, and the next one is given its chance, when it:
+
+- holds no public parameters, or fails to return them (storage error, missing file, …); or
+- holds public parameters the driver rejects — driver name/version skew (`invalid identifier, expecting [dlog.v1], got [dlog.v2]`), an unparsable container, an invalid curve id, or any other field-level validation failure; or
+- holds public parameters byte-identical to those a higher-priority source already tried (they are not deserialized twice).
+
+This is what lets a node recover on its own during an upgrade: when the local copy of the parameters is stale or malformed, it does not shadow the authoritative parameters on the ledger — the provider simply falls through to the fetcher. Note that source 4 is only available when the caller supplied a `PublicParamsFetcher` in the service options.
+
+### Resolution vs. update
+
+The walk above applies when a TMS is being **resolved** (`GetTokenManagerService`, `NewTokenManagerService`). It does **not** apply to `Update`, which resolves from source 1 only.
+
+`Update` carries the public parameters the TMS is to adopt — typically the new parameters just committed to the ledger. If the driver rejects them, `Update` fails and the currently cached service is left running and cached, untouched. Falling back to another source would report success while the node kept running on an older copy, after having already unloaded the service it had; and since the service options an update is built from carry no `PublicParamsFetcher`, such a fallback could only ever land on a stale local copy — the opposite of what the walk exists for.
+
+If no source produces usable public parameters, the returned error aggregates the failure of every source, each tagged with the source name, so the offending copy can be identified. The error wraps `ErrTMSNotFound` if, and only if, no source produced any parameters at all, which means the TMS has not been set up yet — as opposed to being set up with parameters this node cannot use.
+
+Note that both resolution and update hold a single provider-wide lock for the whole walk, not one lock per TMS, so a slow source — a driver deserialization or, on the resolution path, the ledger fetch — blocks lookups for every other network/channel/namespace on the node. Tracked in [#2306](https://github.com/LFDT-Panurus/panurus/issues/2306).
+
 ---
 
 ## Dynamic Updates and Synchronization

--- a/token/core/tms.go
+++ b/token/core/tms.go
@@ -110,7 +110,7 @@ func (m *TMSProvider) GetTokenManagerService(opts driver.ServiceOptions) (servic
 	}
 
 	logger.Debugf("creating new token manager service for [%s] with key [%s]", opts, key)
-	service, err = m.getTokenManagerService(opts)
+	service, err = m.getTokenManagerService(opts, m.publicParamsSources())
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (m *TMSProvider) NewTokenManagerService(opts driver.ServiceOptions) (driver
 	}
 	logger.Debugf("creating new token manager service for [%s]", opts)
 
-	service, err := m.newTMS(&opts)
+	service, err := m.newTMS(&opts, m.publicParamsSources())
 	if err != nil {
 		return nil, err
 	}
@@ -140,6 +140,8 @@ func (m *TMSProvider) NewTokenManagerService(opts driver.ServiceOptions) (driver
 
 // Update updates the public parameters for the specified TMS.
 // If the service is already cached and the public parameters are different, it unloads the old service and reloads it.
+// The TMS is rebuilt from the public parameters carried by the update and from nothing else: if the
+// driver rejects them, Update fails and the currently cached service is left untouched.
 func (m *TMSProvider) Update(opts driver.ServiceOptions) (err error) {
 	if len(opts.Network) == 0 {
 		return errors.Errorf("network not specified")
@@ -171,8 +173,9 @@ func (m *TMSProvider) Update(opts driver.ServiceOptions) (err error) {
 		logger.Debugf("service found, unload token management system for [%s:%s:%s] for key [%s] and reload it", opts.Network, opts.Channel, opts.Namespace, key)
 	}
 
-	// create the service for the new public params
-	newService, err := m.getTokenManagerService(opts)
+	// create the service for the new public params. Only the public params carried by the update
+	// are eligible: see updatePublicParamsSources.
+	newService, err := m.getTokenManagerService(opts, m.updatePublicParamsSources())
 	if err == nil {
 		// unload the old service, if set
 		if service != nil {
@@ -199,9 +202,9 @@ func (m *TMSProvider) ConfigurationFor(network, channel, namespace string) (driv
 	return m.configService.ConfigurationFor(network, channel, namespace)
 }
 
-func (m *TMSProvider) getTokenManagerService(opts driver.ServiceOptions) (service driver.TokenManagerService, err error) {
+func (m *TMSProvider) getTokenManagerService(opts driver.ServiceOptions, sources []ppSource) (service driver.TokenManagerService, err error) {
 	logger.Debugf("creating new token manager service for [%s]", opts)
-	service, err = m.newTMS(&opts)
+	service, err = m.newTMS(&opts, sources)
 	if err != nil {
 		return nil, err
 	}
@@ -216,38 +219,148 @@ func (m *TMSProvider) getTokenManagerService(opts driver.ServiceOptions) (servic
 	return service, nil
 }
 
-func (m *TMSProvider) newTMS(opts *driver.ServiceOptions) (driver.TokenManagerService, error) {
-	ppRaw, err := m.loadPublicParams(opts)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to get driver for [%s]", opts)
-	}
-	opts.PublicParams = ppRaw
-	logger.Debugf("instantiating token service for [%s]", opts)
-
-	ts, err := m.tokenDriverService.NewTokenService(driver.TMSID{Network: opts.Network, Channel: opts.Channel, Namespace: opts.Namespace}, opts.PublicParams)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to instantiate token service for [%s]", opts)
-	}
-
-	return ts, nil
+// ppSource is a named source of public parameters. newTMS walks the sources in priority
+// order, giving each one the chance to produce public parameters the driver accepts.
+type ppSource struct {
+	// name identifies the source in logs and in the aggregated error.
+	name string
+	// retrieve returns the raw public parameters held by this source.
+	retrieve func(opts *driver.ServiceOptions) ([]byte, error)
 }
 
-func (m *TMSProvider) loadPublicParams(opts *driver.ServiceOptions) ([]byte, error) {
-	// priorities:
-	// 1. opts.PublicParams
-	// 2. publicParametersStorage
-	// 3. local configuration
-	// 4. public parameters fetcher, if any
-	for _, retriever := range []func(options *driver.ServiceOptions) ([]byte, error){m.ppFromOpts, m.ppFromStorage, m.ppFromConfig, m.ppFromFetcher} {
-		if ppRaw, err := retriever(opts); err != nil {
-			logger.Warnf("failed to retrieve params for [%s]: [%s]", opts, err)
-		} else if len(ppRaw) != 0 {
-			return ppRaw, nil
-		}
+// publicParamsSources returns the public parameters sources in priority order:
+//  1. opts.PublicParams, the caller-provided public parameters;
+//  2. the local public parameters storage;
+//  3. the local configuration (publicParameters.path);
+//  4. the public parameters fetcher, if any. This is the authoritative source: it reads
+//     the public parameters from the network.
+func (m *TMSProvider) publicParamsSources() []ppSource {
+	return []ppSource{
+		{name: "options", retrieve: m.ppFromOpts},
+		{name: "storage", retrieve: m.ppFromStorage},
+		{name: "configuration", retrieve: m.ppFromConfig},
+		{name: "fetcher", retrieve: m.ppFromFetcher},
 	}
-	logger.Errorf("cannot retrieve public params for [%s]: [%s]", opts, string(debug.Stack()))
+}
 
-	return nil, errors.Join(errors.Errorf("cannot retrieve public params for [%s]", opts), ErrTMSNotFound)
+// updatePublicParamsSources returns the only public parameters source an update may resolve
+// from: the public parameters the update itself carries.
+//
+// Update means "adopt exactly these public parameters". Letting it fall back to another source
+// would make it report success while the TMS keeps running on a different - necessarily older -
+// copy, after having already unloaded the previous service. On the update path the fallback
+// cannot even reach the ledger, because the options an update is built from carry no
+// PublicParamsFetcher, so it could only ever land on a stale local copy: the opposite of what
+// the walk is for. A rejected update must therefore fail, and loudly.
+func (m *TMSProvider) updatePublicParamsSources() []ppSource {
+	return []ppSource{
+		{name: "options", retrieve: m.ppFromOpts},
+	}
+}
+
+// newTMS instantiates the token manager service identified by the passed options, resolving its
+// public parameters from the passed sources.
+//
+// It walks the sources in the given order and, for each of them, retrieves the public parameters
+// and immediately tries to instantiate the token service with them. The first source whose
+// public parameters the driver accepts wins. A source that yields no public parameters, that
+// fails to yield them, or that yields public parameters the driver rejects (driver name/version
+// skew, unparsable container, invalid field, and so on) does not stop the walk: the next source
+// gets its chance. This way a stale or malformed local copy does not shadow the authoritative
+// public parameters fetched from the network.
+//
+// Callers that resolve a TMS pass publicParamsSources. Update passes
+// updatePublicParamsSources, because adopting a different copy than the one it carries would be
+// a silent failure rather than a recovery.
+//
+// On failure, the returned error aggregates the failure of every source, so that the offending
+// source can be identified. It wraps ErrTMSNotFound if, and only if, no source produced any
+// public parameters at all, which signals that the TMS has not been set up yet.
+func (m *TMSProvider) newTMS(opts *driver.ServiceOptions, sources []ppSource) (driver.TokenManagerService, error) {
+	tmsID := driver.TMSID{Network: opts.Network, Channel: opts.Channel, Namespace: opts.Namespace}
+	// public parameters already tried, indexed by digest, to not pay the driver deserialization
+	// cost twice when two sources hold the very same public parameters.
+	tried := make(map[[sha256.Size]byte]string, len(sources))
+	// produced counts the sources that held public parameters, duplicates included. It is what
+	// separates "the TMS is not set up yet" from "the TMS is set up with public parameters this
+	// node cannot use", and it is counted rather than inferred from the errors collected below.
+	produced := 0
+	var retrievalErrs, instantiationErrs []error
+
+	for _, source := range sources {
+		ppRaw, err := source.retrieve(opts)
+		switch {
+		case err != nil:
+			logger.Warnf("failed to retrieve public params for [%s] from [%s]: [%s]", opts, source.name, err)
+			retrievalErrs = append(retrievalErrs, errors.WithMessagef(err, "cannot retrieve public params from [%s]", source.name))
+
+			continue
+		// defensive: every source above reports emptiness as an error, so this branch guards
+		// the ppSource contract for sources added later rather than a reachable state today.
+		case len(ppRaw) == 0:
+			logger.Debugf("no public params for [%s] from [%s]", opts, source.name)
+			retrievalErrs = append(retrievalErrs, errors.Errorf("cannot retrieve public params from [%s]: no public params returned", source.name))
+
+			continue
+		}
+
+		produced++
+
+		digest := sha256.Sum256(ppRaw)
+		if previous, ok := tried[digest]; ok {
+			logger.Debugf("public params for [%s] from [%s] are identical to those from [%s], skip them", opts, source.name, previous)
+			// record the skip: this source was walked, and the aggregated error must say so.
+			instantiationErrs = append(instantiationErrs, errors.Errorf("public params from [%s] are identical to those from [%s], already tried", source.name, previous))
+
+			continue
+		}
+		tried[digest] = source.name
+
+		logger.Debugf("instantiating token service for [%s] with the public params from [%s]", opts, source.name)
+		ts, err := m.newTokenService(tmsID, ppRaw)
+		if err != nil {
+			logger.Warnf("failed to instantiate token service for [%s] with the public params from [%s], try next source: [%s]", opts, source.name, err)
+			instantiationErrs = append(instantiationErrs, errors.WithMessagef(err, "cannot instantiate token service with the public params from [%s]", source.name))
+
+			continue
+		}
+
+		if len(instantiationErrs) != 0 {
+			logger.Infof("instantiated token service for [%s] with the public params from [%s] after [%d] unusable public params", opts, source.name, len(instantiationErrs))
+		}
+
+		return ts, nil
+	}
+
+	if produced == 0 {
+		// no source produced any public parameters: the TMS does not exist, yet.
+		logger.Errorf("cannot retrieve public params for [%s]: [%s]", opts, string(debug.Stack()))
+
+		return nil, errors.Join(append([]error{errors.Errorf("cannot retrieve public params for [%s]", opts), ErrTMSNotFound}, retrievalErrs...)...)
+	}
+
+	// at least one source produced public parameters, but none of them was usable.
+	errs := append([]error{errors.Errorf("failed to instantiate token service for [%s]", opts)}, instantiationErrs...)
+
+	return nil, errors.Join(append(errs, retrievalErrs...)...)
+}
+
+// newTokenService instantiates the token service for the passed public parameters, converting
+// a panic raised while deserializing them into an error. The public parameters are attacker
+// controlled (they come from the network) or simply stale (they come from a local copy written
+// by an older version), and a driver that panics on them must not take down the resolution of
+// the remaining public parameters sources with it.
+func (m *TMSProvider) newTokenService(tmsID driver.TMSID, ppRaw []byte) (ts driver.TokenManagerService, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			// the walk swallows this error and moves on, so the stack is logged here or it is
+			// lost: nothing downstream can say where a driver panicked.
+			logger.Errorf("panic while instantiating token service for [%s] with public params of [%d] bytes: [%v]\n%s", tmsID, len(ppRaw), r, string(debug.Stack()))
+			ts, err = nil, errors.Errorf("caught panic while instantiating token service: [%v]", r)
+		}
+	}()
+
+	return m.tokenDriverService.NewTokenService(tmsID, ppRaw)
 }
 
 func (m *TMSProvider) ppFromOpts(opts *driver.ServiceOptions) ([]byte, error) {
@@ -259,12 +372,15 @@ func (m *TMSProvider) ppFromOpts(opts *driver.ServiceOptions) ([]byte, error) {
 }
 
 func (m *TMSProvider) ppFromStorage(opts *driver.ServiceOptions) ([]byte, error) {
+	if m.publicParametersStorage == nil {
+		return nil, errors.Errorf("no publicParametersStorage available")
+	}
 	ppRaw, err := m.publicParametersStorage.PublicParams(context.Background(), opts.Network, opts.Channel, opts.Namespace)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to load public params from the publicParametersStorage")
 	}
 	if len(ppRaw) == 0 {
-		return nil, errors.Errorf("no public parames found in publicParametersStorage")
+		return nil, errors.Errorf("no public params found in publicParametersStorage")
 	}
 
 	return ppRaw, nil
@@ -273,7 +389,10 @@ func (m *TMSProvider) ppFromStorage(opts *driver.ServiceOptions) ([]byte, error)
 func (m *TMSProvider) ppFromConfig(opts *driver.ServiceOptions) ([]byte, error) {
 	tmsConfig, err := m.configService.ConfigurationFor(opts.Network, opts.Channel, opts.Namespace)
 	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to identify driver from the configuration of [%s], loading driver from public parameters failed too [%s]", opts, err)
+		return nil, errors.WithMessagef(err, "failed to load the configuration of [%s]", opts)
+	}
+	if tmsConfig == nil {
+		return nil, errors.Errorf("no configuration found for [%s]", opts)
 	}
 	cPP := &PublicParameters{}
 	if err := tmsConfig.UnmarshalKey("publicParameters", cPP); err != nil {
@@ -299,14 +418,13 @@ func (m *TMSProvider) ppFromFetcher(opts *driver.ServiceOptions) ([]byte, error)
 			return nil, errors.WithMessagef(err, "failed fetching public parameters")
 		}
 		if len(ppRaw) == 0 {
-			return nil, errors.Errorf("no public parames found in publicParametersStorage")
+			return nil, errors.Errorf("no public params fetched")
 		}
-		opts.PublicParams = ppRaw
 
 		return ppRaw, nil
 	}
 
-	return nil, errors.Errorf("no public params fetched available")
+	return nil, errors.Errorf("no PublicParamsFetcher configured")
 }
 
 func tmsKey(opts driver.ServiceOptions) string {

--- a/token/core/tms_test.go
+++ b/token/core/tms_test.go
@@ -12,6 +12,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/LFDT-Panurus/panurus/token/core"
@@ -293,4 +295,553 @@ func TestTMSProvider(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, core.ErrTMSNotFound)
 	})
+}
+
+// ppFallbackContext holds the collaborators of a TMSProvider under test, wired so that every
+// public parameters source can be driven independently.
+type ppFallbackContext struct {
+	provider     *core.TMSProvider
+	config       *mock.ConfigService
+	tmsConfig    *drivermock.Configuration
+	storage      *mock.PublicParametersStorage
+	driver       *drivermock.Driver
+	fetcher      *drivermock.PublicParamsFetcher
+	tms          *drivermock.TokenManagerService
+	tempDir      string
+	configPPPath string
+}
+
+// newPPFallbackContext returns a TMSProvider whose driver accepts the public parameters tagged
+// [ok], rejects those tagged [malformed] the way a driver rejects public parameters it cannot
+// deserialize, and panics on those tagged [panic]. By default no source holds any public
+// parameters: each test case installs the ones it needs.
+func newPPFallbackContext(t *testing.T) *ppFallbackContext {
+	t.Helper()
+
+	c := &ppFallbackContext{
+		config:    &mock.ConfigService{},
+		storage:   &mock.PublicParametersStorage{},
+		driver:    &drivermock.Driver{},
+		fetcher:   &drivermock.PublicParamsFetcher{},
+		tms:       &drivermock.TokenManagerService{},
+		tempDir:   t.TempDir(),
+		tmsConfig: &drivermock.Configuration{},
+	}
+	c.configPPPath = filepath.Join(c.tempDir, "config-pp.bin")
+
+	c.driver.PublicParametersFromBytesStub = func(raw []byte) (driver.PublicParameters, error) {
+		serialized := &pp.PublicParameters{}
+		require.NoError(t, json.Unmarshal(raw, serialized))
+		switch tag := string(serialized.Raw); {
+		case strings.HasPrefix(tag, "malformed"):
+			return nil, errors.New("failed to deserialize public parameters")
+		case strings.HasPrefix(tag, "panic"):
+			panic("invalid curve id")
+		}
+
+		publicParams := &drivermock.PublicParameters{}
+		publicParams.TokenDriverNameReturns("test")
+		publicParams.TokenDriverVersionReturns(1)
+
+		return publicParams, nil
+	}
+	c.driver.NewTokenServiceReturns(c.tms, nil)
+
+	// no source holds any public parameters, unless a test case says otherwise
+	c.storage.PublicParamsReturns(nil, nil)
+	c.config.ConfigurationForReturns(nil, errors.New("no configuration"))
+	c.fetcher.FetchReturns(nil, nil)
+
+	c.provider = core.NewTMSProvider(c.config, c.storage, core.NewTokenDriverService([]core.NamedFactory[driver.Driver]{
+		{Name: core.TokenDriverIdentifier("test.v1"), Driver: c.driver},
+	}))
+
+	return c
+}
+
+// pubParams returns public parameters for the registered driver, tagged to drive the stubbed
+// driver behaviour ("ok", "malformed", "panic") and to distinguish one blob from another.
+func (c *ppFallbackContext) pubParams(t *testing.T, tag string) []byte {
+	t.Helper()
+	raw, err := json.Marshal(&pp.PublicParameters{Identifier: "test.v1", Raw: []byte(tag)})
+	require.NoError(t, err)
+
+	return raw
+}
+
+// unknownDriverPubParams returns public parameters whose driver identifier is not registered,
+// which is what driver name/version skew looks like to the token driver service.
+func (c *ppFallbackContext) unknownDriverPubParams(t *testing.T) []byte {
+	t.Helper()
+	raw, err := json.Marshal(&pp.PublicParameters{Identifier: "test.v2"})
+	require.NoError(t, err)
+
+	return raw
+}
+
+// setConfigPubParams makes the local configuration point at a file holding the passed public
+// parameters.
+func (c *ppFallbackContext) setConfigPubParams(t *testing.T, ppRaw []byte) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(c.configPPPath, ppRaw, 0600))
+	c.tmsConfig.UnmarshalKeyStub = func(key string, rawVal any) error {
+		if key == "publicParameters" {
+			rawVal.(*core.PublicParameters).Path = c.configPPPath
+		}
+
+		return nil
+	}
+	c.config.ConfigurationForReturns(c.tmsConfig, nil)
+}
+
+// newPPFallbackOpts returns the service options for the TMS under test.
+func newPPFallbackOpts(c *ppFallbackContext, publicParams []byte) driver.ServiceOptions {
+	return driver.ServiceOptions{
+		Network:             "n1",
+		Channel:             "c1",
+		Namespace:           "ns1",
+		PublicParams:        publicParams,
+		PublicParamsFetcher: c.fetcher,
+	}
+}
+
+// TestTMSProviderPublicParamsFallback verifies that the provider does not commit to the first
+// retrievable public parameters, but to the first ones the driver accepts: a source that yields
+// unusable public parameters must not shadow the lower-priority sources, and in particular not
+// the authoritative fetcher. See https://github.com/LFDT-Panurus/panurus/issues/2281.
+func TestTMSProviderPublicParamsFallback(t *testing.T) {
+	// Test case: the local storage holds public parameters the driver cannot deserialize; the
+	// public parameters fetched from the network are used instead.
+	t.Run("unusable storage public params fall back to the fetcher", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		c.storage.PublicParamsReturns(c.pubParams(t, "malformed"), nil)
+		fetched := c.pubParams(t, "ok")
+		c.fetcher.FetchReturns(fetched, nil)
+
+		tms, err := c.provider.NewTokenManagerService(newPPFallbackOpts(c, nil))
+		require.NoError(t, err)
+		assert.Equal(t, c.tms, tms)
+		assert.Equal(t, 1, c.fetcher.FetchCallCount())
+		require.Equal(t, 1, c.driver.NewTokenServiceCallCount())
+		_, usedPP := c.driver.NewTokenServiceArgsForCall(0)
+		assert.Equal(t, fetched, usedPP)
+	})
+
+	// Test case: the caller-provided public parameters carry a driver identifier that is not
+	// registered (driver name/version skew); the local storage takes over.
+	t.Run("unusable options public params fall back to the storage", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		stored := c.pubParams(t, "ok")
+		c.storage.PublicParamsReturns(stored, nil)
+
+		tms, err := c.provider.NewTokenManagerService(newPPFallbackOpts(c, c.unknownDriverPubParams(t)))
+		require.NoError(t, err)
+		assert.Equal(t, c.tms, tms)
+		assert.Equal(t, 0, c.fetcher.FetchCallCount())
+		require.Equal(t, 1, c.driver.NewTokenServiceCallCount())
+		_, usedPP := c.driver.NewTokenServiceArgsForCall(0)
+		assert.Equal(t, stored, usedPP)
+	})
+
+	// Test case: the public parameters on the local filesystem are stale; the public parameters
+	// fetched from the network are used instead.
+	t.Run("unusable configuration public params fall back to the fetcher", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		c.setConfigPubParams(t, c.unknownDriverPubParams(t))
+		fetched := c.pubParams(t, "ok")
+		c.fetcher.FetchReturns(fetched, nil)
+
+		tms, err := c.provider.NewTokenManagerService(newPPFallbackOpts(c, nil))
+		require.NoError(t, err)
+		assert.Equal(t, c.tms, tms)
+		require.Equal(t, 1, c.driver.NewTokenServiceCallCount())
+		_, usedPP := c.driver.NewTokenServiceArgsForCall(0)
+		assert.Equal(t, fetched, usedPP)
+	})
+
+	// Test case: a driver that panics while deserializing the public parameters of one source
+	// does not abort the walk over the remaining sources.
+	t.Run("panic on one source falls through to the next", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		c.storage.PublicParamsReturns(c.pubParams(t, "panic"), nil)
+		fetched := c.pubParams(t, "ok")
+		c.fetcher.FetchReturns(fetched, nil)
+
+		tms, err := c.provider.NewTokenManagerService(newPPFallbackOpts(c, nil))
+		require.NoError(t, err)
+		assert.Equal(t, c.tms, tms)
+		require.Equal(t, 1, c.driver.NewTokenServiceCallCount())
+		_, usedPP := c.driver.NewTokenServiceArgsForCall(0)
+		assert.Equal(t, fetched, usedPP)
+	})
+
+	// Test case: public parameters shared by two sources are only tried once.
+	t.Run("identical public params are tried once", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		stale := c.pubParams(t, "malformed")
+		c.storage.PublicParamsReturns(stale, nil)
+		c.setConfigPubParams(t, stale)
+		c.fetcher.FetchReturns(c.pubParams(t, "ok"), nil)
+
+		_, err := c.provider.NewTokenManagerService(newPPFallbackOpts(c, nil))
+		require.NoError(t, err)
+		// once for the stale public params shared by storage and configuration, once for the
+		// fetched ones
+		assert.Equal(t, 2, c.driver.PublicParametersFromBytesCallCount())
+	})
+
+	// Test case: every source holds the same unusable public parameters. They are deserialized
+	// once, and the error still accounts for every source that was walked, so that a duplicated
+	// stale copy is not silently invisible.
+	t.Run("identical unusable public params are all reported", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		stale := c.pubParams(t, "malformed")
+		c.storage.PublicParamsReturns(stale, nil)
+		c.setConfigPubParams(t, stale)
+		c.fetcher.FetchReturns(stale, nil)
+
+		_, err := c.provider.NewTokenManagerService(newPPFallbackOpts(c, stale))
+		require.Error(t, err)
+		require.NotErrorIs(t, err, core.ErrTMSNotFound)
+		assert.Equal(t, 1, c.driver.PublicParametersFromBytesCallCount())
+		assert.Contains(t, err.Error(), "cannot instantiate token service with the public params from [options]")
+		for _, source := range []string{"storage", "configuration", "fetcher"} {
+			assert.Contains(t, err.Error(), "public params from ["+source+"] are identical to those from [options], already tried")
+		}
+	})
+
+	// Test case: every source holds unusable public parameters. The error reports each source,
+	// and it is not an ErrTMSNotFound: the TMS exists, its public parameters are just unusable.
+	t.Run("all sources unusable", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		c.storage.PublicParamsReturns(c.pubParams(t, "malformed-storage"), nil)
+		c.setConfigPubParams(t, c.unknownDriverPubParams(t))
+		c.fetcher.FetchReturns(c.pubParams(t, "panic-fetcher"), nil)
+
+		_, err := c.provider.NewTokenManagerService(newPPFallbackOpts(c, c.pubParams(t, "malformed-options")))
+		require.Error(t, err)
+		require.NotErrorIs(t, err, core.ErrTMSNotFound)
+		assert.Contains(t, err.Error(), "failed to instantiate token service")
+		for _, source := range []string{"options", "storage", "configuration", "fetcher"} {
+			assert.Contains(t, err.Error(), "from ["+source+"]", "error must report source [%s]", source)
+		}
+	})
+
+	// Test case: no source holds any public parameters. The TMS has not been set up yet, so the
+	// error wraps ErrTMSNotFound and reports why each source came up empty.
+	t.Run("no source holds public params", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		c.storage.PublicParamsReturns(nil, errors.New("storage error"))
+
+		_, err := c.provider.NewTokenManagerService(newPPFallbackOpts(c, nil))
+		require.Error(t, err)
+		require.ErrorIs(t, err, core.ErrTMSNotFound)
+		assert.Contains(t, err.Error(), "cannot retrieve public params")
+		assert.Contains(t, err.Error(), "storage error")
+		for _, source := range []string{"options", "storage", "configuration", "fetcher"} {
+			assert.Contains(t, err.Error(), "from ["+source+"]", "error must report source [%s]", source)
+		}
+		assert.Equal(t, 0, c.driver.NewTokenServiceCallCount())
+	})
+
+	// Test case: a nil configuration returned with no error is reported, not dereferenced.
+	t.Run("nil configuration does not panic", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		c.config.ConfigurationForReturns(nil, nil)
+		fetched := c.pubParams(t, "ok")
+		c.fetcher.FetchReturns(fetched, nil)
+
+		tms, err := c.provider.NewTokenManagerService(newPPFallbackOpts(c, nil))
+		require.NoError(t, err)
+		assert.Equal(t, c.tms, tms)
+	})
+
+	// Test case: the successful public parameters are the ones the service is created with, and
+	// a failed resolution is not cached.
+	t.Run("failed resolution is not cached", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		c.storage.PublicParamsReturns(c.pubParams(t, "malformed"), nil)
+
+		opts := newPPFallbackOpts(c, nil)
+		_, err := c.provider.GetTokenManagerService(opts)
+		require.Error(t, err)
+
+		// the network now serves usable public parameters: the next call must succeed
+		c.fetcher.FetchReturns(c.pubParams(t, "ok"), nil)
+		tms, err := c.provider.GetTokenManagerService(opts)
+		require.NoError(t, err)
+		assert.Equal(t, c.tms, tms)
+	})
+}
+
+// setSource installs public parameters tagged tag into the named source, or makes the source
+// come up empty when tag is "". The tag doubles as the blob's identity, so a test can tell
+// which source's public parameters won.
+func (c *ppFallbackContext) setSource(t *testing.T, source, tag string) []byte {
+	t.Helper()
+
+	var ppRaw []byte
+	switch tag {
+	case "":
+	case "unknown":
+		ppRaw = c.unknownDriverPubParams(t)
+	default:
+		ppRaw = c.pubParams(t, tag)
+	}
+
+	switch source {
+	case "storage":
+		c.storage.PublicParamsReturns(ppRaw, nil)
+	case "configuration":
+		if ppRaw != nil {
+			c.setConfigPubParams(t, ppRaw)
+		}
+	case "fetcher":
+		c.fetcher.FetchReturns(ppRaw, nil)
+	default:
+		t.Fatalf("unknown source [%s]", source)
+	}
+
+	return ppRaw
+}
+
+// TestTMSProviderPublicParamsPriority walks the whole priority matrix: for every combination of
+// usable and unusable sources, the public parameters the token service is instantiated with must
+// be those of the highest-priority *usable* source.
+func TestTMSProviderPublicParamsPriority(t *testing.T) {
+	// "" = source holds nothing, "unknown"/"malformed…" = unusable, "ok…" = usable
+	for _, tc := range []struct {
+		name                              string
+		options, storage, config, fetcher string
+		winner                            string
+	}{
+		{name: "options win", options: "ok-options", storage: "ok-storage", config: "ok-config", fetcher: "ok-fetcher", winner: "ok-options"},
+		{name: "storage wins when options are unusable", options: "unknown", storage: "ok-storage", config: "ok-config", fetcher: "ok-fetcher", winner: "ok-storage"},
+		{name: "storage wins when options are absent", storage: "ok-storage", config: "ok-config", fetcher: "ok-fetcher", winner: "ok-storage"},
+		{name: "configuration wins when options and storage are unusable", options: "unknown", storage: "malformed-storage", config: "ok-config", fetcher: "ok-fetcher", winner: "ok-config"},
+		{name: "fetcher wins when every local source is unusable", options: "unknown", storage: "malformed-storage", config: "unknown", fetcher: "ok-fetcher", winner: "ok-fetcher"},
+		{name: "fetcher wins when every local source is empty", fetcher: "ok-fetcher", winner: "ok-fetcher"},
+		{name: "last source standing is used", options: "malformed-options", storage: "", config: "", fetcher: "ok-fetcher", winner: "ok-fetcher"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newPPFallbackContext(t)
+			var optionsPP []byte
+			if tc.options != "" {
+				if tc.options == "unknown" {
+					optionsPP = c.unknownDriverPubParams(t)
+				} else {
+					optionsPP = c.pubParams(t, tc.options)
+				}
+			}
+			c.setSource(t, "storage", tc.storage)
+			c.setSource(t, "configuration", tc.config)
+			c.setSource(t, "fetcher", tc.fetcher)
+
+			tms, err := c.provider.NewTokenManagerService(newPPFallbackOpts(c, optionsPP))
+			require.NoError(t, err)
+			assert.Equal(t, c.tms, tms)
+
+			// the token service must be built with the winning source's public parameters, and
+			// the walk must stop there: no later source is instantiated
+			require.Equal(t, 1, c.driver.NewTokenServiceCallCount())
+			_, usedPP := c.driver.NewTokenServiceArgsForCall(0)
+			assert.Equal(t, c.pubParams(t, tc.winner), usedPP)
+
+			// the network is only queried when no local source could serve the TMS
+			if tc.winner == "ok-fetcher" {
+				assert.Equal(t, 1, c.fetcher.FetchCallCount())
+			} else {
+				assert.Equal(t, 0, c.fetcher.FetchCallCount(), "the fetcher must not be queried when a local source wins")
+			}
+		})
+	}
+}
+
+// TestTMSProviderPublicParamsSourceErrors verifies that each source explains itself in the
+// aggregated error, so that logs identify the source that came up empty or unusable.
+func TestTMSProviderPublicParamsSourceErrors(t *testing.T) {
+	// Test case: a source that returns empty bytes without an error is reported as empty, and
+	// does not masquerade as a usable source.
+	t.Run("empty sources are reported", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		c.storage.PublicParamsReturns([]byte{}, nil)
+		c.fetcher.FetchReturns([]byte{}, nil)
+
+		_, err := c.provider.NewTokenManagerService(newPPFallbackOpts(c, nil))
+		require.Error(t, err)
+		require.ErrorIs(t, err, core.ErrTMSNotFound)
+		assert.Contains(t, err.Error(), "no public params found in publicParametersStorage")
+		assert.Contains(t, err.Error(), "no public params fetched")
+		assert.Equal(t, 0, c.driver.NewTokenServiceCallCount())
+	})
+
+	// Test case: input validation is reported without touching any source, and is not an
+	// ErrTMSNotFound.
+	t.Run("input validation", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+
+		_, err := c.provider.NewTokenManagerService(driver.ServiceOptions{Namespace: "ns1"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "network not specified")
+		require.NotErrorIs(t, err, core.ErrTMSNotFound)
+
+		_, err = c.provider.NewTokenManagerService(driver.ServiceOptions{Network: "n1"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "namespace not specified")
+		require.NotErrorIs(t, err, core.ErrTMSNotFound)
+
+		assert.Equal(t, 0, c.storage.PublicParamsCallCount())
+		assert.Equal(t, 0, c.fetcher.FetchCallCount())
+	})
+
+	// Test case: a missing PublicParamsFetcher names the missing collaborator instead of
+	// reading like an empty fetch.
+	t.Run("missing fetcher is distinguishable from an empty fetch", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+
+		_, err := c.provider.NewTokenManagerService(driver.ServiceOptions{Network: "n1", Namespace: "ns1"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no PublicParamsFetcher configured")
+	})
+
+	// Test case: a nil publicParametersStorage is reported rather than dereferenced, and the
+	// walk carries on to the remaining sources.
+	t.Run("nil storage is reported and does not stop the walk", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		provider := core.NewTMSProvider(c.config, nil, core.NewTokenDriverService([]core.NamedFactory[driver.Driver]{
+			{Name: core.TokenDriverIdentifier("test.v1"), Driver: c.driver},
+		}))
+		fetched := c.pubParams(t, "ok")
+		c.fetcher.FetchReturns(fetched, nil)
+
+		tms, err := provider.NewTokenManagerService(newPPFallbackOpts(c, nil))
+		require.NoError(t, err)
+		assert.Equal(t, c.tms, tms)
+		require.Equal(t, 1, c.driver.NewTokenServiceCallCount())
+		_, usedPP := c.driver.NewTokenServiceArgsForCall(0)
+		assert.Equal(t, fetched, usedPP)
+	})
+
+	// Test case: a nil publicParametersStorage with no other source reports itself.
+	t.Run("nil storage reports itself", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		provider := core.NewTMSProvider(c.config, nil, core.NewTokenDriverService([]core.NamedFactory[driver.Driver]{
+			{Name: core.TokenDriverIdentifier("test.v1"), Driver: c.driver},
+		}))
+
+		_, err := provider.NewTokenManagerService(driver.ServiceOptions{Network: "n1", Namespace: "ns1"})
+		require.Error(t, err)
+		require.ErrorIs(t, err, core.ErrTMSNotFound)
+		assert.Contains(t, err.Error(), "no publicParametersStorage available")
+	})
+
+	// Test case: the configuration source reports its cause once. It used to embed the wrapped
+	// error in its own message and then wrap it, rendering the cause twice.
+	t.Run("configuration error is rendered once", func(t *testing.T) {
+		c := newPPFallbackContext(t)
+		c.config.ConfigurationForReturns(nil, errors.New("some-unique-config-failure"))
+
+		_, err := c.provider.NewTokenManagerService(newPPFallbackOpts(c, nil))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load the configuration of")
+		assert.Equal(t, 1, strings.Count(err.Error(), "some-unique-config-failure"),
+			"the configuration failure must be rendered exactly once")
+	})
+}
+
+// TestTMSProviderConcurrentGet verifies that concurrent callers racing on the same TMS share a
+// single instance: the walk runs once, so the public parameters are deserialized once and the
+// network is queried once, no matter how many callers arrive together.
+func TestTMSProviderConcurrentGet(t *testing.T) {
+	c := newPPFallbackContext(t)
+	c.fetcher.FetchReturns(c.pubParams(t, "ok"), nil)
+
+	const callers = 32
+	var wg sync.WaitGroup
+	results := make([]driver.TokenManagerService, callers)
+	errs := make([]error, callers)
+	start := make(chan struct{})
+	wg.Add(callers)
+	for i := range callers {
+		go func() {
+			defer wg.Done()
+			<-start
+			results[i], errs[i] = c.provider.GetTokenManagerService(newPPFallbackOpts(c, nil))
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i := range callers {
+		require.NoError(t, errs[i])
+		assert.Equal(t, c.tms, results[i])
+	}
+	assert.Equal(t, 1, c.driver.NewTokenServiceCallCount(), "the TMS must be instantiated once")
+	assert.Equal(t, 1, c.fetcher.FetchCallCount(), "the network must be queried once")
+}
+
+// TestTMSProviderUpdateRejectsUnusablePublicParams pins the boundary between resolving a TMS and
+// updating one: resolution may fall back to another source, an update may not. An update carries
+// the public parameters the TMS is to adopt, so when the driver rejects them the update must
+// fail. Falling back would report success while the node kept running on an older copy, having
+// already unloaded the service it had; and because the options an update is built from carry no
+// fetcher, that fallback could only ever land on a stale local copy - the opposite of what the
+// walk exists for.
+func TestTMSProviderUpdateRejectsUnusablePublicParams(t *testing.T) {
+	c := newPPFallbackContext(t)
+	// a perfectly usable local copy is available: resolution would fall back to it, an update
+	// must not.
+	c.storage.PublicParamsReturns(c.pubParams(t, "ok-storage"), nil)
+
+	err := c.provider.Update(newPPFallbackOpts(c, c.unknownDriverPubParams(t)))
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, core.ErrTMSNotFound,
+		"the public params were delivered, they were just not usable")
+	assert.Contains(t, err.Error(), "[options]", "the error must name the source that failed")
+	assert.Equal(t, 0, c.storage.PublicParamsCallCount(), "an update must not read the local storage")
+	assert.Equal(t, 0, c.fetcher.FetchCallCount(), "an update must not query the network")
+	assert.Equal(t, 0, c.driver.NewTokenServiceCallCount(),
+		"no service may be built from public params the driver rejects")
+}
+
+// TestTMSProviderUpdateKeepsTheCachedServiceOnFailure verifies that a rejected update is not
+// destructive: the service the node is running is neither unloaded nor evicted, so a single bad
+// update event cannot take a working TMS down.
+func TestTMSProviderUpdateKeepsTheCachedServiceOnFailure(t *testing.T) {
+	c := newPPFallbackContext(t)
+	running := c.pubParams(t, "ok-running")
+	runningDigest := sha256.Sum256(running)
+	ppm := &drivermock.PublicParamsManager{}
+	ppm.PublicParamsHashReturns(runningDigest[:])
+	c.tms.PublicParamsManagerReturns(ppm)
+
+	tms, err := c.provider.GetTokenManagerService(newPPFallbackOpts(c, running))
+	require.NoError(t, err)
+	require.Equal(t, c.tms, tms)
+	require.Equal(t, 1, c.driver.NewTokenServiceCallCount())
+
+	require.Error(t, c.provider.Update(newPPFallbackOpts(c, c.unknownDriverPubParams(t))))
+
+	assert.Equal(t, 0, c.tms.DoneCallCount(), "the running service must not be unloaded")
+	again, err := c.provider.GetTokenManagerService(newPPFallbackOpts(c, running))
+	require.NoError(t, err)
+	assert.Equal(t, tms, again, "the cached service must still be the one served")
+	assert.Equal(t, 1, c.driver.NewTokenServiceCallCount(), "the cached service must not be rebuilt")
+}
+
+// TestTMSProviderConfigurationFor verifies that the configuration of a TMS can be read without
+// instantiating it.
+func TestTMSProviderConfigurationFor(t *testing.T) {
+	c := newPPFallbackContext(t)
+	c.config.ConfigurationForReturns(c.tmsConfig, nil)
+
+	config, err := c.provider.ConfigurationFor("n1", "c1", "ns1")
+	require.NoError(t, err)
+	assert.Equal(t, c.tmsConfig, config)
+	assert.Equal(t, 0, c.driver.NewTokenServiceCallCount(), "reading the configuration must not instantiate the TMS")
+
+	c.config.ConfigurationForReturns(nil, errors.New("no configuration"))
+	_, err = c.provider.ConfigurationFor("n1", "c1", "ns1")
+	require.Error(t, err)
 }


### PR DESCRIPTION
Fixes #2281

## Problem

**Old behaviour — stops at the first source that returns bytes, not at the first usable one:**

```text
1. Try options       -> got bytes -> pass to driver -> driver rejects (wrong version)
                                                      |
                                                      v
                                                 STOP. Return error.
                                                 Storage / config / ledger never tried.
```

`newTMS` (`token/core/tms.go`) resolved the public parameters and instantiated the token service as two independent steps: `loadPublicParams` walked the four sources (caller options -> local storage -> local configuration -> network fetcher) and returned the bytes of the first one that had *any*, and a single `NewTokenService` call then decided pass or fail for the whole TMS.

So the walk moved on only when a source returned *no bytes* — never when a source returned bytes the driver **rejects** (driver name/version skew such as `invalid identifier, expecting [dlog.v1], got [dlog.v2]`, an unparsable container, an out-of-range curve id, ...). A retrievable but unusable copy permanently shadowed every lower-priority source, including the authoritative one on the ledger.

Result: a stale or corrupted local copy permanently blocks the authoritative copy on the ledger. During a public parameters upgrade — where the on-chain parameters are updated before the nodes are — the affected TMS cannot be instantiated at all, and cannot recover without manual configuration or database intervention.

Diagnosis was equally hard: only one source ever reached the driver, and the retrieval failures of the earlier ones were `Warnf`'d and dropped, so nothing identified which source supplied the offending bytes.

## Fix

**New behaviour — retrieve and try each source in order, first accepted wins:**

```text
1. Try options       -> got bytes -> driver rejects  -> skip, try next
2. Try storage       -> got bytes -> driver rejects  -> skip, try next
3. Try config file   -> got bytes -> driver rejects  -> skip, try next
4. Try ledger        -> got bytes -> driver ACCEPTS  -> use these, done

If all 4 produced bytes, none usable  -> error "failed to instantiate token service"
                                         (deliberately NOT ErrTMSNotFound)
If no source produced any bytes       -> ErrTMSNotFound ("TMS not set up yet")
```

For each source, `newTMS` retrieves the public parameters **and immediately tries to instantiate the token service with them**, inside the loop. The first source the driver accepts wins. A source that yields nothing, fails to yield, or yields public parameters the driver rejects falls through to the next one. `loadPublicParams` is gone.

- **Named sources** (`ppSource{name, retrieve}`: `options`, `storage`, `configuration`, `fetcher`) so every failure is attributable; the returned error aggregates each source's failure, tagged with the source name.
- **`ErrTMSNotFound` semantics preserved** — returned if and only if *no* source produced any bytes ("TMS not set up yet"), never when a source produced unusable bytes. It is now decided by an explicit count of the sources that produced bytes. The callers that branch on it (`token/services/network/fabric/endorsement/fsc`) are unaffected.
- **No duplicate work**: public parameters byte-identical to a blob a higher-priority source already tried are not deserialized twice, and the fetcher is still never called when a higher-priority source succeeds.
- **`newTokenService`** converts a panic raised while deserializing stale or attacker-controlled public parameters into an error, and logs the stack at the recover site. Without it, one panicking blob would still shadow the authoritative public parameters — the same failure mode.
- Walking every source reaches two paths a short-circuiting source used to hide: `ppFromConfig` dereferenced a `nil` `driver.Configuration` returned with a `nil` error (the pre-existing test even carried a "To avoid panic in ppFromConfig" comment), and `ppFromStorage` a nil storage. Both are now reported as errors.

## Bonus fix (commit 2) — the `Update` path

> **This is not `main`'s behaviour — the two are not the same.** On `main`, `Update` always won on source 1: `options` is first in the priority order and an update always carries public parameters, so `main` never consulted storage on this path, never fell back, and was never destructive (`service.Done()` sits behind `if err == nil`). The fallback described below was **introduced by commit 1 of this PR**, which routed `Update` through the new walk. Commit 2 removes it. It is a regression caught in review, not a pre-existing bug.

**After commit 1:** `Update(newPP)` -> driver rejects newPP -> falls through to local storage -> builds a service from an older copy -> **reports success**, having already unloaded the service that was running. Reached from the ledger setup listener (`token/services/network/fabric/network.go`), that turned a node which merely needed a binary upgrade into a node silently running on superseded public parameters, with `ManagementServiceProvider.Update` also shutting down the selector manager and clearing its cache on the way. On the update path the fallback cannot even reach the ledger, because the service options an update is built from carry no `PublicParamsFetcher` — so it could only ever land on a stale local copy, the opposite of what the walk is for.

**After commit 2:** `Update(newPP)` -> driver rejects newPP -> **fails, and leaves the running service untouched.** `Update` resolves from source 1 alone (`updatePublicParamsSources`) and accepts only what it was given. No fallback.

Also in commit 2:

- **the panic's stack is kept.** `newTokenService` turns a panic into an error and the walk moves on, so the stack was lost and nothing downstream could say where a driver panicked. It is now logged at the recover site.
- **`ErrTMSNotFound` is decided by a count**, not inferred from `len(instantiationErrs)`. The previous form relied on "a duplicate implies an earlier failed attempt", an invariant nothing enforces.
- **the write to `opts.PublicParams` is gone.** Every caller passes a pointer to its own by-value copy, so the documented post-condition was unobservable.

## Tests

`TestTMSProviderPublicParamsFallback` in `token/core/tms_test.go`, 9 sub-cases:

- fallback to a usable source when `options` / `storage` / `configuration` hold unusable public parameters;
- a driver panic on one source does not abort the walk;
- identical public parameters held by two sources are tried once;
- all sources unusable -> error names every source and is **not** an `ErrTMSNotFound`;
- no source holds any public parameters -> `ErrTMSNotFound`, and every source's reason is reported;
- a `nil` configuration returned with a `nil` error does not panic;
- a failed resolution is not cached, so a later call succeeds once the network serves usable public parameters.

These sub-cases were verified to fail against the pre-fix `newTMS` (four fail outright, the panic case aborts the run) and to pass after it.

For the `Update` path: `TestTMSProviderUpdateRejectsUnusablePublicParams` (the update fails, and never reads storage or queries the network) and `TestTMSProviderUpdateKeepsTheCachedServiceOnFailure` (the running service is neither unloaded nor evicted). These replace `TestTMSProviderUpdateFallback`, which asserted the behaviour commit 1 had introduced.

`TestTMSProviderConcurrentGet` covers 32 concurrent resolvers, asserting the TMS is instantiated once and the network queried once.

## Verification

- `go test ./token/core/` passes, also under `-race`.
- `golangci-lint run token/core/...` -> 0 issues; `make checks` -> exit 0.
- `go test ./token/...` shows one unrelated pre-existing failure, `TestTranslatePath` in `token/services/identity/config`: it asserts the checkout path contains "panurus" and the local worktree is named differently. It fails identically on unmodified `main`.

## Docs

`docs/public_parameters.md` gains a "Resolution Order" section under *Discovery and Fetching*, documenting the four sources, the retrieve-and-try-in-order semantics, and the error/`ErrTMSNotFound` contract — plus a "Resolution vs. update" subsection stating that the walk does not apply to `Update`, and a note that source 4 requires a configured `PublicParamsFetcher`.

## Known limitation (not addressed here)

`GetTokenManagerService` holds the provider-wide write lock across the whole walk, which may now include the ledger fetch, so a hung fetch blocks TMS lookups for every namespace on the node. This is pre-existing — the fetcher was always reachable under that lock — but this change makes reaching it more likely. Fixing it means per-key creation locking, which changes when the post-init callback can run concurrently, so it is tracked separately in #2306 rather than folded in here.
