### PR TITLE
fix(recovery): bound per-transaction recovery with a timeout

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,23 +240,59 @@ token:
               # Performance impact: Each scan queries the transaction database for pending transactions.
               scanInterval: 5s
               
-              # batchSize is the maximum number of pending transactions claimed per scan. Default: 100.
+              # batchSize is the maximum number of pending transactions claimed per scan. Default: 16.
               # Limits the number of transactions processed in a single recovery sweep to prevent
               # overwhelming the system. Increase for high-throughput environments with many pending transactions.
               # Performance impact: Larger batches reduce scan overhead but increase memory usage and processing time per sweep.
-              batchSize: 100
+              batchSize: 16
               
-              # workerCount is the number of local workers that process claimed transactions in parallel. Default: 4.
+              # workerCount is the number of local workers that process claimed transactions in parallel. Default: 8.
               # Increase to improve recovery throughput in high-volume scenarios.
               # Decrease to reduce resource consumption on constrained systems.
               # Performance impact: More workers increase CPU and network utilization but improve recovery speed.
-              workerCount: 4
+              workerCount: 8
               
-              # leaseDuration is how long a claimed transaction remains leased to this instance before it can be reclaimed. Default: 30s.
+              # leaseDuration is how long a claimed transaction remains leased to this instance before it can be reclaimed. Default: 5m.
               # This prevents stuck transactions from blocking recovery indefinitely if a worker crashes.
               # Should be longer than the typical time to query and process a single transaction.
               # Relationship: Should be greater than the expected network latency + processing time for transaction status queries.
-              leaseDuration: 30s
+              leaseDuration: 5m
+
+              # transactionTimeout bounds a single transaction's recovery attempt: the
+              # handler's Recover call, which queries the ledger for status and applies
+              # finality logic. Default: 60s. If set explicitly (and non-zero), rejected
+              # below a 10s floor: a shorter deadline risks abandoning recoveries that were
+              # merely slow, not genuinely stuck.
+              # Without this, a hung status query blocks the worker indefinitely, and this
+              # instance holds recovery leadership for as long as anything is abandoned in
+              # the background (see the leadership note further down), so a permanently
+              # hung status query stalls recovery on every replica.
+              # Relationship: workerCount workers can each be stuck for the full
+              # transactionTimeout at once, so size leaseDuration against
+              # leaseDuration > (batchSize / workerCount) x transactionTimeout. Also keep
+              # scanInterval comfortably below leaseDuration: a stuck transaction's claim
+              # is kept alive only by this instance's own next sweep reclaiming it, so a
+              # scanInterval close to or above leaseDuration risks the claim lapsing
+              # between sweeps. The manager Warns at startup (does not fail to start) when
+              # either does not hold: an attempt still in flight when this happens keeps
+              # its claim rather than releasing it, so this is a throughput concern, not a
+              # correctness one.
+              # Set to 0 to disable the deadline entirely. Do this only if you accept the
+              # tradeoff: a Recover call that ignores its context can then block Stop()
+              # indefinitely, since a deadline is the only thing that can interrupt a call
+              # the callee itself never reads.
+              transactionTimeout: 60s
+
+              # stuckTransactionAlertThreshold escalates the per-attempt failure log from
+              # Warn to Error once the same transaction has hit transactionTimeout this many
+              # consecutive times, so a persistently-unresponsive peer is visible to alerting
+              # instead of blending into routine sweep failures. Default: 5.
+              # Log-severity only: it never changes the transaction's status, and it never
+              # changes when the manager skips a re-attempt (that happens independently,
+              # whenever an earlier attempt for the same tx hasn't returned yet). Past the
+              # threshold, the log backs off by doubling rather than firing every sweep.
+              # Set to 0 to disable the escalation.
+              stuckTransactionAlertThreshold: 5
               
               # instanceID identifies this replica as the owner of recovery claims.
               # If empty, a process-local identifier is generated automatically at startup using a UUID.
@@ -643,11 +679,13 @@ token:
               enabled: true
               ttl: 30s
               scanInterval: 5s
-              batchSize: 100
-              workerCount: 4
-              leaseDuration: 30s
+              batchSize: 16
+              workerCount: 8
+              leaseDuration: 5m
+              transactionTimeout: 60s
               instanceID:
               notFoundGracePeriod: 30m
+              stuckTransactionAlertThreshold: 5
 ```
 
 Default values:
@@ -655,27 +693,32 @@ Default values:
 - enabled: true
 - ttl: 30s
 - scanInterval: 5s
-- batchSize: 100
-- workerCount: 4
-- leaseDuration: 30s
+- batchSize: 16
+- workerCount: 8
+- leaseDuration: 5m
+- transactionTimeout: 60s (set to 0 to disable the per-transaction deadline; an explicit non-zero value below 10s is rejected)
 - instanceID: empty, auto-generated when the recovery manager starts
 - notFoundGracePeriod: 30m (set to 0 to disable promotion to Orphan)
+- stuckTransactionAlertThreshold: 5 (set to 0 to disable the log escalation)
 
 **Parameter Relationships and Tuning:**
 
 - **Recovery is enabled by default** to ensure automatic recovery of lost finality listeners.
 - **Only pending transactions older than `ttl` are considered for recovery** to avoid interfering with active transaction processing.
-- **The manager validates** that `ttl`, `scanInterval`, `batchSize`, `workerCount`, and `leaseDuration` are all greater than zero.
-- **Recovery leadership** uses a PostgreSQL advisory lock so that only one replica performs a recovery sweep at a time, on the owner transaction path. The lock identifier is no longer configurable: it is derived from the TMS's own `requests` table name, which already carries the network, channel and namespace. That makes it unique per TMS automatically, so several TMSes sharing one PostgreSQL database no longer compete for a single lock, and there is nothing left for an operator to keep unique by hand. The audit transaction store does not yet participate in this coordination — its recovery leader factory is nil, so every replica is granted leadership and the audit sweep runs redundantly on each of them; see [#2143](https://github.com/LFDT-Panurus/panurus/issues/2143).
+- **The manager validates** that `ttl`, `scanInterval`, `batchSize`, and `workerCount` are all greater than zero, that `leaseDuration` is greater than zero, and that `transactionTimeout` is not negative (`0` means unbounded; any positive value is accepted without an upper bound, though loading the configuration separately rejects an explicit non-zero value below a 10s floor, see the next bullet). It additionally **Warns at startup, without failing to start,** when `leaseDuration > (batchSize / workerCount) x transactionTimeout` or `scanInterval < leaseDuration` do not hold, see the next bullet.
+- **Recovery leadership** uses a PostgreSQL advisory lock so that only one replica performs a recovery sweep at a time, on the owner transaction path. The lock identifier is no longer configurable: it is derived from the TMS's own `requests` table name, which already carries the network, channel and namespace. That makes it unique per TMS automatically, so several TMSes sharing one PostgreSQL database no longer compete for a single lock, and there is nothing left for an operator to keep unique by hand. Leadership is normally released at the end of each sweep, but held across sweeps for as long as any transaction is still abandoned in the background from a previous sweep (see `transactionTimeout` below), so this instance keeps winning it — and thereby keeps its own reclaim renewing that transaction's lease — instead of leaving that to chance; `Stop()` always releases it regardless. The audit transaction store does not yet participate in this coordination — its recovery leader factory is nil, so every replica is granted leadership and the audit sweep runs redundantly on each of them; see [#2143](https://github.com/LFDT-Panurus/panurus/issues/2143).
+- **`transactionTimeout`** bounds a single `Handler.Recover()` call, not the whole sweep. The call runs in its own goroutine so the worker can give up on the deadline even if the call itself never honours the context. A per-transaction bound does not bound the sweep: a batch of `batchSize` claims split across `workerCount` workers can take up to `(batchSize / workerCount) × transactionTimeout` worst case, so the invariant that actually matters is `leaseDuration > (batchSize / workerCount) × transactionTimeout`. With the shipped defaults that worst case is `2 × 60s = 120s`, comfortably inside the default 5m `leaseDuration`. Separately, `scanInterval` should stay comfortably below `leaseDuration`: a stuck transaction's claim is kept alive only by this instance's own next sweep reclaiming the still-`Pending` row (which refreshes the claim as a side effect), and this instance holds recovery leadership across sweeps for as long as any transaction stays abandoned specifically so that reclaim keeps happening on this instance rather than depending on it winning leadership again by chance, but a `scanInterval` close to or above `leaseDuration` still risks that renewal arriving too late between this instance's own sweeps. If you only set `leaseDuration` and leave `transactionTimeout` unset, the manager automatically lowers the 60s default below whatever `leaseDuration` you configured (floored at 10s) rather than leaving it at a disproportionate default. An explicit, non-zero `transactionTimeout` below 10s is rejected when the configuration is loaded: a deadline that tight is likely to abandon recoveries that were merely slow on a loaded network, not genuinely stuck. `transactionTimeout: 0` disables the deadline entirely, but `Stop()` does **not** bound a ctx-blind call the way the deadline does; disabling it can leave `Stop()` blocked indefinitely on a hung `Recover` call (the manager logs a Warn at startup when this is set). Note the bound stops at `Handler.Recover()`: `ClaimPendingTransactions`, `ReleaseRecoveryClaim`, and `SetStatus` still run on the sweep's own context, which carries no deadline, so a wedged database connection in any of those still blocks the worker and, since leadership is held for as long as anything is abandoned, every replica of the TMS in the meantime, the same stall `transactionTimeout` was added to fix for the ledger side. `transactionTimeout` is a bound on the handler call only, not a general no-stall guarantee for the sweep. A `recoverCtx.Done()` firing because `Stop()` cancelled the manager, rather than because `transactionTimeout` actually elapsed, is not counted or alerted on as a timeout.
 - **`instanceID`** is used as the lease owner identifier for claimed transactions; if omitted, the manager generates a unique UUID automatically at startup.
 - **`notFoundGracePeriod`** controls how long a transaction whose status query keeps returning `NotFound` is left in `Pending` before being promoted to the terminal `Orphan` status. This protects the recovery sweep from being permanently blocked by transactions whose audit log was persisted but whose broadcast never reached the ledger. The promoted row is marked `Orphan` rather than `Deleted` so operators can distinguish broadcast failures from ledger-rejected transactions. Raise the default if your network has long catch-up windows after committer/orderer restarts; set it to `0` to disable the promotion entirely.
+- **`stuckTransactionAlertThreshold`** escalates the per-attempt failure log from Warn to Error once the same transaction has hit `transactionTimeout` this many consecutive times, so a persistently-unresponsive peer surfaces to alerting instead of blending into routine sweep-failure logs. Past the threshold, the log backs off by doubling (at the threshold, then `2×`, `4×`, `8×`, ...) rather than firing on every sweep, so a transaction stuck for hours does not flood alerting. It is log-severity only: a timeout means the status query didn't answer in time, not that the transaction failed. Unlike `notFoundGracePeriod`, it never changes the transaction's status. The row is still reclaimed every sweep, but while an earlier attempt is still running past its own `transactionTimeout`, the manager skips starting a second one for the same transaction, without releasing its claim, rather than running duplicate concurrent `Recover` calls; the claim is released once that earlier attempt actually returns, whenever that is. Set to `0` to disable the escalation.
 
 **Tuning Recommendations:**
 
 1. **For High-Throughput Environments:**
-   - Increase `batchSize` to 200-500 to process more transactions per sweep
-   - Increase `workerCount` to 8-16 to improve parallel processing
+   - Increase `batchSize` to 100-500 to process more transactions per sweep
+   - Increase `workerCount` to 16-32 to improve parallel processing
    - Decrease `scanInterval` to 2-3s for faster recovery detection
+   - Raise `leaseDuration` alongside `batchSize`/`workerCount` to keep `leaseDuration > (batchSize / workerCount) x transactionTimeout`
 
 
 ### Optional: token.storage.tableNames
@@ -884,7 +927,7 @@ multiply `acquireDeadline` there.
    - Keep default backoff settings to balance retry attempts with resource usage
 
 2. **For Resource-Constrained Environments:**
-   - Decrease `batchSize` to 50 to reduce memory usage
+   - Decrease `batchSize` to 8 to reduce memory usage
    - Decrease `workerCount` to 2 to reduce CPU load
    - Increase `scanInterval` to 10-15s to reduce database queries
 

--- a/docs/services/storage/recovery.md
+++ b/docs/services/storage/recovery.md
@@ -65,11 +65,13 @@ recovery:
   enabled: true              # Enable/disable recovery
   ttl: 30s                   # Minimum age before recovery
   scanInterval: 5s           # How often to scan
-  batchSize: 100             # Max transactions per scan
-  workerCount: 4             # Parallel workers
-  leaseDuration: 30s         # Claim lease duration
+  batchSize: 16              # Max transactions per scan
+  workerCount: 8             # Parallel workers
+  leaseDuration: 5m          # Claim lease duration
+  transactionTimeout: 60s    # Deadline for a single transaction's recovery attempt (0 = unbounded, or >= 10s)
   instanceID: ""             # Instance identifier
   notFoundGracePeriod: 30m   # Promote NotFound rows to Orphan after this age (0 disables)
+  stuckTransactionAlertThreshold: 5  # Escalate to Error log after this many consecutive timeouts (0 disables)
 ```
 
 ## Usage Example
@@ -78,13 +80,15 @@ Creating a recovery manager:
 
 ```go
 config := recovery.Config{
-    Enabled:             true,
-    TTL:                 30 * time.Second,
-    ScanInterval:        5 * time.Second,
-    BatchSize:           100,
-    WorkerCount:         4,
-    LeaseDuration:       30 * time.Second,
-    NotFoundGracePeriod: 30 * time.Minute,
+    Enabled:                        true,
+    TTL:                            30 * time.Second,
+    ScanInterval:                   5 * time.Second,
+    BatchSize:                      16,
+    WorkerCount:                    8,
+    LeaseDuration:                  5 * time.Minute,
+    TransactionTimeout:             60 * time.Second,
+    NotFoundGracePeriod:            30 * time.Minute,
+    StuckTransactionAlertThreshold: 5,
 }
 
 manager := recovery.NewManager(
@@ -121,14 +125,14 @@ func (h *MyHandler) Recover(ctx context.Context, txID string) error {
 
 ## Recovery Process Flow
 
-1. Manager acquires leadership (PostgreSQL advisory lock)
+1. Manager acquires leadership (PostgreSQL advisory lock). Normally released at the end of each sweep, but held across sweeps for as long as any transaction is still abandoned in the background from a previous sweep (see step 5): this instance's own next `ClaimPendingTransactions` call is what keeps that transaction's claim lease alive (step 5), and that only reliably happens if this instance keeps winning leadership, rather than leaving it to the next non-blocking lock attempt succeeding by chance. `Stop()` always releases leadership when called, regardless of whether anything is still abandoned
 2. Manager queries for pending transactions older than TTL
 3. Manager atomically claims a batch of transactions, each returned as a `RecoveryClaim` (`TxID` + `StoredAt`)
 4. Manager distributes claimed transactions to worker pool
-5. Each worker calls `Handler.Recover()` for its transactions
+5. Each worker calls `Handler.Recover()` for its transactions, bounded by `transactionTimeout`: the call runs in its own goroutine, and the worker moves on as soon as the deadline fires rather than waiting for the call to return, so a peer that hangs without honouring the context (as some ledger calls do) still cannot block the sweep indefinitely, and since leadership is held for as long as anything is abandoned (step 1), neither can every other replica in the meantime. The abandoned goroutine keeps running in the background until the underlying call eventually completes; its claim stays held (not released) in the meantime, and its eventual result is used, not discarded (see step 8). If the same transaction is still claimed and re-dispatched to a worker before that abandoned goroutine returns, the manager skips it rather than starting a second concurrent `Recover` call for it
 6. Handler queries network and applies finality logic
-7. If the handler reports `NotFound` and the row was stored more than `notFoundGracePeriod` ago, the manager promotes the row to `Orphan` via `SetStatus` so it exits the eligible scan range
-8. Manager releases claims with success/failure message
+7. If the handler reports `NotFound` and the row was stored more than `notFoundGracePeriod` ago, the manager promotes the row to `Orphan` via `SetStatus` so it exits the eligible scan range, unless this is a step-5 background finalization arriving after `Stop()` has already run, in which case the promotion is skipped: leadership was released by `Stop()` (step 1), so another replica may have since legitimately resolved the same transaction, and an unconditional `SetStatus` could overwrite that outcome
+8. Manager releases each claim with a success/failure message, as soon as a final result for it is known: synchronously, for a `Recover()` call that returns within `transactionTimeout`, or later in the background, for one that did not (step 5), whichever comes first, and only once. The in-flight guard for a transaction is cleared only after this release actually completes, not before, so a sweep that reclaims the same transaction in between cannot start a second attempt out from under the release still in progress
 9. Process repeats on next scan interval
 
 ## Transaction Status Lifecycle
@@ -166,10 +170,24 @@ All three terminal statuses (`Confirmed`, `Deleted`, `Orphan`) are excluded from
 - Increase `ttl` (60s or more)
 - Ensure `leaseDuration` > expected processing time
 
+### Transaction Timeout
+- `transactionTimeout` bounds a single `Handler.Recover()` call (ledger status query plus finality logic), not the whole sweep. It is not a general no-stall guarantee for the sweep: `ClaimPendingTransactions`, `ReleaseRecoveryClaim`, and `SetStatus` still run on the sweep's own context, which has no deadline, so a wedged database connection in any of those can still stall recovery on every replica of the TMS, the same failure mode `transactionTimeout` was added to fix on the ledger side
+- That per-transaction bound does not by itself bound the sweep: a batch of `batchSize` claims split across `workerCount` workers, each taking the full `transactionTimeout`, takes up to `(batchSize / workerCount) × transactionTimeout` worst case. The invariant to size `leaseDuration` against is `leaseDuration > (batchSize / workerCount) × transactionTimeout`. With the shipped defaults (`batchSize: 16`, `workerCount: 8`, `transactionTimeout: 60s`) that worst case is `2 × 60s = 120s`, comfortably inside the default `leaseDuration: 5m`. The manager Warns at startup, rather than refusing to start, when this does not hold: an attempt still in flight when this happens keeps its claim rather than releasing it (see the "stuck transaction" bullet below), so this is a throughput concern, not a correctness one
+- `leaseDuration` should also comfortably exceed `scanInterval`. A transaction still recovering past its `transactionTimeout` keeps its claim alive only because this instance's own next sweep reclaims the same still-`Pending` row, which refreshes the claim's lease as a side effect, and this instance holds recovery leadership across sweeps for as long as that transaction stays abandoned specifically so that reclaim keeps happening on schedule (see step 1 of the process flow above) rather than depending on this instance winning leadership again by chance. If `scanInterval` is not shorter than `leaseDuration`, that renewal can still arrive too late and the claim can lapse between this instance's own sweeps. The manager Warns at startup when this does not hold
+- Raise it if legitimate recoveries (e.g. large token requests re-verified from the database) routinely take longer than the default 60s; lower it if a slow or flaky peer should be given up on sooner, down to a 10s floor: an explicit `transactionTimeout` below 10s is rejected when the configuration is loaded, since a deadline that tight is likely to abandon recoveries that were merely slow rather than genuinely stuck. Setting it to `0` disables the per-transaction deadline entirely, but that also removes the only thing that can interrupt a `Recover` call that ignores its context: `Stop()` itself can then block indefinitely on a hung call, and every later `Start`/`Stop` wedges behind it. The manager logs a Warn at startup when the timeout is disabled; it does not stop you from doing it
+- A transaction that keeps timing out stays `Pending` and is re-claimed on every sweep, but the manager will not start a second concurrent `Recover` call for it while an earlier attempt is still running past its own `transactionTimeout`: it skips the attempt instead. Unlike earlier versions of this manager, the claim is **not** released when this happens: releasing it while the earlier attempt might still be running is what let a second replica claim and run a concurrent `Recover` (and `Commit`) against the same transaction. The claim stays held, kept alive by the leadership-holding and reclaim-renewal described above, until the original stuck attempt actually returns, at which point the manager finalizes it in the background, releasing the claim with the real outcome and only then clearing the in-flight guard, whenever that turns out to be, including well after the sweep (or even the process's `Stop()` call) that first hit the timeout has already moved on. A `recoverCtx.Done()` firing because `Stop()` cancelled the manager, rather than because `transactionTimeout` actually elapsed, is not counted or alerted on as a timeout: it is an ordinary shutdown catching an attempt mid-flight, not evidence the transaction itself is stuck
+- `stuckTransactionAlertThreshold` escalates the per-attempt failure log from Warn to Error once the same transaction has timed out this many times in a row, so a persistently-unresponsive peer is visible to alerting instead of blending into routine sweep failures. Past the threshold the log backs off by doubling (threshold, `2×`, `4×`, `8×`, ...) rather than firing every sweep, so a transaction stuck for hours does not flood alerting. It is purely a log-severity signal: a timeout means the status query didn't answer in time, not that the transaction failed. Unlike a persistent `NotFound`, the manager does not promote it to `Orphan`. Set to `0` to disable the escalation
+
 ## Thread Safety
 
 The Manager is thread-safe and can be safely started/stopped from multiple goroutines. The Handler implementation must also be thread-safe as it will be called concurrently by multiple workers.
 
 ## Shutdown Behaviour
 
-`Stop()` cancels the manager context and waits for the recovery loop to return. If a sweep is mid-batch, the fan-out to the worker pool aborts on cancellation: workers stop after their in-flight `Handler.Recover()` call and any claims not yet dispatched are simply left undispatched. Those rows keep their `Pending` status, so they become eligible again once their lease (`leaseDuration`) expires and are picked up by the next sweep — on this or another replica. The aborted sweep reports a `recovery fan-out cancelled` error. Because this is an ordinary shutdown rather than a failure, the loop logs it at debug level and only warns for genuine sweep errors. The sweep summary counts successes against the claims actually dispatched, so a partial sweep logs `claimed=N, dispatched=M, ...` at warn level instead of crediting the undispatched tail as succeeded.
+`Stop()` cancels the manager context and waits for the recovery loop to return. If a sweep is mid-batch, the fan-out to the worker pool aborts on cancellation: workers exit as soon as they observe the cancellation, and any claims not yet dispatched are simply left undispatched. Those rows keep their `Pending` status, so they become eligible again once their lease (`leaseDuration`) expires and are picked up by the next sweep — on this or another replica. The aborted sweep reports a `recovery fan-out cancelled` error. Because this is an ordinary shutdown rather than a failure, the loop logs it at debug level and only warns for genuine sweep errors. The sweep summary counts successes against the claims actually dispatched, so a partial sweep logs `claimed=N, dispatched=M, ...` at warn level instead of crediting the undispatched tail as succeeded.
+
+With a `transactionTimeout` configured, a worker mid-`Handler.Recover()` does not wait out that call on shutdown: it abandons the call once the deadline fires and moves on (see [Transaction Timeout](#transaction-timeout)), so `Stop()` returning does **not** guarantee every in-flight recovery attempt has actually stopped. An abandoned call can keep running after `Stop()` returns and eventually reach `Commit`, writing into a store the SDK may already be tearing down as part of node shutdown. This is the same accepted tradeoff the timeout mechanism makes everywhere else: bounding the worker takes priority over waiting for a ctx-blind call to finish. With `transactionTimeout: 0` there is no deadline to abandon the call at, so `Stop()` instead blocks on `Handler.Recover()` directly, potentially indefinitely if the handler ignores its context.
+
+The claim on a transaction abandoned this way is not released by `Stop()` either: it is released only once the abandoned call actually returns and the manager finalizes it in the background, which can be well after `Stop()` has already returned. That finalization uses its own independent context rather than the (by then long since cancelled) sweep or manager context, specifically so the release can still succeed after shutdown.
+
+Recovery leadership, unlike the claim above, is always released by `Stop()`, even if a transaction is still abandoned in the background: this instance can no longer productively use it once its own sweep loop has exited, and holding onto it would only block a live peer that could otherwise take over. That means a transaction still abandoned when `Stop()` runs is no longer guaranteed to have its lease renewed by this instance, and a live peer can legitimately reclaim and finish it while this instance's own attempt is still finishing up in the background. For that reason, if the background finalization's handler eventually reports the transaction as `NotFound`, the manager does not promote it to `Orphan` once it observes that `Stop()` already ran: another replica may have since resolved it to something else, and unlike the owner-scoped claim release, `SetStatus` has no way to tell that has happened.

--- a/token/services/storage/services/recovery/config.go
+++ b/token/services/storage/services/recovery/config.go
@@ -11,11 +11,14 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token/services/config"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
 const (
 	// ConfigKeyRecovery is the configuration key for recovery settings
 	ConfigKeyRecovery = "services.network.fabric.recovery"
+
+	defaultStuckTransactionAlertThreshold = 5
 )
 
 var logger = logging.MustGetLogger()
@@ -34,6 +37,36 @@ type Config struct {
 	WorkerCount int
 	// LeaseDuration is the duration of the recovery claim lease.
 	LeaseDuration time.Duration
+	// TransactionTimeout bounds a single transaction's recovery attempt (the
+	// handler's Recover call, which queries the ledger for status and applies
+	// finality logic). Without it, a hung status query blocks the worker
+	// indefinitely and, because leadership is held for the whole sweep, stalls
+	// recovery on every replica of the TMS. An attempt that outlives this
+	// deadline keeps its claim rather than releasing it (see manager.go's
+	// finishAbandonedRecovery), so Start() only Warns, it does not fail,
+	// when leaseDuration > (batchSize/workerCount) x transactionTimeout or
+	// scanInterval < leaseDuration do not hold — see warnIfLeaseMayExpireMidSweep
+	// and warnIfLeaseMayExpireBetweenSweeps. Zero disables the deadline
+	// (accepts explicit zero as "unbounded", see LoadConfig); validateConfig
+	// rejects negative values. LoadConfig separately rejects an operator's
+	// explicit non-zero value below a 10s floor: a shorter deadline reads a
+	// slow-but-legitimate ledger round-trip under load as a stuck transaction
+	// and abandons it before it had a real chance to finish. That floor is
+	// enforced in LoadConfig rather than validateConfig because it only
+	// applies to a value the operator actually chose, not one this package
+	// defaulted or clamped to, and LoadConfig is the only place that still
+	// knows which is which (see LoadConfig's TransactionTimeout handling).
+	TransactionTimeout time.Duration
+	// StuckTransactionAlertThreshold: after this many consecutive
+	// TransactionTimeout expirations for the same transaction, the recovery
+	// loop logs at Error instead of Warn so a persistently-timing-out
+	// transaction is visible to alerting rather than blending into the
+	// routine per-sweep failure log. It never changes the transaction's
+	// stored status: a timeout only means the status query didn't answer in
+	// time, not that the transaction failed to reach the ledger, so unlike
+	// a persistent NotFound it cannot be promoted to Orphan. Zero disables
+	// the escalation.
+	StuckTransactionAlertThreshold int
 	// InstanceID identifies the current replica as the lease owner.
 	InstanceID string
 	// NotFoundGracePeriod: when GetTransactionStatus returns a NotFound error and
@@ -47,13 +80,15 @@ type Config struct {
 // DefaultConfig returns the default recovery configuration
 func DefaultConfig() Config {
 	return Config{
-		Enabled:             true,
-		TTL:                 30 * time.Second,
-		ScanInterval:        5 * time.Second,
-		BatchSize:           defaultBatchSize,
-		WorkerCount:         defaultWorkers,
-		LeaseDuration:       defaultLeaseDuration,
-		NotFoundGracePeriod: 30 * time.Minute,
+		Enabled:                        true,
+		TTL:                            30 * time.Second,
+		ScanInterval:                   5 * time.Second,
+		BatchSize:                      defaultBatchSize,
+		WorkerCount:                    defaultWorkers,
+		LeaseDuration:                  defaultLeaseDuration,
+		TransactionTimeout:             defaultTransactionTimeout,
+		NotFoundGracePeriod:            30 * time.Minute,
+		StuckTransactionAlertThreshold: defaultStuckTransactionAlertThreshold,
 	}
 }
 
@@ -90,6 +125,41 @@ func LoadConfig(cfg *config.Configuration) (Config, error) {
 	if config.LeaseDuration > 0 {
 		result.LeaseDuration = config.LeaseDuration
 	}
+	// TransactionTimeout accepts an explicit zero to mean "unbounded" (opt out
+	// of the per-transaction deadline entirely), so check IsSet rather than
+	// the Go zero value, same reasoning as NotFoundGracePeriod below. Without
+	// this gate, transactionTimeout: 0 would silently fall back to the
+	// package default and the opt-out would be unreachable.
+	if cfg.IsSet(ConfigKeyRecovery + ".transactionTimeout") {
+		if config.TransactionTimeout > 0 && config.TransactionTimeout < minTransactionTimeout {
+			return Config{}, errors.Errorf("recovery transactionTimeout [%s] is below the %s floor: a shorter deadline risks abandoning recoveries that were about to succeed", config.TransactionTimeout, minTransactionTimeout)
+		}
+		result.TransactionTimeout = config.TransactionTimeout
+	} else if result.TransactionTimeout >= result.LeaseDuration {
+		// The operator never touched transactionTimeout, so it is still
+		// sitting at the package default here. If they configured a smaller
+		// leaseDuration, a transactionTimeout that size makes little
+		// operational sense next to it (round 7 no longer hard-fails Start()
+		// over this specific relationship, see warnIfLeaseMayExpireMidSweep,
+		// but there is still no reason to leave an operator at a default this
+		// disproportionate to a lease they explicitly chose). Clamp the
+		// default down instead; a transactionTimeout the operator set
+		// explicitly is left exactly as they wrote it.
+		//
+		// Floored at minTransactionTimeout rather than left at
+		// leaseDuration/2: the explicit-value floor check above only fires
+		// when IsSet is true, so a clamped default landing below it would
+		// otherwise slip through unrejected, and 0 here would silently land
+		// the operator in the "unbounded" opt-out (see the IsSet gate above
+		// and callHandler) rather than the bounded default this clamp exists
+		// to keep them on. For a leaseDuration small enough that half of it
+		// undercuts the floor, the clamped default ends up at or above
+		// leaseDuration itself; that is exactly the disproportionate
+		// relationship warnIfLeaseMayExpireMidSweep and
+		// warnIfLeaseMayExpireBetweenSweeps Warn about at Start(), which is
+		// the right severity for a lease this small, not a hard failure.
+		result.TransactionTimeout = max(result.LeaseDuration/2, minTransactionTimeout)
+	}
 	if config.InstanceID != "" {
 		result.InstanceID = config.InstanceID
 	}
@@ -99,6 +169,12 @@ func LoadConfig(cfg *config.Configuration) (Config, error) {
 	// to the 30 min default and the documented opt-out would be unreachable.
 	if cfg.IsSet(ConfigKeyRecovery + ".notFoundGracePeriod") {
 		result.NotFoundGracePeriod = config.NotFoundGracePeriod
+	}
+	// StuckTransactionAlertThreshold accepts an explicit zero to disable the
+	// log escalation, so check IsSet rather than the Go zero value, same as
+	// NotFoundGracePeriod above.
+	if cfg.IsSet(ConfigKeyRecovery + ".stuckTransactionAlertThreshold") {
+		result.StuckTransactionAlertThreshold = config.StuckTransactionAlertThreshold
 	}
 	// advisoryLockID used to let an operator keep multiple independent recovery
 	// managers on the same database from colliding. The lock id is now derived

--- a/token/services/storage/services/recovery/config_test.go
+++ b/token/services/storage/services/recovery/config_test.go
@@ -7,12 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package recovery_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
-	"github.com/LFDT-Panurus/panurus/token/services/config"
-	"github.com/LFDT-Panurus/panurus/token/services/storage/services/recovery"
+	tokenconfig "github.com/LFDT-Panurus/panurus/token/services/config"
+	"github.com/LFDT-Panurus/panurus/token/services/config/mocks"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	recovery2 "github.com/LFDT-Panurus/panurus/token/services/storage/services/recovery"
+	mock2 "github.com/LFDT-Panurus/panurus/token/services/storage/services/recovery/mock"
 	fscconfig "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,11 +29,336 @@ func TestLoadConfig_IgnoresStaleAdvisoryLockID(t *testing.T) {
 	cp, err := fscconfig.NewProvider("./testdata/stalecfg")
 	require.NoError(t, err)
 
-	cfg := config.NewConfiguration(cp, "n1c1ns1", driver.TMSID{Network: "n1", Channel: "c1", Namespace: "ns1"})
+	cfg := tokenconfig.NewConfiguration(cp, "n1c1ns1", driver.TMSID{Network: "n1", Channel: "c1", Namespace: "ns1"})
 
-	loaded, err := recovery.LoadConfig(cfg)
+	loaded, err := recovery2.LoadConfig(cfg)
 	require.NoError(t, err, "a stale advisoryLockID key must not fail the load")
 
 	assert.True(t, loaded.Enabled)
 	assert.Equal(t, 45*time.Second, loaded.TTL, "the rest of the block must still be applied")
+}
+
+func newTestTMSConfig(isSet func(key string) bool, unmarshal func(key string, rawVal any) error) *tokenconfig.Configuration {
+	cp := &mocks.Provider{}
+	cp.IsSetStub = isSet
+	cp.UnmarshalKeyStub = unmarshal
+
+	return tokenconfig.NewConfiguration(cp, "tms1", driver.TMSID{Network: "net", Channel: "ch", Namespace: "ns"})
+}
+
+// TestLoadConfig_ClampsDefaultTransactionTimeoutBelowConfiguredLeaseDuration
+// is the regression test for the round-2 startup failure: an operator who
+// only configures leaseDuration, never touching transactionTimeout, used to
+// end up with the 10s package default paired against their smaller
+// leaseDuration. validateConfig at the time rejected that combination at
+// Start(), refusing to start a node whose config was valid before
+// transactionTimeout existed at all. Round 7 removed that specific
+// validateConfig check (see warnIfLeaseMayExpireMidSweep), but the clamp
+// itself is still worth keeping: leaving an operator at a default that dwarfs
+// a lease they explicitly configured smaller is confusing regardless of
+// whether Start() still hard-fails over it. Uses a leaseDuration large enough
+// that half of it still clears minTransactionTimeout, so the clamp lands
+// strictly below the lease; see
+// TestLoadConfig_ClampFloorsAtMinTransactionTimeoutForSmallLeaseDuration for
+// the case where it cannot.
+func TestLoadConfig_ClampsDefaultTransactionTimeoutBelowConfiguredLeaseDuration(t *testing.T) {
+	tmsCfg := newTestTMSConfig(
+		func(key string) bool {
+			// The recovery block and leaseDuration are present; transactionTimeout
+			// is never mentioned, matching an operator who never set it.
+			return strings.HasSuffix(key, recovery2.ConfigKeyRecovery) ||
+				strings.HasSuffix(key, recovery2.ConfigKeyRecovery+".leaseDuration")
+		},
+		func(_ string, rawVal any) error {
+			cfg, ok := rawVal.(*recovery2.Config)
+			require.True(t, ok)
+			// Enabled is applied unconditionally in LoadConfig (not IsSet-gated
+			// like the other fields here), so it has to be set explicitly to
+			// match a real operator's recovery block. Left at the Go zero value,
+			// Start() returns before validateConfig ever runs and this test
+			// passes without exercising the clamp at all.
+			cfg.Enabled = true
+			cfg.LeaseDuration = 60 * time.Second
+
+			return nil
+		},
+	)
+
+	result, err := recovery2.LoadConfig(tmsCfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, 60*time.Second, result.LeaseDuration)
+	assert.Positive(t, result.TransactionTimeout, "clamping must not silently disable the deadline")
+	assert.Less(t, result.TransactionTimeout, result.LeaseDuration,
+		"an operator who never touched transactionTimeout must not end up with a default disproportionate to the leaseDuration they configured")
+
+	// The actual regression: Start() must succeed against the LoadConfig
+	// output for an operator who only set leaseDuration.
+	m := recovery2.NewManager(logging.MustGetLogger(), &mock2.Storage{}, &mock2.Handler{}, result)
+	require.NoError(t, m.Start())
+	require.NoError(t, m.Stop())
+}
+
+// TestLoadConfig_ClampFloorsAtMinTransactionTimeoutForSmallLeaseDuration
+// covers a leaseDuration small enough that half of it undercuts
+// minTransactionTimeout: the clamp must floor at minTransactionTimeout rather
+// than at leaseDuration/2, even though that leaves the result at or above the
+// leaseDuration the operator configured. round 8 made that combination a
+// Warn at Start() (see warnIfLeaseMayExpireMidSweep /
+// warnIfLeaseMayExpireBetweenSweeps), not a LoadConfig failure: landing an
+// operator on a default below the 10s floor would silently trade one startup
+// regression (round 6, this file's own history above) for another.
+func TestLoadConfig_ClampFloorsAtMinTransactionTimeoutForSmallLeaseDuration(t *testing.T) {
+	tmsCfg := newTestTMSConfig(
+		func(key string) bool {
+			return strings.HasSuffix(key, recovery2.ConfigKeyRecovery) ||
+				strings.HasSuffix(key, recovery2.ConfigKeyRecovery+".leaseDuration")
+		},
+		func(_ string, rawVal any) error {
+			cfg, ok := rawVal.(*recovery2.Config)
+			require.True(t, ok)
+			cfg.Enabled = true
+			cfg.LeaseDuration = 5 * time.Second
+
+			return nil
+		},
+	)
+
+	result, err := recovery2.LoadConfig(tmsCfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, 5*time.Second, result.LeaseDuration)
+	assert.Equal(t, 10*time.Second, result.TransactionTimeout,
+		"a leaseDuration/2 below the 10s floor must clamp up to the floor, not down to a value the LoadConfig floor check would otherwise have to reject")
+
+	// The actual regression this guards against: Start() must still succeed,
+	// even though the clamped default now exceeds the configured leaseDuration.
+	m := recovery2.NewManager(logging.MustGetLogger(), &mock2.Storage{}, &mock2.Handler{}, result)
+	require.NoError(t, m.Start())
+	require.NoError(t, m.Stop())
+}
+
+// TestLoadConfig_ClampFloorsAboveZeroForTinyLeaseDuration guards the edge of
+// the same clamp: result.LeaseDuration/2 truncates to 0 for a leaseDuration
+// below 2ns, and 0 means "unbounded" everywhere else in this package (see the
+// IsSet gate above and callHandler), so a naive clamp would land an operator
+// in that opt-out by accident instead of a bounded, if absurdly tight,
+// deadline. Superseded in practice by the minTransactionTimeout floor (see
+// TestLoadConfig_ClampFloorsAtMinTransactionTimeoutForSmallLeaseDuration), but
+// still worth asserting directly at this extreme.
+func TestLoadConfig_ClampFloorsAboveZeroForTinyLeaseDuration(t *testing.T) {
+	tmsCfg := newTestTMSConfig(
+		func(key string) bool {
+			return strings.HasSuffix(key, recovery2.ConfigKeyRecovery) ||
+				strings.HasSuffix(key, recovery2.ConfigKeyRecovery+".leaseDuration")
+		},
+		func(_ string, rawVal any) error {
+			cfg, ok := rawVal.(*recovery2.Config)
+			require.True(t, ok)
+			cfg.Enabled = true
+			cfg.LeaseDuration = time.Nanosecond
+
+			return nil
+		},
+	)
+
+	result, err := recovery2.LoadConfig(tmsCfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, time.Nanosecond, result.LeaseDuration)
+	assert.Positive(t, result.TransactionTimeout,
+		"the clamp must not truncate to 0, which means unbounded rather than a tight deadline")
+}
+
+// TestLoadConfig_TransactionTimeoutZeroSurvivesAsUnbounded guards the other
+// direction of the same gate: an operator who explicitly opts out with
+// transactionTimeout: 0 must not have that silently overridden back to the
+// package default.
+func TestLoadConfig_TransactionTimeoutZeroSurvivesAsUnbounded(t *testing.T) {
+	tmsCfg := newTestTMSConfig(
+		func(key string) bool {
+			return strings.HasSuffix(key, recovery2.ConfigKeyRecovery) ||
+				strings.HasSuffix(key, recovery2.ConfigKeyRecovery+".transactionTimeout")
+		},
+		func(_ string, rawVal any) error {
+			cfg, ok := rawVal.(*recovery2.Config)
+			require.True(t, ok)
+			cfg.TransactionTimeout = 0 // explicit opt-out
+
+			return nil
+		},
+	)
+
+	result, err := recovery2.LoadConfig(tmsCfg)
+	require.NoError(t, err)
+
+	assert.Zero(t, result.TransactionTimeout,
+		"an explicit transactionTimeout: 0 must survive as the documented unbounded opt-out, not fall back to the package default")
+	assert.Equal(t, 5*time.Minute, result.LeaseDuration, "leaseDuration left unset should keep its default")
+}
+
+// TestLoadConfig_RejectsTransactionTimeoutBelowFloor covers round 8 review's
+// ask on the 10s default: an operator's explicit transactionTimeout below the
+// floor is rejected at LoadConfig, rather than silently accepted only to then
+// abandon recoveries that were about to succeed on a merely slow ledger
+// round-trip. Enforced in LoadConfig, not validateConfig, so tests elsewhere
+// in this package remain free to construct a Config directly with a
+// millisecond-scale TransactionTimeout to exercise timeout handling quickly.
+func TestLoadConfig_RejectsTransactionTimeoutBelowFloor(t *testing.T) {
+	tmsCfg := newTestTMSConfig(
+		func(key string) bool {
+			return strings.HasSuffix(key, recovery2.ConfigKeyRecovery) ||
+				strings.HasSuffix(key, recovery2.ConfigKeyRecovery+".transactionTimeout")
+		},
+		func(_ string, rawVal any) error {
+			cfg, ok := rawVal.(*recovery2.Config)
+			require.True(t, ok)
+			cfg.TransactionTimeout = 5 * time.Second
+
+			return nil
+		},
+	)
+
+	_, err := recovery2.LoadConfig(tmsCfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "10s")
+}
+
+func TestManager_StartValidatesConfig(t *testing.T) {
+	base := func() recovery2.Config {
+		return recovery2.Config{
+			Enabled:            true,
+			TTL:                time.Second,
+			ScanInterval:       time.Second,
+			BatchSize:          1,
+			WorkerCount:        1,
+			LeaseDuration:      time.Second,
+			TransactionTimeout: 100 * time.Millisecond,
+			InstanceID:         "test-instance",
+		}
+	}
+
+	tests := []struct {
+		name          string
+		mutate        func(*recovery2.Config)
+		wantErrSubstr string
+	}{
+		{"non-positive TTL", func(c *recovery2.Config) { c.TTL = 0 }, "invalid recovery TTL"},
+		{"non-positive scan interval", func(c *recovery2.Config) { c.ScanInterval = 0 }, "invalid recovery scan interval"},
+		{"non-positive batch size", func(c *recovery2.Config) { c.BatchSize = 0 }, "invalid recovery batch size"},
+		{"non-positive worker count", func(c *recovery2.Config) { c.WorkerCount = 0 }, "invalid recovery worker count"},
+		{"non-positive lease duration", func(c *recovery2.Config) { c.LeaseDuration = 0 }, "invalid recovery lease duration"},
+		{"negative transaction timeout", func(c *recovery2.Config) { c.TransactionTimeout = -time.Millisecond }, "invalid recovery transaction timeout"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base()
+			tt.mutate(&cfg)
+
+			m := recovery2.NewManager(logging.MustGetLogger(), &mock2.Storage{}, &mock2.Handler{}, cfg)
+			err := m.Start()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrSubstr)
+		})
+	}
+}
+
+// TestManager_StartAcceptsZeroTransactionTimeoutAsUnbounded verifies the
+// exemption: TransactionTimeout == 0 is valid at any LeaseDuration.
+func TestManager_StartAcceptsZeroTransactionTimeoutAsUnbounded(t *testing.T) {
+	cfg := recovery2.Config{
+		Enabled:            true,
+		TTL:                time.Second,
+		ScanInterval:       time.Second,
+		BatchSize:          1,
+		WorkerCount:        1,
+		LeaseDuration:      time.Second,
+		TransactionTimeout: 0,
+		InstanceID:         "test-instance",
+	}
+
+	mockDB := &mock2.Storage{}
+	mockDB.AcquireRecoveryLeadershipReturns(nil, false, nil)
+
+	m := recovery2.NewManager(logging.MustGetLogger(), mockDB, &mock2.Handler{}, cfg)
+	require.NoError(t, m.Start())
+	require.NoError(t, m.Stop())
+}
+
+// TestManager_WarnsWhenTransactionTimeoutMayExceedLeaseDuringSweep is the
+// round-7 regression test for the finding that validateConfig's
+// transactionTimeout < leaseDuration check enforced the wrong relationship:
+// the docs describe leaseDuration > (batchSize/workerCount) x
+// transactionTimeout, which this config violates (10 claims/worker x 200ms =
+// 2s worst case, against a 1s lease) despite transactionTimeout (200ms)
+// itself being comfortably less than leaseDuration (1s) — the old check would
+// have passed this silently. Warn, not a Start() failure: see the doc comment
+// on warnIfLeaseMayExpireMidSweep.
+func TestManager_WarnsWhenTransactionTimeoutMayExceedLeaseDuringSweep(t *testing.T) {
+	logger := &sweepLogger{}
+	cfg := recovery2.Config{
+		Enabled:            true,
+		TTL:                time.Second,
+		ScanInterval:       time.Second,
+		BatchSize:          10,
+		WorkerCount:        1,
+		LeaseDuration:      time.Second,
+		TransactionTimeout: 200 * time.Millisecond,
+		InstanceID:         "test-instance",
+	}
+
+	mockDB := &mock2.Storage{}
+	mockDB.AcquireRecoveryLeadershipReturns(nil, false, nil)
+
+	m := recovery2.NewManager(logger, mockDB, &mock2.Handler{}, cfg)
+	require.NoError(t, m.Start())
+	require.NoError(t, m.Stop())
+
+	found := false
+	for _, msg := range logger.allMessages() {
+		if strings.Contains(msg, "worst-case sweep duration") && strings.Contains(msg, "leaseDuration") {
+			found = true
+
+			break
+		}
+	}
+	assert.True(t, found, "expected a Warn about worst-case sweep duration vs leaseDuration, got: %v", logger.allMessages())
+}
+
+// TestManager_WarnsWhenScanIntervalMayExceedLeaseDuration is the round-7
+// regression test for the new renewal-by-reclaim design: a stuck
+// transaction's claim is kept alive only by this instance's own next
+// ClaimPendingTransactions call reclaiming it (see the inFlight field's doc
+// comment), so if ScanInterval is not comfortably shorter than
+// LeaseDuration, the claim can lapse between sweeps.
+func TestManager_WarnsWhenScanIntervalMayExceedLeaseDuration(t *testing.T) {
+	logger := &sweepLogger{}
+	cfg := recovery2.Config{
+		Enabled:            true,
+		TTL:                time.Second,
+		ScanInterval:       2 * time.Second,
+		BatchSize:          1,
+		WorkerCount:        1,
+		LeaseDuration:      time.Second,
+		TransactionTimeout: 100 * time.Millisecond,
+		InstanceID:         "test-instance",
+	}
+
+	mockDB := &mock2.Storage{}
+	mockDB.AcquireRecoveryLeadershipReturns(nil, false, nil)
+
+	m := recovery2.NewManager(logger, mockDB, &mock2.Handler{}, cfg)
+	require.NoError(t, m.Start())
+	require.NoError(t, m.Stop())
+
+	found := false
+	for _, msg := range logger.allMessages() {
+		if strings.Contains(msg, "scanInterval") && strings.Contains(msg, "leaseDuration") {
+			found = true
+
+			break
+		}
+	}
+	assert.True(t, found, "expected a Warn about scanInterval vs leaseDuration, got: %v", logger.allMessages())
 }

--- a/token/services/storage/services/recovery/manager.go
+++ b/token/services/storage/services/recovery/manager.go
@@ -22,10 +22,47 @@ import (
 )
 
 const (
-	defaultBatchSize     = 100
-	defaultWorkers       = 4
-	defaultLeaseDuration = 30 * time.Second
+	defaultBatchSize          = 16
+	defaultWorkers            = 8
+	defaultLeaseDuration      = 5 * time.Minute
+	defaultTransactionTimeout = 60 * time.Second
+
+	// minTransactionTimeout is the floor LoadConfig enforces on an operator's
+	// explicit (non-zero) transactionTimeout setting. Below this, a transient
+	// slow ledger round-trip under load reads as a stuck transaction and gets
+	// abandoned before it had a real chance to finish (round 8 review,
+	// finding on the 10s default). Enforced in LoadConfig rather than
+	// validateConfig: LoadConfig is the only place that still knows whether a
+	// value was the operator's explicit choice or an internal default/clamp,
+	// which matters here (see LoadConfig's TransactionTimeout handling) the
+	// same way it mattered for the timeout-vs-lease relationship round 6
+	// hard-failed on and round 7 had to walk back to a Warn.
+	minTransactionTimeout = 10 * time.Second
+
+	// timeoutCountTTL bounds how long a txID lingers in timeoutCounts after its
+	// last recorded timeout. A transaction that times out here and is then
+	// confirmed by an independent finality listener leaves the Pending scan
+	// range and is never reattempted by this manager, so nothing would
+	// otherwise ever remove its entry.
+	timeoutCountTTL = time.Hour
 )
+
+// errRecoveryInFlight is returned by callHandler when a previous attempt for
+// the same txID is still running in an abandoned goroutine, see callHandler.
+var errRecoveryInFlight = errors.New("recovery attempt already in flight")
+
+// errSkippedInFlight is what recoverTransaction returns to recoverTransactions
+// for the errRecoveryInFlight case: no recovery was attempted at all, so it
+// must not be counted, or logged, as a success or a failure of this sweep.
+var errSkippedInFlight = errors.New("recovery: transaction skipped, previous attempt still in flight")
+
+// errSkippedShutdown is what recoverTransaction returns when callHandler's
+// recoverCtx.Done() fired for a reason other than TransactionTimeout elapsing
+// (in practice, the parent context being cancelled by Stop()). Like
+// errSkippedInFlight, no timing-related conclusion about the transaction
+// itself can be drawn, so it must not be counted, logged, or alerted on as a
+// timeout or a failure.
+var errSkippedShutdown = errors.New("recovery: transaction skipped, attempt interrupted by shutdown")
 
 //go:generate counterfeiter -o mock/storage.go -fake-name Storage . Storage
 
@@ -67,6 +104,66 @@ type Manager struct {
 	wg      sync.WaitGroup
 	started bool
 	mu      sync.Mutex
+
+	// timeoutCounts tracks, per txID, how many consecutive attempts have hit
+	// the TransactionTimeout deadline, and when that was last recorded. It
+	// only exists for the log escalation in recoverTransaction; it is
+	// best-effort in-memory state (reset on restart, or if leadership moves to
+	// another replica) and never changes a transaction's stored status.
+	// pruneTimeoutCounts drops entries older than timeoutCountTTL.
+	timeoutCounts map[string]timeoutEntry
+	timeoutMu     sync.Mutex
+
+	// inFlight tracks txIDs with a callHandler goroutine still running past
+	// its TransactionTimeout deadline. A stuck transaction stays Pending and
+	// is re-claimed on every sweep, so without this guard each sweep would
+	// start a fresh goroutine for it: unbounded goroutine growth, and
+	// duplicate concurrent Recover calls for the same txID, which defeats the
+	// mutual exclusion the claim lease exists to provide (Recover reaches
+	// Commit). It is also what runSweep checks to decide whether recovery
+	// leadership must be held across sweeps rather than released at the end
+	// of this one: see the leadership field below.
+	inFlight   map[string]struct{}
+	inFlightMu sync.Mutex
+
+	// leadership is the recovery leadership lease currently held by this
+	// instance, or nil if not held. It is touched only by runSweep, which
+	// always runs on the single recoveryLoop goroutine, and by Stop, which
+	// only reads/clears it after wg.Wait() guarantees runSweep is no longer
+	// running; no mutex is needed for that reason.
+	//
+	// Round 7 released leadership at the end of every sweep unconditionally,
+	// relying on this instance winning the advisory lock again on its next
+	// tick to reclaim (and thereby renew the lease on) any row still
+	// abandoned in inFlight. That assumption does not hold: AcquireRecoveryLeadership
+	// is a non-blocking try-lock (runSweep gives up for this tick if it is
+	// not acquired), so a different replica can legitimately win it on the
+	// very next sweep and this instance would then never call
+	// ClaimPendingTransactions again for that row. Its lease then lapses on
+	// schedule and a live peer can claim and run Recover -> Commit against it
+	// while this instance's abandoned goroutine is still silently running:
+	// exactly the hazard round 7 was meant to close (round 8 review, finding 1).
+	//
+	// So leadership is now held across sweeps for as long as inFlight is
+	// non-empty: as long as this instance keeps leadership, no other replica
+	// can acquire it, so nobody else can claim an abandoned row out from
+	// under this instance, and this instance's own next sweep keeps renewing
+	// that row's lease via ClaimPendingTransactions exactly as before. Once
+	// inFlight drains back to empty, leadership reverts to being released at
+	// the end of each sweep, same as pre-round-8 behaviour, so a healthy,
+	// unstuck instance still rotates leadership fairly with its peers. Stop
+	// always releases leadership if held, regardless of inFlight: an
+	// abandoned goroutine that outlives Stop() is already documented as
+	// running unsupervised past shutdown (see finishAbandonedRecovery), and
+	// this instance can no longer productively use leadership once its sweep
+	// loop has exited, so holding onto it would only block live peers.
+	leadership Leadership
+}
+
+// timeoutEntry is the value type of Manager.timeoutCounts.
+type timeoutEntry struct {
+	count    int
+	lastSeen time.Time
 }
 
 // NewManager creates a new recovery manager
@@ -77,10 +174,12 @@ func NewManager(
 	config Config,
 ) *Manager {
 	return &Manager{
-		logger:  logger,
-		storage: storage,
-		handler: handler,
-		config:  config,
+		logger:        logger,
+		storage:       storage,
+		handler:       handler,
+		config:        config,
+		timeoutCounts: make(map[string]timeoutEntry),
+		inFlight:      make(map[string]struct{}),
 	}
 }
 
@@ -103,6 +202,17 @@ func (m *Manager) Start() error {
 		return err
 	}
 
+	m.warnIfLeaseMayExpireMidSweep()
+	m.warnIfLeaseMayExpireBetweenSweeps()
+
+	if m.config.TransactionTimeout <= 0 {
+		// A ctx-blind Recover call (see callHandler) can only be bounded by a
+		// deadline, not by cancellation, so disabling transactionTimeout
+		// removes the one thing that can interrupt a hung call: Stop() itself
+		// then blocks on it, wedging every later Start/Stop too.
+		m.logger.Warnf("recovery: transactionTimeout is disabled (0); a Recover call that ignores its context can block Stop() indefinitely")
+	}
+
 	if m.config.InstanceID == "" {
 		m.config.InstanceID = fmt.Sprintf("recovery-%p", m)
 	}
@@ -116,8 +226,8 @@ func (m *Manager) Start() error {
 	m.wg.Add(1)
 	go m.recoveryLoop()
 
-	m.logger.Infof("transaction recovery manager started (TTL: %s, Scan Interval: %s, Batch Size: %d, Workers: %d, Lease Duration: %s, Instance ID: %s)",
-		m.config.TTL, m.config.ScanInterval, m.config.BatchSize, m.config.WorkerCount, m.config.LeaseDuration, m.config.InstanceID)
+	m.logger.Infof("transaction recovery manager started (TTL: %s, Scan Interval: %s, Batch Size: %d, Workers: %d, Lease Duration: %s, Transaction Timeout: %s, Instance ID: %s)",
+		m.config.TTL, m.config.ScanInterval, m.config.BatchSize, m.config.WorkerCount, m.config.LeaseDuration, m.config.TransactionTimeout, m.config.InstanceID)
 
 	return nil
 }
@@ -134,6 +244,7 @@ func (m *Manager) Stop() error {
 	m.logger.Infof("stopping transaction recovery manager")
 	m.cancel()
 	m.wg.Wait()
+	m.releaseLeadership()
 	m.started = false
 	m.logger.Infof("transaction recovery manager stopped")
 
@@ -207,28 +318,116 @@ func (m *Manager) validateConfig() error {
 		return errors.Errorf("invalid recovery worker count [%d]", m.config.WorkerCount)
 	case m.config.LeaseDuration <= 0:
 		return errors.Errorf("invalid recovery lease duration [%s]", m.config.LeaseDuration)
+	case m.config.TransactionTimeout < 0:
+		return errors.Errorf("invalid recovery transaction timeout [%s]", m.config.TransactionTimeout)
 	default:
 		return nil
 	}
 }
 
+// warnIfLeaseMayExpireMidSweep logs an advisory Warn when the worst-case time
+// a single worker can spend on its share of one sweep's batch — up to
+// TransactionTimeout per claim, times ceil(BatchSize/WorkerCount) claims per
+// worker — could reach or exceed LeaseDuration. This is the invariant the docs
+// describe (leaseDuration > (batchSize/workerCount) x transactionTimeout), not
+// the simpler transactionTimeout < leaseDuration this package enforced through
+// round 6: that comparison was both the wrong relationship (it ignores
+// BatchSize/WorkerCount entirely) and unnecessarily fatal. Since round 7 a
+// claim whose local attempt is still running is held, not released, until
+// finishAbandonedRecovery's goroutine actually completes (see callHandler), so
+// this is no longer a correctness requirement for that specific hazard, only a
+// throughput one: a sweep that runs long enough can have its own claim lease
+// on a not-yet-reached record expire and get picked up by another replica.
+// Hence Warn, not a Start() failure.
+func (m *Manager) warnIfLeaseMayExpireMidSweep() {
+	if m.config.TransactionTimeout <= 0 || m.config.WorkerCount <= 0 {
+		return
+	}
+	perWorker := (m.config.BatchSize + m.config.WorkerCount - 1) / m.config.WorkerCount
+	worstCase := time.Duration(perWorker) * m.config.TransactionTimeout
+	if worstCase >= m.config.LeaseDuration {
+		m.logger.Warnf("recovery: worst-case sweep duration (%d claim(s)/worker x transactionTimeout %s = %s) may reach or exceed leaseDuration %s; some claims could be reclaimed by another replica before this sweep reaches them",
+			perWorker, m.config.TransactionTimeout, worstCase, m.config.LeaseDuration)
+	}
+}
+
+// warnIfLeaseMayExpireBetweenSweeps logs an advisory Warn when ScanInterval is
+// not comfortably shorter than LeaseDuration.
+//
+// A transaction whose Recover call is still running past its
+// TransactionTimeout keeps its claim: the claim is not released, and it is
+// re-affirmed (recovery_claim_expires_at pushed out again) as a side effect of
+// this instance's own next ClaimPendingTransactions call reclaiming the same
+// still-Pending row, exactly as it already does every sweep for a stuck
+// transaction (see the inFlight doc comment). Since round 8, runSweep holds
+// recovery leadership across sweeps for as long as inFlight is non-empty
+// specifically so this instance keeps winning that reclaim rather than
+// leaving it to chance (see the leadership field doc comment). That
+// reclaim still only arrives on time if this instance's sweeps run more often
+// than the lease can expire. If ScanInterval is close to or exceeds
+// LeaseDuration, a stuck transaction's claim can lapse in the gap between
+// this instance's own sweeps, and be picked up by another replica while the
+// original attempt is still abandoned in the background.
+func (m *Manager) warnIfLeaseMayExpireBetweenSweeps() {
+	if m.config.TransactionTimeout <= 0 {
+		// No abandoned-goroutine hazard without a bounded attempt: nothing here
+		// depends on renewal-by-reclaim.
+		return
+	}
+	if m.config.ScanInterval >= m.config.LeaseDuration {
+		m.logger.Warnf("recovery: scanInterval %s is not shorter than leaseDuration %s; a stuck transaction's claim could expire between sweeps and be reclaimed by another replica while this instance's attempt is still running",
+			m.config.ScanInterval, m.config.LeaseDuration)
+	}
+}
+
 func (m *Manager) runSweep(ctx context.Context) error {
-	leadership, acquired, err := m.storage.AcquireRecoveryLeadership(ctx)
-	if err != nil {
-		return errors.Wrapf(err, "failed to acquire recovery leadership")
-	}
-	if !acquired {
-		m.logger.Debugf("recovery leadership not acquired")
+	m.pruneTimeoutCounts()
 
-		return nil
-	}
-	defer func() {
-		if err := leadership.Close(); err != nil {
-			m.logger.Warnf("failed to release recovery leadership: %v", err)
+	if m.leadership == nil {
+		leadership, acquired, err := m.storage.AcquireRecoveryLeadership(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "failed to acquire recovery leadership")
 		}
-	}()
+		if !acquired {
+			m.logger.Debugf("recovery leadership not acquired")
 
-	return m.recoverTransactions(ctx)
+			return nil
+		}
+		m.leadership = leadership
+	}
+
+	sweepErr := m.recoverTransactions(ctx)
+
+	// Only release leadership once nothing is left abandoned in inFlight: see
+	// the leadership field's doc comment for why holding it across sweeps
+	// while inFlight is non-empty is what keeps this instance's own reclaim
+	// renewing an abandoned row's lease, instead of leaving that to chance.
+	if !m.hasInFlight() {
+		m.releaseLeadership()
+	}
+
+	return sweepErr
+}
+
+// hasInFlight reports whether any txID currently has a callHandler goroutine
+// running past its TransactionTimeout deadline.
+func (m *Manager) hasInFlight() bool {
+	m.inFlightMu.Lock()
+	defer m.inFlightMu.Unlock()
+
+	return len(m.inFlight) > 0
+}
+
+// releaseLeadership closes the currently-held recovery leadership lease, if
+// any, and clears it. Safe to call when no leadership is held.
+func (m *Manager) releaseLeadership() {
+	if m.leadership == nil {
+		return
+	}
+	if err := m.leadership.Close(); err != nil {
+		m.logger.Warnf("failed to release recovery leadership: %v", err)
+	}
+	m.leadership = nil
 }
 
 // recoverTransactions claims pending transactions and re-registers finality listeners using local workers.
@@ -264,7 +463,7 @@ func (m *Manager) recoverTransactions(ctx context.Context) error {
 		go m.worker(ctx, &workerWG, work, errCh)
 	}
 
-	dispatched, fanOutErr := m.fanOut(ctx, records, work)
+	dispatched, skippedNil, fanOutErr := m.fanOut(ctx, records, work)
 	close(work)
 
 	workerWG.Wait()
@@ -272,8 +471,18 @@ func (m *Manager) recoverTransactions(ctx context.Context) error {
 
 	var firstErr error
 	failures := 0
+	skipped := 0
 	for err := range errCh {
 		if err == nil {
+			continue
+		}
+		if errors.Is(err, errSkippedInFlight) || errors.Is(err, errSkippedShutdown) {
+			// Not a failure: recoverTransaction made no attempt at all (still
+			// in flight), or its attempt was interrupted by shutdown rather
+			// than actually failing, so neither must be logged as one or
+			// count toward firstErr.
+			skipped++
+
 			continue
 		}
 		failures++
@@ -288,10 +497,35 @@ func (m *Manager) recoverTransactions(ctx context.Context) error {
 	// against len(records): a cancelled fan-out leaves the tail undispatched,
 	// and those claims never reach errCh. Attributing them to len(records)-failures
 	// would report never-attempted work as succeeded.
-	if failures > 0 || dispatched < len(records) {
-		m.logger.Warnf("completed recovery sweep: claimed=%d, dispatched=%d, succeeded=%d, failed=%d",
-			len(records), dispatched, dispatched-failures, failures)
-	} else {
+	succeeded := dispatched - failures - skipped
+	// considered is what fanOut actually finished looking at: real dispatches
+	// plus nil entries it stepped over without sending anywhere. dispatched
+	// alone undercounts len(records) whenever a nil entry is present (fanOut
+	// never sends those to a worker, so they never reach errCh either), which
+	// would otherwise make dispatched < len(records) permanently true and
+	// silently suppress the "all skipped" warning below on exactly the sweep
+	// where it matters most.
+	considered := dispatched + skippedNil
+	switch {
+	case skipped > 0 && skipped == dispatched && considered == len(records):
+		// Every claimed transaction was either dispatched or a defensive nil
+		// skip, and every dispatched transaction hit the in-flight guard: the
+		// sweep made no progress at all, even though nothing "failed".
+		// Debug-level "all succeeded" would read as healthy and hide that.
+		// The considered == len(records) half of this condition matters too:
+		// without it, a fan-out cancelled mid-batch after dispatching only
+		// skips would also print "all skipped", overstating what the sweep
+		// even attempted.
+		m.logger.Warnf("completed recovery sweep: claimed=%d, all skipped (previous attempts still in flight), no progress made", len(records))
+	case failures > 0 || skipped > 0 || considered < len(records):
+		// skipped > 0 here means a mix of skips and real outcomes, or a
+		// cancelled fan-out (the all-skipped case above already returned
+		// otherwise), so this is not "fully wedged" the way the case above
+		// is, just worth surfacing the breakdown rather than reporting a
+		// clean "all succeeded".
+		m.logger.Warnf("completed recovery sweep: claimed=%d, dispatched=%d, succeeded=%d, failed=%d, skipped=%d",
+			len(records), dispatched, succeeded, failures, skipped)
+	default:
 		m.logger.Debugf("completed recovery sweep: claimed=%d, all succeeded", len(records))
 	}
 
@@ -315,13 +549,17 @@ func (m *Manager) recoverTransactions(ctx context.Context) error {
 // and Stop's wg.Wait() would hang while holding m.mu, wedging every later
 // Start/Stop call.
 //
-// It returns the number of claims actually handed to a worker. Callers need
-// this to report the sweep outcome: claims left undispatched by a cancellation
-// never reach errCh, so they cannot be inferred from the failure count.
-func (m *Manager) fanOut(ctx context.Context, records []*ttxdb.RecoveryClaim, work chan<- *ttxdb.RecoveryClaim) (int, error) {
-	dispatched := 0
+// It returns the number of claims actually handed to a worker, and the number
+// of nil entries stepped over along the way. Callers need both to report the
+// sweep outcome: claims left undispatched by a cancellation never reach errCh,
+// so they cannot be inferred from the failure count, and a nil entry is
+// neither a dispatch nor a cancellation but still must count as "considered"
+// or the completeness check in recoverTransactions never reaches len(records).
+func (m *Manager) fanOut(ctx context.Context, records []*ttxdb.RecoveryClaim, work chan<- *ttxdb.RecoveryClaim) (dispatched int, skippedNil int, err error) {
 	for i, claim := range records {
 		if claim == nil {
+			skippedNil++
+
 			continue
 		}
 		select {
@@ -330,11 +568,11 @@ func (m *Manager) fanOut(ctx context.Context, records []*ttxdb.RecoveryClaim, wo
 		case <-ctx.Done():
 			m.logger.Debugf("recovery fan-out cancelled: %d of %d claim(s) not dispatched", len(records)-i, len(records))
 
-			return dispatched, errors.Wrapf(ctx.Err(), "recovery fan-out cancelled")
+			return dispatched, skippedNil, errors.Wrapf(ctx.Err(), "recovery fan-out cancelled")
 		}
 	}
 
-	return dispatched, nil
+	return dispatched, skippedNil, nil
 }
 
 func (m *Manager) worker(ctx context.Context, wg *sync.WaitGroup, work <-chan *ttxdb.RecoveryClaim, errCh chan<- error) {
@@ -355,33 +593,323 @@ func (m *Manager) worker(ctx context.Context, wg *sync.WaitGroup, work <-chan *t
 	}
 }
 
-// recoverTransaction attempts to recover a transaction using the injected handler
-// and always releases the claim with an appropriate message.
+// callHandler invokes the handler's Recover, bounded by TransactionTimeout.
+//
+// context.WithTimeout alone only signals cancellation, it cannot interrupt a
+// callee that never reads the context, and the ledger status query behind
+// Recover is exactly that on some backends (e.g. FSC's fabric
+// Ledger.GetTransactionByID takes no context at all). So Recover is run in
+// its own goroutine and callHandler gives up as soon as recoverCtx is done,
+// instead of waiting for the call to return. On a real hang, the goroutine is
+// abandoned: it leaks until the underlying blocking call eventually returns
+// (or the process exits). That is the accepted cost of bounding a call this
+// package does not control the cancellation semantics of; the alternative is
+// leaving the worker (and the leadership it holds for the whole sweep)
+// blocked indefinitely, which is the bug this exists to fix.
+//
+// finished reports whether callHandler has a final result to act on now. It
+// is false in two cases, both meaning a goroutine is still running
+// unsupervised by this call: a previous attempt for txID is still in flight
+// (errRecoveryInFlight), or this attempt's own recoverCtx just timed out with
+// nothing in resultCh yet. Round 7 changed what happens next in the
+// finished == false case: earlier rounds returned immediately and let the
+// caller release the claim regardless, which is exactly what let a second
+// replica claim and run a concurrent Recover -> Commit against the same tx
+// while the first replica's abandoned goroutine was still running. Now the
+// claim is deliberately left alone (see recoverTransaction) and
+// finishAbandonedRecovery takes over responsibility for clearing inFlight and
+// releasing it, once the goroutine actually returns, however long that takes.
+//
+// A stuck transaction stays Pending and is re-claimed on every sweep, so
+// without the tryMarkInFlight guard below each sweep would abandon another
+// goroutine for the same txID: unbounded goroutine growth, and duplicate
+// concurrent Recover calls racing each other to Commit for the same tx. That
+// same re-claim is also what keeps the DB claim itself alive while
+// finishAbandonedRecovery waits: see the inFlight field's doc comment.
+//
+// TransactionTimeout == 0 means "unbounded" (see LoadConfig / validateConfig):
+// Recover is then called directly on ctx, with no derived deadline, no
+// in-flight guard, and no extra goroutine, so a ctx-blind call can block
+// Stop() indefinitely (Start logs a Warn about this when the timeout is
+// disabled).
+func (m *Manager) callHandler(ctx context.Context, txID string, storedAt time.Time) (finished bool, err error) {
+	if m.config.TransactionTimeout <= 0 {
+		return true, m.handler.Recover(ctx, txID)
+	}
+
+	if !m.tryMarkInFlight(txID) {
+		return false, errRecoveryInFlight
+	}
+
+	recoverCtx, cancel := context.WithTimeout(ctx, m.config.TransactionTimeout)
+
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- m.handler.Recover(recoverCtx, txID)
+	}()
+
+	select {
+	case result := <-resultCh:
+		cancel()
+		m.clearInFlight(txID)
+
+		return true, result
+	case <-recoverCtx.Done():
+		if ok, result := preferResult(resultCh); ok {
+			cancel()
+			m.clearInFlight(txID)
+
+			return true, result
+		}
+
+		//nolint:gosec // G118: deliberate, not an oversight, finishAbandonedRecovery's doc comment explains why it cannot use ctx or m.ctx for the release call itself; ctx is passed only as a stable snapshot to check against later.
+		go m.finishAbandonedRecovery(ctx, txID, storedAt, resultCh, cancel)
+
+		return false, recoverCtx.Err()
+	}
+}
+
+// preferResult performs a non-blocking check of resultCh, for the moment
+// recoverCtx's deadline fires: Go's select picks pseudo-randomly among
+// simultaneously-ready cases, so a handler result that arrived at the same
+// instant as the deadline can otherwise be discarded as a timeout even though
+// the recovery genuinely succeeded. ok reports whether a result was actually
+// there; callers use it to tell "genuinely finished, race lost the select"
+// from "still running", which need different handling (see callHandler).
+func preferResult(resultCh <-chan error) (ok bool, err error) {
+	select {
+	case err := <-resultCh:
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+// finishAbandonedRecovery waits for a Recover call that already outlived its
+// TransactionTimeout to actually return, then performs the cleanup
+// recoverTransaction deliberately skipped for it: releasing the claim with
+// the real outcome via finishRecovery, and only then clearing inFlight.
+//
+// That order matters (round 8 review, finding 2): clearing inFlight first
+// would let a sweep that reclaims txID between clearInFlight and finishRecovery's
+// release start a brand new Recover call, and then have this goroutine's
+// finishRecovery release the claim and overwrite status_message out from
+// under that fresh attempt. Keeping inFlight set until the release actually
+// completes means any such reclaim in that window is turned away by
+// tryMarkInFlight and simply retried on a later sweep instead.
+//
+// This runs detached from both the sweep that started it and from Stop(): a
+// call that already outlived one deadline may run for an unbounded time (see
+// callHandler's doc comment above), so by the time it finally returns, the
+// sweep's own ctx has long since completed and m.ctx may already be cancelled
+// by Stop(). Tying this goroutine's cleanup to either would mean the release
+// either never happens or is attempted with an already-cancelled context;
+// context.Background() below is deliberate for the same reason. A release
+// call that itself hangs (e.g. the store is unreachable) blocks only this one
+// detached goroutine, the same accepted leak shape as the Recover call it is
+// finishing up after.
+//
+// sweepCtx is the context callHandler was itself called with, i.e. the
+// specific sweep's ctx at the moment this attempt was abandoned, not
+// m.ctx read live, which is a Manager field a later Start() can reassign
+// (see Start) while this detached goroutine is still running, making a live
+// read of m.ctx a data race. A context.Context is safe for concurrent use by
+// design, and this specific one does not change once captured: it only ever
+// transitions from not-done to done, so reading its Err() here needs no
+// further synchronization. sweepCtx.Err() being non-nil records whether Stop()
+// had already run, for this lifecycle, before this call finally returned,
+// i.e. whether this instance no longer necessarily held recovery leadership
+// continuously on txID's behalf (Stop always releases leadership regardless
+// of inFlight, see the leadership field). finishRecovery uses that to decide
+// whether the Orphan-promotion heuristic is still safe to apply (round 8
+// review, finding 3).
+func (m *Manager) finishAbandonedRecovery(sweepCtx context.Context, txID string, storedAt time.Time, resultCh <-chan error, cancel context.CancelFunc) {
+	err := <-resultCh
+	cancel()
+	stoppedBeforeReturn := sweepCtx.Err() != nil
+	m.logger.Infof("recovery: tx [%s] finished after previously timing out; finalizing now", txID)
+
+	if releaseErr := m.finishRecovery(context.Background(), txID, storedAt, err, !stoppedBeforeReturn); releaseErr != nil {
+		m.logger.Warnf("recovery: abandoned attempt for transaction [%s] finished with an error: %v", txID, releaseErr)
+	}
+
+	m.clearInFlight(txID)
+}
+
+// tryMarkInFlight reports whether txID was not already in flight, marking it
+// so as a side effect. The caller must pair a true result with a later
+// clearInFlight once the underlying attempt actually finishes.
+func (m *Manager) tryMarkInFlight(txID string) bool {
+	m.inFlightMu.Lock()
+	defer m.inFlightMu.Unlock()
+	if _, ok := m.inFlight[txID]; ok {
+		return false
+	}
+	m.inFlight[txID] = struct{}{}
+
+	return true
+}
+
+func (m *Manager) clearInFlight(txID string) {
+	m.inFlightMu.Lock()
+	defer m.inFlightMu.Unlock()
+	delete(m.inFlight, txID)
+}
+
+// recordTimeout increments and returns the consecutive-timeout count for txID.
+func (m *Manager) recordTimeout(txID string) int {
+	m.timeoutMu.Lock()
+	defer m.timeoutMu.Unlock()
+	entry := m.timeoutCounts[txID]
+	entry.count++
+	entry.lastSeen = time.Now()
+	m.timeoutCounts[txID] = entry
+
+	return entry.count
+}
+
+// clearTimeoutCount resets the consecutive-timeout count for txID, e.g. once
+// an attempt succeeds or fails for a reason other than a timeout.
+func (m *Manager) clearTimeoutCount(txID string) {
+	m.timeoutMu.Lock()
+	defer m.timeoutMu.Unlock()
+	delete(m.timeoutCounts, txID)
+}
+
+// pruneTimeoutCounts drops entries untouched for longer than timeoutCountTTL.
+// clearTimeoutCount only fires when this manager reattempts the same txID; a
+// transaction that times out and is then confirmed by an independent
+// finality listener leaves the Pending scan range and is never reattempted,
+// so its entry would otherwise never be removed. Called once per sweep
+// rather than per timeout to keep the cost off the hot path.
+func (m *Manager) pruneTimeoutCounts() {
+	cutoff := time.Now().Add(-timeoutCountTTL)
+
+	m.timeoutMu.Lock()
+	defer m.timeoutMu.Unlock()
+	for txID, entry := range m.timeoutCounts {
+		if entry.lastSeen.Before(cutoff) {
+			delete(m.timeoutCounts, txID)
+		}
+	}
+}
+
+// maybeAlertStuckTransaction logs at Error once count crosses
+// StuckTransactionAlertThreshold, then backs off by doubling (threshold, 2x,
+// 4x, 8x, ...) instead of logging on every sweep. A stuck transaction is
+// re-claimed every scan interval, so an unthrottled log here would flood
+// alerting at that rate for as long as it stays stuck, which tends to get the
+// whole alert muted rather than actually surfacing it.
+func (m *Manager) maybeAlertStuckTransaction(txID string, count int) {
+	threshold := m.config.StuckTransactionAlertThreshold
+	if threshold <= 0 || count < threshold {
+		return
+	}
+	if count != threshold && (count%threshold != 0 || !isPowerOfTwo(count/threshold)) {
+		return
+	}
+	m.logger.Errorf("recovery: tx [%s] has timed out %d consecutive times (transactionTimeout=%s), status still unknown, investigate peer/network health", txID, count, m.config.TransactionTimeout)
+}
+
+func isPowerOfTwo(n int) bool {
+	return n > 0 && n&(n-1) == 0
+}
+
+// recoverTransaction attempts to recover a transaction using the injected
+// handler. The claim is released exactly once, with an appropriate message,
+// for whichever of two paths actually produces a final result first: here,
+// synchronously, if the handler returns within TransactionTimeout, or later,
+// asynchronously by finishAbandonedRecovery, if it does not (see callHandler).
+func (m *Manager) recoverTransaction(ctx context.Context, txID string, storedAt time.Time) error {
+	m.logger.Debugf("recovering transaction [%s]", txID)
+
+	finished, err := m.callHandler(ctx, txID, storedAt)
+
+	if !finished {
+		// A goroutine is still running unsupervised by this call, for one of
+		// three reasons, and the claim must NOT be released here regardless
+		// of which: doing so, as pre-round-7 code did, is what let a second
+		// replica claim and run a concurrent Recover -> Commit against the
+		// same tx while the original attempt was still in flight. The claim
+		// stays held; finishAbandonedRecovery releases it once that attempt
+		// actually returns, whenever that is.
+		if errors.Is(err, errRecoveryInFlight) {
+			// A previous attempt for this txID is already running past its
+			// own TransactionTimeout: this is genuinely stuck from this
+			// sweep's point of view.
+			count := m.recordTimeout(txID)
+			m.maybeAlertStuckTransaction(txID, count)
+			m.logger.Debugf("recovery: tx [%s] skipped, a previous attempt is still running past transactionTimeout (%d consecutive timeout(s))", txID, count)
+
+			return errSkippedInFlight
+		}
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			// recoverCtx.Done() fired for a reason other than
+			// TransactionTimeout elapsing: in practice, ctx's parent (m.ctx)
+			// was cancelled by Stop(). A clean shutdown catching an attempt
+			// mid-flight is not evidence the transaction itself is stuck, so
+			// unlike the two cases above it must not count toward, or alert
+			// on, the consecutive-timeout tally (round 8 review, finding 4).
+			m.logger.Debugf("recovery: tx [%s] recovery attempt interrupted (%v), claim held for finishAbandonedRecovery to release", txID, err)
+
+			return errSkippedShutdown
+		}
+
+		// This attempt's own deadline just fired with nothing back yet: a
+		// real, this-attempt timeout.
+		count := m.recordTimeout(txID)
+		m.maybeAlertStuckTransaction(txID, count)
+		m.logger.Debugf("recovery: tx [%s] still running past transactionTimeout, claim held for finishAbandonedRecovery to release (%d consecutive timeout(s))", txID, count)
+
+		return errors.Wrapf(err, "recovery timed out for transaction [%s]", txID)
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		count := m.recordTimeout(txID)
+		m.maybeAlertStuckTransaction(txID, count)
+	} else {
+		m.clearTimeoutCount(txID)
+	}
+
+	return m.finishRecovery(ctx, txID, storedAt, err, true)
+}
+
+// finishRecovery applies the Orphan-promotion policy and releases the claim
+// with an outcome message, given a final result for txID. Called
+// synchronously by recoverTransaction on the normal, within-deadline path,
+// and asynchronously by finishAbandonedRecovery once an attempt that outlived
+// its own deadline actually completes; either way this is called exactly once
+// per attempt, whichever path resolves first, and is the only place that
+// releases the claim.
 //
 // If the handler reports the transaction is not on the ledger and the row was
 // stored more than NotFoundGracePeriod ago, the row is force-marked Orphan to
 // prevent the queue head from being permanently blocked by transactions that
 // never reached the ledger (e.g. broadcast failures whose audit log was
 // persisted but whose tx never reached the orderer). Without this,
-// ORDER BY stored_at ASC + LIMIT BatchSize would replay the same oldest-100
-// rows on every sweep forever. The status is deliberately distinct from
-// Deleted so operators and downstream tooling can tell broadcast losses apart
-// from txs the ledger actively rejected.
-func (m *Manager) recoverTransaction(ctx context.Context, txID string, storedAt time.Time) error {
-	m.logger.Debugf("recovering transaction [%s]", txID)
-
-	// Attempt recovery using the injected handler
-	err := m.handler.Recover(ctx, txID)
-
-	// Residual race: SetStatus is unconditional, so an independent finality
-	// listener that confirms this tx between our claim and the write below
-	// could be overwritten by Orphan. In practice the NotFoundGracePeriod
-	// (default 30 min) makes this window vanishingly small — we only get
-	// here when the tx has been Pending for grace+ AND Recover just returned
-	// NotFound. Future hardening: replace SetStatus with an atomic
-	// "status=Pending → Orphan" CAS at the SQL layer.
+// ORDER BY stored_at ASC + LIMIT BatchSize would replay the same oldest rows
+// on every sweep forever. The status is deliberately distinct from Deleted so
+// operators and downstream tooling can tell broadcast losses apart from txs
+// the ledger actively rejected.
+//
+// allowOrphanPromotion gates that write. The synchronous call site always
+// passes true: it runs while this instance still holds recovery leadership
+// for the sweep in progress, so nothing else can have raced ahead on txID.
+// finishAbandonedRecovery passes false once it observes the sweep's own ctx
+// already cancelled (Stop() ran before this attempt finally returned): Stop always
+// releases leadership regardless of inFlight (see the leadership field), so a
+// live peer could since have legitimately reclaimed and resolved txID, to
+// say Confirmed, while this attempt was still finishing in the background.
+// SetStatus is unconditional and owner-blind, unlike the owner-scoped release
+// below it, so an unguarded write here could stomp that outcome with a stale
+// Orphan (round 8 review, finding 3). Skipping the promotion in that case
+// still releases the claim and logs the real outcome; a true fix needs an
+// owner/status-scoped CAS at the SQL layer, filed as a follow-up rather than
+// widening this PR into the storage driver.
+func (m *Manager) finishRecovery(ctx context.Context, txID string, storedAt time.Time, err error, allowOrphanPromotion bool) error {
 	markedOrphan := false
-	if err != nil && m.config.NotFoundGracePeriod > 0 && !storedAt.IsZero() && isNotFoundError(err) {
+	if allowOrphanPromotion && err != nil && m.config.NotFoundGracePeriod > 0 && !storedAt.IsZero() && isNotFoundError(err) {
 		age := time.Since(storedAt)
 		if age > m.config.NotFoundGracePeriod {
 			orphanMsg := fmt.Sprintf("tx never reached ledger (NotFound after %v, grace=%v)", age.Truncate(time.Second), m.config.NotFoundGracePeriod)

--- a/token/services/storage/services/recovery/manager_internal_test.go
+++ b/token/services/storage/services/recovery/manager_internal_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package recovery
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/token/services/storage"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/ttxdb"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubStorage is a hand-written Storage double, not the counterfeiter mock in
+// this package's mock subpackage: that mock imports this package to reference
+// its interfaces, so an internal (package recovery) test file cannot import
+// it without an import cycle. External tests use the counterfeiter mock; this
+// file needs the internal-test package for direct access to unexported
+// Manager fields and methods.
+type stubStorage struct {
+	releaseFn   func(ctx context.Context, txID, owner, message string) error
+	setStatusFn func(ctx context.Context, txID string, status storage.TxStatus, message string) error
+}
+
+func (s *stubStorage) AcquireRecoveryLeadership(context.Context) (Leadership, bool, error) {
+	return nil, false, nil
+}
+
+func (s *stubStorage) ClaimPendingTransactions(context.Context, time.Duration, time.Duration, int, string) ([]*ttxdb.RecoveryClaim, error) {
+	return nil, nil
+}
+
+func (s *stubStorage) ReleaseRecoveryClaim(ctx context.Context, txID, owner, message string) error {
+	if s.releaseFn != nil {
+		return s.releaseFn(ctx, txID, owner, message)
+	}
+
+	return nil
+}
+
+func (s *stubStorage) SetStatus(ctx context.Context, txID string, status storage.TxStatus, message string) error {
+	if s.setStatusFn != nil {
+		return s.setStatusFn(ctx, txID, status, message)
+	}
+
+	return nil
+}
+
+// TestFinishAbandonedRecovery_ClearsInFlightOnlyAfterReleaseCompletes is the
+// regression test for round 8 review finding 2: clearing inFlight before the
+// release completes lets a sweep that reclaims txID in that window start a
+// second, concurrent Recover call, which the finisher's later release then
+// pulls the rug out from under.
+func TestFinishAbandonedRecovery_ClearsInFlightOnlyAfterReleaseCompletes(t *testing.T) {
+	releaseStarted := make(chan struct{})
+	releaseProceed := make(chan struct{})
+	store := &stubStorage{
+		releaseFn: func(context.Context, string, string, string) error {
+			close(releaseStarted)
+			<-releaseProceed
+
+			return nil
+		},
+	}
+
+	m := NewManager(logging.MustGetLogger(), store, nil, Config{InstanceID: "inst"})
+	//nolint:fatcontext // test double for Start's own field assignment, not a per-request context
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+	defer m.cancel()
+
+	const txID = "tx1"
+	require.True(t, m.tryMarkInFlight(txID))
+
+	resultCh := make(chan error, 1)
+	resultCh <- nil
+	_, cancelRecover := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		m.finishAbandonedRecovery(m.ctx, txID, time.Time{}, resultCh, cancelRecover)
+		close(done)
+	}()
+
+	select {
+	case <-releaseStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("release was never started")
+	}
+
+	assert.False(t, m.tryMarkInFlight(txID),
+		"inFlight must still be held while the release is in progress, or a concurrent sweep could start a second Recover call for the same tx")
+
+	close(releaseProceed)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("finishAbandonedRecovery never returned")
+	}
+
+	assert.True(t, m.tryMarkInFlight(txID), "inFlight must be cleared once the release has actually completed")
+}
+
+// TestFinishAbandonedRecovery_SkipsOrphanPromotionAfterStop is the regression
+// test for round 8 review finding 3: SetStatus is unconditional and
+// owner-blind, unlike the owner-scoped release beside it, so once Stop() has
+// released leadership a live peer could have already resolved txID (e.g. to
+// Confirmed) by the time this detached finisher's NotFound result arrives.
+// Promoting to Orphan in that case would stomp a real outcome with a stale
+// one; finishAbandonedRecovery must skip the promotion once it observes the
+// manager already stopped.
+func TestFinishAbandonedRecovery_SkipsOrphanPromotionAfterStop(t *testing.T) {
+	setStatusCalls := 0
+	store := &stubStorage{
+		setStatusFn: func(context.Context, string, storage.TxStatus, string) error {
+			setStatusCalls++
+
+			return nil
+		},
+	}
+
+	m := NewManager(logging.MustGetLogger(), store, nil, Config{
+		InstanceID:          "inst",
+		NotFoundGracePeriod: time.Millisecond,
+	})
+	//nolint:fatcontext // test double for Start's own field assignment, not a per-request context
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+	m.cancel() // simulate Stop() having already run before this attempt returns
+
+	const txID = "tx1"
+	m.tryMarkInFlight(txID)
+
+	resultCh := make(chan error, 1)
+	resultCh <- errors.New("rpc error: code = NotFound desc = transaction ID [tx1]: not found in index: tx not found")
+	_, cancelRecover := context.WithCancel(context.Background())
+
+	storedAt := time.Now().Add(-time.Hour) // well past the 1ms grace period
+
+	m.finishAbandonedRecovery(m.ctx, txID, storedAt, resultCh, cancelRecover)
+
+	assert.Equal(t, 0, setStatusCalls,
+		"must not promote to Orphan once Stop() has already run: a live peer may have since resolved txID and SetStatus has no owner/status guard to protect that outcome")
+}
+
+// TestPreferResult exercises the tie-break directly, without relying on real
+// goroutine/timer timing to force the race between a handler result and a
+// deadline firing at the same instant.
+func TestPreferResult(t *testing.T) {
+	t.Run("returns the result and ok=true when it arrived before the deadline fired", func(t *testing.T) {
+		resultCh := make(chan error, 1)
+		resultCh <- nil
+
+		ok, err := preferResult(resultCh)
+		assert.True(t, ok)
+		assert.NoError(t, err)
+	})
+
+	t.Run("reports ok=false when the handler has not finished yet", func(t *testing.T) {
+		resultCh := make(chan error, 1)
+
+		ok, _ := preferResult(resultCh)
+		assert.False(t, ok)
+	})
+}
+
+func TestIsPowerOfTwo(t *testing.T) {
+	assert.False(t, isPowerOfTwo(0))
+	assert.False(t, isPowerOfTwo(-2))
+	assert.True(t, isPowerOfTwo(1))
+	assert.True(t, isPowerOfTwo(2))
+	assert.False(t, isPowerOfTwo(3))
+	assert.True(t, isPowerOfTwo(4))
+	assert.False(t, isPowerOfTwo(5))
+	assert.True(t, isPowerOfTwo(8))
+}

--- a/token/services/storage/services/recovery/manager_test.go
+++ b/token/services/storage/services/recovery/manager_test.go
@@ -9,7 +9,9 @@ package recovery_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -23,18 +25,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// recordingLogger wraps the package's no-op MockLogger and records Errorf
+// calls, so the escalation tests can assert on when the alert fires without
+// depending on the real zap-backed logger's output.
+type recordingLogger struct {
+	logging.MockLogger
+	mu       sync.Mutex
+	messages []string
+}
+
+func (l *recordingLogger) Errorf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.messages = append(l.messages, fmt.Sprintf(format, args...))
+}
+
+func (l *recordingLogger) errorMessages() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.messages))
+	copy(out, l.messages)
+
+	return out
+}
+
 func TestNewManager(t *testing.T) {
 	logger := logging.MustGetLogger()
 	mockDB := &mock2.Storage{}
 	mockHandler := &mock2.Handler{}
 	config := recovery2.Config{
-		Enabled:       true,
-		TTL:           30 * time.Second,
-		ScanInterval:  30 * time.Second,
-		BatchSize:     100,
-		WorkerCount:   1,
-		LeaseDuration: 30 * time.Second,
-		InstanceID:    "test-instance",
+		Enabled:            true,
+		TTL:                30 * time.Second,
+		ScanInterval:       30 * time.Second,
+		BatchSize:          100,
+		WorkerCount:        1,
+		LeaseDuration:      30 * time.Second,
+		TransactionTimeout: time.Second,
+		InstanceID:         "test-instance",
 	}
 
 	manager := recovery2.NewManager(
@@ -52,13 +79,14 @@ func TestManager_StartStop(t *testing.T) {
 	mockDB := &mock2.Storage{}
 	mockHandler := &mock2.Handler{}
 	config := recovery2.Config{
-		Enabled:       true,
-		TTL:           100 * time.Millisecond,
-		ScanInterval:  100 * time.Millisecond,
-		BatchSize:     100,
-		WorkerCount:   1,
-		LeaseDuration: time.Second,
-		InstanceID:    "test-instance",
+		Enabled:            true,
+		TTL:                100 * time.Millisecond,
+		ScanInterval:       100 * time.Millisecond,
+		BatchSize:          100,
+		WorkerCount:        1,
+		LeaseDuration:      time.Second,
+		TransactionTimeout: 500 * time.Millisecond,
+		InstanceID:         "test-instance",
 	}
 
 	leadership := &mock2.Leadership{}
@@ -97,13 +125,14 @@ func TestManager_RecoverTransaction(t *testing.T) {
 	mockDB := &mock2.Storage{}
 	mockHandler := &mock2.Handler{}
 	config := recovery2.Config{
-		Enabled:       true,
-		TTL:           100 * time.Millisecond,
-		ScanInterval:  100 * time.Millisecond,
-		BatchSize:     100,
-		WorkerCount:   1,
-		LeaseDuration: time.Second,
-		InstanceID:    "test-instance",
+		Enabled:            true,
+		TTL:                100 * time.Millisecond,
+		ScanInterval:       100 * time.Millisecond,
+		BatchSize:          100,
+		WorkerCount:        1,
+		LeaseDuration:      time.Second,
+		TransactionTimeout: 500 * time.Millisecond,
+		InstanceID:         "test-instance",
 	}
 
 	// Create a pending transaction claim
@@ -152,13 +181,14 @@ func TestManager_SkipAlreadyRecovered(t *testing.T) {
 	mockDB := &mock2.Storage{}
 	mockHandler := &mock2.Handler{}
 	config := recovery2.Config{
-		Enabled:       true,
-		TTL:           50 * time.Millisecond,
-		ScanInterval:  50 * time.Millisecond,
-		BatchSize:     100,
-		WorkerCount:   1,
-		LeaseDuration: time.Second,
-		InstanceID:    "test-instance",
+		Enabled:            true,
+		TTL:                50 * time.Millisecond,
+		ScanInterval:       50 * time.Millisecond,
+		BatchSize:          100,
+		WorkerCount:        1,
+		LeaseDuration:      time.Second,
+		TransactionTimeout: 500 * time.Millisecond,
+		InstanceID:         "test-instance",
 	}
 
 	// Create a pending transaction claim
@@ -218,6 +248,7 @@ func TestManager_PromoteOrphanOnNotFoundPastGracePeriod(t *testing.T) {
 		BatchSize:           100,
 		WorkerCount:         1,
 		LeaseDuration:       time.Second,
+		TransactionTimeout:  500 * time.Millisecond,
 		InstanceID:          "test-instance",
 		NotFoundGracePeriod: 10 * time.Millisecond,
 	}
@@ -273,6 +304,7 @@ func TestManager_NoPromotionWhenGracePeriodDisabled(t *testing.T) {
 		BatchSize:           100,
 		WorkerCount:         1,
 		LeaseDuration:       time.Second,
+		TransactionTimeout:  500 * time.Millisecond,
 		InstanceID:          "test-instance",
 		NotFoundGracePeriod: 0,
 	}
@@ -328,13 +360,14 @@ func TestManager_StopDuringFanOutDoesNotDeadlock(t *testing.T) {
 	mockDB := &mock2.Storage{}
 	mockHandler := &mock2.Handler{}
 	config := recovery2.Config{
-		Enabled:       true,
-		TTL:           10 * time.Millisecond,
-		ScanInterval:  10 * time.Millisecond,
-		BatchSize:     100,
-		WorkerCount:   1,
-		LeaseDuration: time.Second,
-		InstanceID:    "test-instance",
+		Enabled:            true,
+		TTL:                10 * time.Millisecond,
+		ScanInterval:       10 * time.Millisecond,
+		BatchSize:          100,
+		WorkerCount:        1,
+		LeaseDuration:      time.Second,
+		TransactionTimeout: 500 * time.Millisecond,
+		InstanceID:         "test-instance",
 	}
 
 	// Step 1: many more claims than workers, so the fan-out loop is guaranteed to
@@ -417,6 +450,7 @@ func TestManager_PromoteOrphanOnNoSuchTransactionID(t *testing.T) {
 		BatchSize:           100,
 		WorkerCount:         1,
 		LeaseDuration:       time.Second,
+		TransactionTimeout:  500 * time.Millisecond,
 		InstanceID:          "test-instance",
 		NotFoundGracePeriod: 10 * time.Millisecond,
 	}
@@ -457,13 +491,579 @@ func TestManager_PromoteOrphanOnNoSuchTransactionID(t *testing.T) {
 	assert.Contains(t, gotMsg, "tx never reached ledger")
 }
 
+// TestManager_TransactionTimeoutBoundsHungRecover walks the scenario from
+// issue #2192: a Recover call that never returns on its own (a hung status
+// query). Without a per-transaction deadline, the worker would block forever
+// and, since leadership is held for the whole sweep, no replica would ever
+// recover another pending transaction. The stub here honours ctx.Done() the
+// way a well-behaved caller would, so this proves the manager derives a
+// bounded context for the call; it does not by itself prove the manager
+// survives a handler that ignores that context entirely, see
+// TestManager_TransactionTimeoutBoundsRecoverIgnoringContext for that, which
+// is the shape of the real hang this issue is about (FSC's fabric
+// Ledger.GetTransactionByID takes no context at all).
+func TestManager_TransactionTimeoutBoundsHungRecover(t *testing.T) {
+	logger := logging.MustGetLogger()
+	mockDB := &mock2.Storage{}
+	mockHandler := &mock2.Handler{}
+	config := recovery2.Config{
+		Enabled:            true,
+		TTL:                10 * time.Millisecond,
+		ScanInterval:       100 * time.Millisecond,
+		BatchSize:          100,
+		WorkerCount:        1,
+		LeaseDuration:      time.Second,
+		TransactionTimeout: 50 * time.Millisecond,
+		InstanceID:         "test-instance",
+	}
+
+	txRecord := &ttxdb.RecoveryClaim{TxID: "txHung"}
+
+	leadership1 := &mock2.Leadership{}
+	leadership1.CloseReturns(nil)
+	leadership2 := &mock2.Leadership{}
+	leadership2.CloseReturns(nil)
+
+	mockDB.AcquireRecoveryLeadershipReturnsOnCall(0, leadership1, true, nil)
+	mockDB.AcquireRecoveryLeadershipReturns(leadership2, true, nil)
+	mockDB.ClaimPendingTransactionsReturnsOnCall(0, []*ttxdb.RecoveryClaim{txRecord}, nil)
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{}, nil)
+	mockDB.ReleaseRecoveryClaimReturns(nil)
+
+	// Simulates a hung network call: only returns once its context is cancelled.
+	mockHandler.RecoverStub = func(ctx context.Context, _ string) error {
+		<-ctx.Done()
+
+		return ctx.Err()
+	}
+
+	manager := recovery2.NewManager(logger, mockDB, mockHandler, config)
+	require.NoError(t, manager.Start())
+
+	// Poll for leadership having been released and reacquired at least once,
+	// rather than sleeping a fixed duration: a fixed sleep only needs to
+	// outlast the jitter (up to 1s) plus the 50ms transaction timeout on this
+	// machine, at this moment, under this load; require.Eventually asserts
+	// the same outcome without hardcoding how long that takes.
+	require.Eventually(t, func() bool {
+		return mockDB.AcquireRecoveryLeadershipCallCount() >= 2
+	}, 5*time.Second, 10*time.Millisecond,
+		"leadership must be released and reacquired on the next tick, not held for the hang's duration")
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- manager.Stop() }()
+
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() deadlocked: the hung Recover call was never bounded")
+	}
+
+	require.GreaterOrEqual(t, mockHandler.RecoverCallCount(), 1)
+
+	// Round 7: the claim is no longer released synchronously when the sweep's
+	// own attempt times out (see finishAbandonedRecovery) — releasing it then,
+	// as pre-round-7 code did, is what let a second replica claim and run a
+	// concurrent Recover -> Commit against the same tx while the first
+	// replica's abandoned goroutine was still running. This handler honours
+	// ctx.Done(), so its goroutine returns shortly after recoverCtx's deadline
+	// fires regardless, and finishAbandonedRecovery releases the claim once it
+	// does; require.Eventually accounts for that being asynchronous now
+	// instead of asserting on it immediately after Stop() returns.
+	require.Eventually(t, func() bool {
+		return mockDB.ReleaseRecoveryClaimCallCount() >= 1
+	}, 5*time.Second, 10*time.Millisecond, "the claim must eventually be released once the abandoned attempt actually returns")
+
+	_, gotTxID, _, gotMsg := mockDB.ReleaseRecoveryClaimArgsForCall(0)
+	assert.Equal(t, "txHung", gotTxID)
+	assert.Contains(t, gotMsg, "context deadline exceeded")
+}
+
+// TestManager_TransactionTimeoutBoundsRecoverIgnoringContext is the sharper
+// version of the scenario above: the mock handler here never reads ctx at
+// all, simulating a blocking call like FSC's fabric
+// Ledger.GetTransactionByID, which takes no context and therefore cannot
+// itself be interrupted by context.WithTimeout. If the manager only relied on
+// the handler honouring ctx.Done() (as recoverCtx, cancel :=
+// context.WithTimeout(...); handler.Recover(recoverCtx, txID) would), this
+// test would hang until the real 30s test timeout. It passes only because
+// the manager runs Recover in its own goroutine and gives up on
+// recoverCtx.Done() independently of whether the handler ever notices.
+//
+// It also covers the round-7 finding: since the handler here never returns,
+// finishAbandonedRecovery never gets a result to release the claim with, so
+// ReleaseRecoveryClaim must never be called for the whole test — the claim
+// stays held for as long as the abandoned goroutine might still be running,
+// instead of being released back for another replica to pick up while a
+// Recover call against the same tx is still silently in flight.
+// TestManager_TransactionTimeoutBoundsRecoverIgnoringContext also covers the
+// round 8 leadership-holding fix (finding 1): while txIgnoresCtx's Recover
+// call is abandoned in flight, recovery leadership must be held across
+// sweeps, not released and reacquired. Releasing it (round 7's behaviour)
+// would let another replica win the advisory lock's non-blocking try-lock on
+// a later sweep and reclaim txIgnoresCtx once this instance stopped
+// renewing its lease, running Recover -> Commit concurrently with this
+// instance's still-silently-running attempt: the exact hazard this test's
+// final assertion guards against.
+func TestManager_TransactionTimeoutBoundsRecoverIgnoringContext(t *testing.T) {
+	logger := logging.MustGetLogger()
+	mockDB := &mock2.Storage{}
+	mockHandler := &mock2.Handler{}
+	config := recovery2.Config{
+		Enabled:            true,
+		TTL:                10 * time.Millisecond,
+		ScanInterval:       20 * time.Millisecond,
+		BatchSize:          100,
+		WorkerCount:        1,
+		LeaseDuration:      time.Second,
+		TransactionTimeout: 50 * time.Millisecond,
+		InstanceID:         "test-instance",
+	}
+
+	txRecord := &ttxdb.RecoveryClaim{TxID: "txIgnoresCtx"}
+
+	leadership := &mock2.Leadership{}
+	leadership.CloseReturns(nil)
+
+	mockDB.AcquireRecoveryLeadershipReturns(leadership, true, nil)
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{txRecord}, nil)
+	mockDB.ReleaseRecoveryClaimReturns(nil)
+
+	// Never reads ctx: blocks until the test process exits (or GC, in
+	// practice never for the duration of this test). The manager must not
+	// wait on this to return.
+	mockHandler.RecoverStub = func(_ context.Context, _ string) error {
+		select {}
+	}
+
+	manager := recovery2.NewManager(logger, mockDB, mockHandler, config)
+	require.NoError(t, manager.Start())
+
+	// Let several sweeps elapse while txIgnoresCtx stays abandoned in flight.
+	require.Eventually(t, func() bool {
+		return mockDB.ClaimPendingTransactionsCallCount() >= 3
+	}, 5*time.Second, 10*time.Millisecond,
+		"expected multiple sweeps to run while the claim is held")
+
+	assert.Equal(t, 1, mockDB.AcquireRecoveryLeadershipCallCount(),
+		"leadership must be held across sweeps, not released and reacquired, while an abandoned goroutine is still in flight")
+	assert.Equal(t, 0, leadership.CloseCallCount(),
+		"leadership must not be released while inFlight is non-empty")
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- manager.Stop() }()
+
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() deadlocked: the manager waited on a handler that ignores ctx")
+	}
+
+	assert.Equal(t, 1, leadership.CloseCallCount(),
+		"Stop() must always release held leadership, regardless of any still-abandoned goroutine, so it does not block a live peer indefinitely")
+	assert.Equal(t, 0, mockDB.ReleaseRecoveryClaimCallCount(),
+		"a handler that never returns must never have its claim released: doing so is what let a second replica claim and Commit the same tx while this attempt is still silently running")
+}
+
+// TestManager_SkipsReclaimedTransactionStillInFlight is the regression test
+// for the round-2 finding: a transaction that keeps timing out stays Pending
+// and is re-claimed on every sweep. Before the tryMarkInFlight guard, each
+// sweep abandoned another goroutine for the same txID, so a stuck
+// transaction accumulated unbounded goroutines and could run duplicate
+// concurrent Recover calls (each reaching Commit) for the same tx. The
+// handler here never returns, so the very first attempt's goroutine leaks
+// forever; every later sweep must still find Recover having been called
+// exactly once.
+func TestManager_SkipsReclaimedTransactionStillInFlight(t *testing.T) {
+	logger := logging.MustGetLogger()
+	mockDB := &mock2.Storage{}
+	mockHandler := &mock2.Handler{}
+	config := recovery2.Config{
+		Enabled:            true,
+		TTL:                5 * time.Millisecond,
+		ScanInterval:       15 * time.Millisecond,
+		BatchSize:          100,
+		WorkerCount:        1,
+		LeaseDuration:      time.Second,
+		TransactionTimeout: 20 * time.Millisecond,
+		InstanceID:         "test-instance",
+	}
+
+	txRecord := &ttxdb.RecoveryClaim{TxID: "txStuck"}
+
+	leadership := &mock2.Leadership{}
+	leadership.CloseReturns(nil)
+	mockDB.AcquireRecoveryLeadershipReturns(leadership, true, nil)
+	// Every sweep reclaims the same still-Pending row: it never resolves, so
+	// it keeps being the oldest eligible claim.
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{txRecord}, nil)
+	mockDB.ReleaseRecoveryClaimReturns(nil)
+
+	// Never returns: simulates the first sweep's abandoned goroutine still
+	// running when later sweeps reclaim the same txID.
+	mockHandler.RecoverStub = func(_ context.Context, _ string) error {
+		select {}
+	}
+
+	manager := recovery2.NewManager(logger, mockDB, mockHandler, config)
+	require.NoError(t, manager.Start())
+
+	require.Eventually(t, func() bool {
+		return mockDB.ClaimPendingTransactionsCallCount() >= 5
+	}, 5*time.Second, 10*time.Millisecond, "need several sweeps to reclaim the still-pending row")
+
+	_ = manager.Stop()
+
+	assert.Equal(t, 1, mockHandler.RecoverCallCount(),
+		"a transaction whose previous attempt is still in flight must not get a second concurrent Recover call")
+}
+
+// sweepLogger records every Warnf/Debugf call verbatim, so
+// TestManager_SweepSummary_MixedSkipAndSuccessIsNotReportedAsFullyWedged can
+// assert on the exact sweep-summary line logged. Deliberately separate from
+// recordingLogger above, which only captures Errorf and is relied on by the
+// escalation tests to contain nothing but those calls.
+type sweepLogger struct {
+	logging.MockLogger
+	mu       sync.Mutex
+	messages []string
+}
+
+func (l *sweepLogger) Warnf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.messages = append(l.messages, fmt.Sprintf(format, args...))
+}
+
+func (l *sweepLogger) Debugf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.messages = append(l.messages, fmt.Sprintf(format, args...))
+}
+
+func (l *sweepLogger) allMessages() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.messages))
+	copy(out, l.messages)
+
+	return out
+}
+
+// TestManager_SweepSummary_MixedSkipAndSuccessIsNotReportedAsFullyWedged is
+// the regression test for the round-4 review finding: recoverTransactions
+// reported a sweep as "all skipped, no progress made" as soon as any
+// transaction was skipped, even when other transactions in the same sweep
+// genuinely succeeded. txStuck never returns, so from the second sweep
+// onward it is skipped as still in flight; txOK succeeds on every sweep. A
+// sweep claiming both must report the real breakdown, not claim the sweep
+// made no progress at all.
+func TestManager_SweepSummary_MixedSkipAndSuccessIsNotReportedAsFullyWedged(t *testing.T) {
+	logger := &sweepLogger{}
+	mockDB := &mock2.Storage{}
+	mockHandler := &mock2.Handler{}
+	config := recovery2.Config{
+		Enabled:            true,
+		TTL:                5 * time.Millisecond,
+		ScanInterval:       15 * time.Millisecond,
+		BatchSize:          100,
+		WorkerCount:        2,
+		LeaseDuration:      time.Second,
+		TransactionTimeout: 20 * time.Millisecond,
+		InstanceID:         "test-instance",
+	}
+
+	stuckRecord := &ttxdb.RecoveryClaim{TxID: "txStuck"}
+	okRecord := &ttxdb.RecoveryClaim{TxID: "txOK"}
+
+	leadership := &mock2.Leadership{}
+	leadership.CloseReturns(nil)
+	mockDB.AcquireRecoveryLeadershipReturns(leadership, true, nil)
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{stuckRecord, okRecord}, nil)
+	mockDB.ReleaseRecoveryClaimReturns(nil)
+
+	mockHandler.RecoverStub = func(_ context.Context, txID string) error {
+		if txID == "txStuck" {
+			select {}
+		}
+
+		return nil
+	}
+
+	manager := recovery2.NewManager(logger, mockDB, mockHandler, config)
+	require.NoError(t, manager.Start())
+
+	require.Eventually(t, func() bool {
+		return mockDB.ClaimPendingTransactionsCallCount() >= 3
+	}, 5*time.Second, 10*time.Millisecond, "need several sweeps for txStuck's skip to kick in")
+
+	// Snapshot before Stop(), not after: Stop() can race with a sweep that is
+	// still actively dispatching txOK, and round 8 correctly reclassifies an
+	// attempt interrupted by that shutdown as skipped rather than failed (see
+	// errSkippedShutdown), not as a genuine failure. If that race is lost,
+	// the one sweep truncated by Stop() can legitimately have nothing to show
+	// for itself and log "all skipped" too, which is not the round-4 bug this
+	// test guards against: that bug was a healthy, uninterrupted sweep with a
+	// real success being misreported. Reading the log before Stop() looks
+	// only at sweeps that ran to completion, which is what round 4 covers.
+	msgs := logger.allMessages()
+	_ = manager.Stop()
+	for _, m := range msgs {
+		assert.NotContains(t, m, "all skipped",
+			"a sweep with a real success must not be reported as fully wedged: %s", m)
+	}
+
+	found := false
+	for _, m := range msgs {
+		if strings.Contains(m, "skipped=1") && strings.Contains(m, "succeeded=1") {
+			found = true
+
+			break
+		}
+	}
+	assert.True(t, found, "expected a sweep-summary line reporting both the skip and the success, got: %v", msgs)
+}
+
+// TestManager_StuckTransactionAlertThreshold_EscalatesAndBacksOff verifies
+// both that the Error escalation fires once a transaction crosses
+// StuckTransactionAlertThreshold, and that it then backs off by doubling
+// rather than firing on every sweep (round-2 finding: an unthrottled Error
+// log would fire every scanInterval indefinitely, flooding alerting).
+func TestManager_StuckTransactionAlertThreshold_EscalatesAndBacksOff(t *testing.T) {
+	logger := &recordingLogger{}
+	mockDB := &mock2.Storage{}
+	mockHandler := &mock2.Handler{}
+	config := recovery2.Config{
+		Enabled:                        true,
+		TTL:                            5 * time.Millisecond,
+		ScanInterval:                   15 * time.Millisecond,
+		BatchSize:                      100,
+		WorkerCount:                    1,
+		LeaseDuration:                  time.Second,
+		TransactionTimeout:             10 * time.Millisecond,
+		InstanceID:                     "test-instance",
+		StuckTransactionAlertThreshold: 2,
+	}
+
+	txRecord := &ttxdb.RecoveryClaim{TxID: "txStuckAlert"}
+
+	leadership := &mock2.Leadership{}
+	leadership.CloseReturns(nil)
+	mockDB.AcquireRecoveryLeadershipReturns(leadership, true, nil)
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{txRecord}, nil)
+	mockDB.ReleaseRecoveryClaimReturns(nil)
+
+	// Cooperative: honours ctx.Done(), so each sweep's attempt genuinely
+	// completes (times out) and clears the in-flight guard, letting the next
+	// sweep actually re-attempt instead of being skipped by it. This is what
+	// lets consecutive timeouts actually accumulate for the escalation.
+	mockHandler.RecoverStub = func(ctx context.Context, _ string) error {
+		<-ctx.Done()
+
+		return ctx.Err()
+	}
+
+	manager := recovery2.NewManager(logger, mockDB, mockHandler, config)
+	require.NoError(t, manager.Start())
+
+	require.Eventually(t, func() bool {
+		return mockHandler.RecoverCallCount() >= 9
+	}, 5*time.Second, 10*time.Millisecond, "need several consecutive timeouts to observe the backoff")
+
+	_ = manager.Stop()
+
+	msgs := logger.errorMessages()
+	require.NotEmpty(t, msgs, "escalation must fire once the threshold is crossed")
+	for _, m := range msgs {
+		assert.Contains(t, m, "txStuckAlert")
+	}
+	// threshold=2 backs off at 2, 4, 8, ...: far fewer crossings than attempts.
+	assert.Less(t, len(msgs), mockHandler.RecoverCallCount(),
+		"the Error log must back off instead of firing on every sweep")
+}
+
+// TestManager_StuckTransactionAlertThreshold_ZeroDisablesEscalation verifies
+// the documented opt-out.
+func TestManager_StuckTransactionAlertThreshold_ZeroDisablesEscalation(t *testing.T) {
+	logger := &recordingLogger{}
+	mockDB := &mock2.Storage{}
+	mockHandler := &mock2.Handler{}
+	config := recovery2.Config{
+		Enabled:                        true,
+		TTL:                            5 * time.Millisecond,
+		ScanInterval:                   15 * time.Millisecond,
+		BatchSize:                      100,
+		WorkerCount:                    1,
+		LeaseDuration:                  time.Second,
+		TransactionTimeout:             10 * time.Millisecond,
+		InstanceID:                     "test-instance",
+		StuckTransactionAlertThreshold: 0,
+	}
+
+	txRecord := &ttxdb.RecoveryClaim{TxID: "txStuckNoAlert"}
+
+	leadership := &mock2.Leadership{}
+	leadership.CloseReturns(nil)
+	mockDB.AcquireRecoveryLeadershipReturns(leadership, true, nil)
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{txRecord}, nil)
+	mockDB.ReleaseRecoveryClaimReturns(nil)
+
+	mockHandler.RecoverStub = func(ctx context.Context, _ string) error {
+		<-ctx.Done()
+
+		return ctx.Err()
+	}
+
+	manager := recovery2.NewManager(logger, mockDB, mockHandler, config)
+	require.NoError(t, manager.Start())
+
+	require.Eventually(t, func() bool {
+		return mockHandler.RecoverCallCount() >= 5
+	}, 5*time.Second, 10*time.Millisecond, "need several consecutive timeouts")
+
+	_ = manager.Stop()
+
+	assert.Empty(t, logger.errorMessages(), "StuckTransactionAlertThreshold: 0 must disable the escalation entirely")
+}
+
+// shutdownLogger records every Warnf/Debugf/Errorf call, so
+// TestManager_ShutdownDuringRecoveryIsNotCountedAsTimeout can both check the
+// exact message logged and confirm the stuck-transaction escalation (set to
+// fire on the very first recordTimeout call here) never fires.
+type shutdownLogger struct {
+	logging.MockLogger
+	mu       sync.Mutex
+	messages []string
+}
+
+func (l *shutdownLogger) record(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.messages = append(l.messages, fmt.Sprintf(format, args...))
+}
+
+func (l *shutdownLogger) Warnf(format string, args ...any)  { l.record(format, args...) }
+func (l *shutdownLogger) Debugf(format string, args ...any) { l.record(format, args...) }
+func (l *shutdownLogger) Errorf(format string, args ...any) { l.record(format, args...) }
+
+func (l *shutdownLogger) allMessages() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.messages))
+	copy(out, l.messages)
+
+	return out
+}
+
+// TestManager_ShutdownDuringRecoveryIsNotCountedAsTimeout is the regression
+// test for round 8 review finding 4: recoverCtx.Done() firing because Stop()
+// cancelled the parent context looks identical, from callHandler's return
+// values alone, to a real TransactionTimeout expiry. Before this fix,
+// recoverTransaction could not tell them apart, so a clean shutdown that
+// caught an attempt mid-flight was recorded and alerted on exactly like a
+// genuinely stuck transaction. TransactionTimeout is set far longer than the
+// test needs, and StuckTransactionAlertThreshold to 1, so any recordTimeout
+// call at all is enough to prove the bug is present.
+func TestManager_ShutdownDuringRecoveryIsNotCountedAsTimeout(t *testing.T) {
+	logger := &shutdownLogger{}
+	mockDB := &mock2.Storage{}
+	mockHandler := &mock2.Handler{}
+	config := recovery2.Config{
+		Enabled:                        true,
+		TTL:                            10 * time.Millisecond,
+		ScanInterval:                   100 * time.Millisecond,
+		BatchSize:                      100,
+		WorkerCount:                    1,
+		LeaseDuration:                  time.Minute,
+		TransactionTimeout:             time.Minute,
+		StuckTransactionAlertThreshold: 1,
+		InstanceID:                     "test-instance",
+	}
+
+	txRecord := &ttxdb.RecoveryClaim{TxID: "txShutdown"}
+
+	leadership := &mock2.Leadership{}
+	leadership.CloseReturns(nil)
+	mockDB.AcquireRecoveryLeadershipReturns(leadership, true, nil)
+	mockDB.ClaimPendingTransactionsReturnsOnCall(0, []*ttxdb.RecoveryClaim{txRecord}, nil)
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{}, nil)
+
+	started := make(chan struct{})
+	var once sync.Once
+	mockHandler.RecoverStub = func(_ context.Context, _ string) error {
+		once.Do(func() { close(started) })
+		select {} // never returns, regardless of ctx
+	}
+
+	manager := recovery2.NewManager(logger, mockDB, mockHandler, config)
+	require.NoError(t, manager.Start())
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler was never invoked")
+	}
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- manager.Stop() }()
+
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() deadlocked")
+	}
+
+	for _, msg := range logger.allMessages() {
+		assert.NotContains(t, msg, "still running past transactionTimeout",
+			"a shutdown-triggered abandonment must not be logged with real-timeout wording: %s", msg)
+		assert.NotContains(t, msg, "has timed out",
+			"the stuck-transaction escalation must never fire for a shutdown, even at threshold=1: %s", msg)
+	}
+
+	found := false
+	for _, msg := range logger.allMessages() {
+		if strings.Contains(msg, "interrupted") {
+			found = true
+
+			break
+		}
+	}
+	assert.True(t, found, "expected a debug log noting the attempt was interrupted rather than timed out, got: %v", logger.allMessages())
+}
+
+// TestManager_DefaultConfigDoesNotSelfTriggerLeaseWarnings is the regression
+// test for round 8 review finding 5: DefaultConfig previously combined a
+// BatchSize/WorkerCount/TransactionTimeout ratio whose worst case always
+// exceeded LeaseDuration, so every untouched deployment logged a Warn on
+// every single Start().
+func TestManager_DefaultConfigDoesNotSelfTriggerLeaseWarnings(t *testing.T) {
+	logger := &sweepLogger{}
+	mockDB := &mock2.Storage{}
+	mockHandler := &mock2.Handler{}
+
+	manager := recovery2.NewManager(logger, mockDB, mockHandler, recovery2.DefaultConfig())
+	require.NoError(t, manager.Start())
+	require.NoError(t, manager.Stop())
+
+	for _, msg := range logger.allMessages() {
+		assert.NotContains(t, msg, "worst-case sweep duration",
+			"the default config must not trip its own mid-sweep lease warning: %s", msg)
+		assert.NotContains(t, msg, "scanInterval",
+			"the default config must not trip its own between-sweeps lease warning: %s", msg)
+	}
+}
+
 func TestDefaultConfig(t *testing.T) {
 	config := recovery2.DefaultConfig()
 
 	assert.True(t, config.Enabled, "Recovery should be enabled by default")
 	assert.Equal(t, 30*time.Second, config.TTL)
 	assert.Equal(t, 5*time.Second, config.ScanInterval)
-	assert.Equal(t, 100, config.BatchSize)
-	assert.Equal(t, 4, config.WorkerCount)
-	assert.Equal(t, 30*time.Second, config.LeaseDuration)
+	assert.Equal(t, 16, config.BatchSize)
+	assert.Equal(t, 8, config.WorkerCount)
+	assert.Equal(t, 5*time.Minute, config.LeaseDuration)
+	assert.Equal(t, 60*time.Second, config.TransactionTimeout)
 }


### PR DESCRIPTION
The recovery sweep's context had no deadline, so a hung GetTransactionStatus call could block a worker forever. Since leadership is held for the whole sweep, that stalls recovery on every replica of the TMS, not just the one that hit the slow peer.

This adds a `TransactionTimeout` config field (default 10s, validated like the other durations) and wraps the handler's `Recover` call in `context.WithTimeout` at the per-transaction call site. Claim release and orphan promotion still use the sweep's own context, so a timed-out attempt is cleaned up normally instead of being cut off itself.

Added a test where the mock handler actually honors ctx.Done() (a real hang simulation) and asserts leadership is released and reacquired rather than held for the duration of the hang.

The LeaseDuration renewal question raised in the same issue is separate and not addressed here.

Fixes #2192