### PR TITLE
fix(evm): a third bug-hunt pass over the network driver

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -161,6 +161,10 @@ jobs:
             dir: ./x/token/services/network/evm
             pkg: ./abi
             func: FuzzDecodeBytes32
+          - name: evm-parse-hex-quantities
+            dir: ./x/token/services/network/evm
+            pkg: ./client
+            func: FuzzParseHexQuantities
           - name: evm-hex-to-address
             dir: ./x/token/services/network/evm
             pkg: ./client

--- a/docs/services/network-ethereum.md
+++ b/docs/services/network-ethereum.md
@@ -720,6 +720,31 @@ Ethereum transaction with the submitter's key, and broadcasts it.
 These are properties of the shipped Approach-2 driver that an operator has to know about. Bootstrapping
 steps live in the [Ethereum Deployment Runbook](./network-ethereum-deployment.md).
 
+### Startup checks
+
+`Connect` refuses to bind a TMS to a network whose configuration contradicts the chain, so a
+misconfiguration surfaces at startup rather than as failing transactions later. It checks two things.
+
+The first is the chain id: the node has to report the chain the driver is configured to sign for,
+otherwise every signature would be produced for a chain nobody is running.
+
+The second is the endorsement policy. `contracts.tokenState` names the verifier it delegates signature
+checking to, and the driver reads the threshold and endorser set back from it. The configured
+`endorsement.threshold` has to equal the one the `EndorsementVerifier` was constructed with, and every
+address in `endorsement.endorsers` has to be registered in it. Getting either wrong is expensive to
+diagnose without this check, because it does not look like a configuration problem: the node collects
+what it believes is a quorum, spends a full endorsement round trip doing it, and the contract then
+rejects the bundle, which arrives as a revert. One stale endorser address is enough to fail every
+transaction, because the initiator counts its reply toward the quorum and the contract rejects the whole
+bundle as an unauthorized signer.
+
+Only a contradiction the driver actually observed is fatal. If the verifier cannot be read at all — the
+contract is not deployed yet, or the node is briefly unhappy — the check is logged and skipped rather
+than refusing the connection. These reads use the `latest` block tag rather than the configured one:
+the endorser set and threshold are immutable after the verifier is constructed, so there is nothing a
+later block can change, and reading at `finalized` would leave a freshly deployed network unable to see
+its own verifier for the whole finalization window.
+
 ### How finality resolves
 
 The primary signal is the transaction receipt, polled alongside `eth_getTransactionByHash`: known but no

--- a/docs/services/network-ethereum.md
+++ b/docs/services/network-ethereum.md
@@ -786,6 +786,14 @@ The split is load-bearing. Collapsing the two leaves a caller choosing between r
 forever and giving up on a working one. A revert is detected during `eth_estimateGas`, which executes the
 transaction — so a rejected transaction is reported **before** any gas is paid for it.
 
+Recognising a revert is node-specific, which is worth knowing when adding support for a new one. Besu
+reports it as JSON-RPC code `-32000`, inside the range the spec reserves for implementations; geth and
+anvil use EIP-1474's code `3`. The driver accepts either, and anything else in the reserved range, always
+paired with `revert` appearing in the message — so a non-revert failure carrying one of those codes
+(`out of gas` on `3`, `header not found` on `-32000`) stays in the transient class. A node that reports a
+revert some other way would have its transactions classified transient, and callers would retry them
+forever, so that is the first thing to check against an unfamiliar client.
+
 ### Transaction recovery across restarts
 
 The ttx layer registers a finality listener **in memory** when it stores a transaction. A node that restarts

--- a/integration/nwo/token/evm/besu.go
+++ b/integration/nwo/token/evm/besu.go
@@ -155,6 +155,11 @@ func StartBesu(ctx context.Context, cfg BesuConfig) (*Besu, error) {
 		endpoint:    "http://127.0.0.1:" + strconv.Itoa(cfg.Port),
 	}
 	if err := node.waitReady(ctx); err != nil {
+		// The container is running but unusable, and the caller is handed no Node to stop it with, so
+		// nothing else will ever remove it. The next run will not reap it either: the name embeds a
+		// freshly reserved host port, so it never collides with the name that run cleans up.
+		removeContainer(node)
+
 		return nil, err
 	}
 	logger.Infof("besu is up at %s (chain %d)", node.endpoint, cfg.ChainID)

--- a/integration/nwo/token/evm/gateway_node.go
+++ b/integration/nwo/token/evm/gateway_node.go
@@ -158,6 +158,11 @@ func startGatewayNode(ctx context.Context, image string, chainID int64, port int
 		endpoint:    "http://127.0.0.1:" + strconv.Itoa(cfg.Port),
 	}
 	if err := node.waitReady(ctx); err != nil {
+		// The container is running but unusable, and the caller is handed no Node to stop it with, so
+		// nothing else will ever remove it. The next run will not reap it either: the name embeds a
+		// freshly reserved host port, so it never collides with the name that run cleans up.
+		removeContainer(node)
+
 		return nil, err
 	}
 	logger.Infof("fabric-x-evm gateway is up at %s (chain %d)", node.endpoint, cfg.ChainID)

--- a/integration/nwo/token/evm/node.go
+++ b/integration/nwo/token/evm/node.go
@@ -6,7 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package evm
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Node is the chain a TMS settles on, provisioned per backend and hiding the concrete Besu/gateway node.
 type Node interface {
@@ -20,3 +23,19 @@ type Node interface {
 
 // Besu already satisfies Node; this assertion keeps that true without touching Besu.
 var _ Node = (*Besu)(nil)
+
+// removeContainer tears down a node that came up but never became usable.
+//
+// It runs on its own short-lived context rather than the caller's: the usual reason a node is being
+// removed here is that waiting for it ran out of time, and reusing the context that just expired
+// would leave the container behind exactly when it most needs removing. Failure is logged rather than
+// returned, because the caller is already reporting why the node is unusable and that is the more
+// useful error of the two.
+func removeContainer(node Node) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := node.Stop(ctx); err != nil {
+		logger.Warnf("could not remove the unready evm container: %v", err)
+	}
+}

--- a/integration/nwo/token/evm/node_test.go
+++ b/integration/nwo/token/evm/node_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// stubNode records whether the context was still live at the moment Stop ran. It has to be sampled
+// there rather than afterwards: removeContainer cancels its context on the way out, so a context
+// captured for later inspection always reads as cancelled and would pass whatever the fix did.
+type stubNode struct {
+	stopped        int
+	liveWhenCalled bool
+	err            error
+}
+
+func (s *stubNode) Endpoint() string { return "" }
+func (s *stubNode) ChainID() int64   { return 0 }
+func (s *stubNode) Stop(ctx context.Context) error {
+	s.stopped++
+	s.liveWhenCalled = ctx.Err() == nil
+
+	return s.err
+}
+
+// TestRemoveContainerUsesAFreshContext pins the reason removeContainer does not take the caller's
+// context. A node is removed here precisely because waiting for it ran out of time, so passing the
+// expired context on would refuse the removal at the one moment it matters and leave the container
+// running with nothing left holding a reference to it.
+func TestRemoveContainerUsesAFreshContext(t *testing.T) {
+	node := &stubNode{}
+	removeContainer(node)
+
+	assert.Equal(t, 1, node.stopped, "the container must be removed")
+	assert.True(t, node.liveWhenCalled, "the teardown context must still be live when Stop runs")
+}
+
+// TestRemoveContainerToleratesAFailedStop checks a removal that fails is reported rather than
+// propagated: the caller is already returning why the node is unusable, which is the more useful of
+// the two errors.
+func TestRemoveContainerToleratesAFailedStop(t *testing.T) {
+	node := &stubNode{err: errors.New("docker is gone")}
+
+	assert.NotPanics(t, func() { removeContainer(node) })
+	assert.Equal(t, 1, node.stopped)
+}

--- a/integration/nwo/token/evm/node_test.go
+++ b/integration/nwo/token/evm/node_test.go
@@ -53,3 +53,23 @@ func TestRemoveContainerToleratesAFailedStop(t *testing.T) {
 	assert.NotPanics(t, func() { removeContainer(node) })
 	assert.Equal(t, 1, node.stopped)
 }
+
+// TestCleanupStopsASharedNodeOnce pins that teardown removes each container once rather than once per
+// TMS. startNode hands every TMS on a network the same Node, so a per-entry Stop removes the same
+// container repeatedly and reports every removal past the first as a failure, which reads as a broken
+// teardown when the teardown in fact worked.
+func TestCleanupStopsASharedNodeOnce(t *testing.T) {
+	shared := &stubNode{}
+	handler := &NetworkHandler{Entries: map[string]*Entry{
+		"tms-a": {Node: shared},
+		"tms-b": {Node: shared},
+		"tms-c": {Node: shared},
+	}}
+
+	handler.Cleanup()
+
+	assert.Equal(t, 1, shared.stopped, "one container, one removal")
+	for id, entry := range handler.Entries {
+		assert.Nil(t, entry.Node, "entry [%s] must be cleared", id)
+	}
+}

--- a/integration/nwo/token/evm/nwo.go
+++ b/integration/nwo/token/evm/nwo.go
@@ -359,13 +359,22 @@ func (p *NetworkHandler) UpdatePublicParams(tms *topology2.TMS, ppRaw []byte) {
 }
 
 // Cleanup stops the chain.
+//
+// Every TMS on one network shares a Node, because startNode reuses the first one brought up rather
+// than booting a container per TMS. Stopping per entry would therefore remove the same container once
+// per TMS and report every removal past the first as a failure, so a healthy multi-TMS teardown
+// printed warnings about a container that had in fact been removed correctly.
 func (p *NetworkHandler) Cleanup() {
+	stopped := make(map[Node]struct{}, len(p.Entries))
 	for _, entry := range p.Entries {
 		if entry.Node == nil {
 			continue
 		}
-		if err := entry.Node.Stop(context.Background()); err != nil {
-			logger.Warnf("failed to stop the EVM node: %v", err)
+		if _, done := stopped[entry.Node]; !done {
+			stopped[entry.Node] = struct{}{}
+			if err := entry.Node.Stop(context.Background()); err != nil {
+				logger.Warnf("failed to stop the EVM node: %v", err)
+			}
 		}
 		entry.Node = nil
 	}

--- a/x/token/services/network/evm/client/fuzz_test.go
+++ b/x/token/services/network/evm/client/fuzz_test.go
@@ -9,6 +9,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"math/big"
 	"strings"
 	"testing"
 )
@@ -202,6 +203,51 @@ func FuzzJSONReceiptToReceipt(f *testing.F) {
 		}
 		for i := range j.Logs {
 			assertLogMatchesRaw(t, receipt.Logs[i], j.Logs[i])
+		}
+	})
+}
+
+// FuzzParseHexQuantities fuzzes the two JSON-RPC hex-quantity decoders.
+//
+// Every numeric field a node reports arrives through one of these: chain id, base fee, suggested tip,
+// gas estimate, nonce, block number, receipt status. They are the driver's most-used wire decoders and
+// the node's answer is not something the driver gets to check first.
+//
+// The property is that they agree on what a quantity is. parseHexUint refuses a signed value through
+// strconv.ParseUint, but big.Int.SetString accepts one, so parseHexBig used to return a negative for
+// "0x-5". That mattered: a negative fee reaches rlpBigInt, which encodes magnitude and drops the sign,
+// so the transaction would be signed for a value the driver never computed. A parsed quantity must
+// therefore never be negative, and neither decoder may panic on anything.
+func FuzzParseHexQuantities(f *testing.F) {
+	for _, seed := range []string{
+		"0x0", "0x1", "0x7a69", "0xff",
+		"", "0x", "0X", "0x0000000000000000000000000000000000000000000000000000000000000005",
+		"0x-5", "0x+5", "0X-1", // signed: rejected by parseHexUint, once accepted by parseHexBig
+		"0xzz", "0x_5", "0x 5", "-0x5", "5", "0xffffffffffffffffff", // overflows uint64, fine for big
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		if v, err := parseHexBig(raw); err == nil {
+			if v == nil {
+				t.Fatalf("parseHexBig(%q) returned no value and no error", raw)
+			}
+			if v.Sign() < 0 {
+				t.Fatalf("parseHexBig(%q) returned the negative quantity %s; quantities are unsigned", raw, v)
+			}
+		}
+
+		// Whatever parseHexUint accepts, parseHexBig must accept and agree on, since the two decode the
+		// same wire form and callers pick between them only by the width they need.
+		if u, err := parseHexUint(raw); err == nil {
+			b, err := parseHexBig(raw)
+			if err != nil {
+				t.Fatalf("parseHexUint(%q) accepted %d but parseHexBig rejected it: %v", raw, u, err)
+			}
+			if b.Cmp(new(big.Int).SetUint64(u)) != 0 {
+				t.Fatalf("parseHexUint(%q)=%d disagrees with parseHexBig=%s", raw, u, b)
+			}
 		}
 	})
 }

--- a/x/token/services/network/evm/client/jsonrpc.go
+++ b/x/token/services/network/evm/client/jsonrpc.go
@@ -209,10 +209,18 @@ func (c *JSONRPCClient) EstimateGas(ctx context.Context, msg CallMsg) (uint64, e
 // errMethodNotFound is the JSON-RPC code for a method the node does not implement.
 const errMethodNotFound = -32601
 
-// errServer is the code nodes use for an execution failure, which includes a reverted call. It is
-// not part of the JSON-RPC specification, which reserves -32000 to -32099 for implementations, so it
-// is paired with the message rather than trusted alone.
-const errServer = -32000
+// errExecutionReverted is EIP-1474's "execution error" code, which is what geth, anvil and everything
+// built on them return for a reverted call, with the revert data attached.
+const errExecutionReverted = 3
+
+// errServerMin and errServerMax bound the range JSON-RPC reserves for implementation-defined errors.
+// Besu reports a revert as -32000 inside it, and other nodes pick other values in the same range, so
+// the whole range is accepted and paired with the message rather than any single code being trusted
+// alone.
+const (
+	errServerMin = -32099
+	errServerMax = -32000
+)
 
 // ErrExecutionReverted marks the node reporting that the call it was given reverts against current
 // state, as opposed to failing to answer at all.
@@ -223,12 +231,26 @@ const errServer = -32000
 // malformed response - says nothing about the transaction and has to be retried instead.
 var ErrExecutionReverted = errors.New("execution reverted")
 
-// isReverted reports whether a JSON-RPC error is a revert. It pairs the implementation-defined code
-// with the message, because the code covers everything a node treats as a server-side execution error
-// and the wording differs between clients ("execution reverted" on geth, "Execution reverted" on
-// Besu).
+// isReverted reports whether a JSON-RPC error is a revert.
+//
+// Getting this wrong is not cosmetic. A revert is the chain rejecting the transaction, which is
+// permanent and has to be re-derived; everything else says nothing about the transaction and has to be
+// retried. The submitter maps the two onto ErrTransactionReverted and ErrNetworkUnavailable, so a
+// revert this function misses is handed to the caller as "retry with backoff" for a transaction that
+// will be rejected identically every time.
+//
+// Nodes disagree on both halves of the answer. Besu reports a revert as -32000, inside the range
+// JSON-RPC reserves for implementations; geth and anvil report it as EIP-1474's code 3. The wording
+// differs too ("execution reverted" on geth, "Execution reverted" on Besu, and anvil appends the
+// custom-error selector). So the code is accepted from either the reserved range or 3, and is always
+// paired with the message, which keeps a non-revert failure carrying one of those codes ("out of gas"
+// on 3, "header not found" on -32000) out of the permanent class.
 func isReverted(err *rpcError) bool {
-	return err != nil && err.Code == errServer && strings.Contains(strings.ToLower(err.Message), "revert")
+	if err == nil || !strings.Contains(strings.ToLower(err.Message), "revert") {
+		return false
+	}
+
+	return err.Code == errExecutionReverted || (err.Code >= errServerMin && err.Code <= errServerMax)
 }
 
 // SuggestGasFees returns the node's suggested EIP-1559 fees: the priority tip it reports, and a max

--- a/x/token/services/network/evm/client/jsonrpc.go
+++ b/x/token/services/network/evm/client/jsonrpc.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"math/big"
 	"net/http"
 	"strconv"
@@ -25,6 +26,20 @@ import (
 // deadline of its own.
 const DefaultRequestTimeout = 30 * time.Second
 
+// maxResponseBytes bounds the JSON-RPC response body this client will buffer.
+//
+// http.Client.Timeout bounds how long a response may take, not how large it may be, so without this a
+// node that streams an endless body makes the driver allocate until it dies. The node is ordinarily
+// operator-run infrastructure rather than an attacker, so this is defence in depth rather than a
+// closed hole; it is the same bound statedelta.Validate already puts on the other input the driver
+// reads from somebody else, and it costs nothing when the node behaves.
+//
+// The cap is set well above any legitimate answer. The largest of those by far is
+// getPublicParameters, whose bytes arrive ABI-encoded and then hex-encoded, so roughly twice their
+// size on the wire; 64 MiB leaves room for parameters an order of magnitude larger than the shipped
+// drivers produce.
+const maxResponseBytes = 64 << 20
+
 // JSONRPCClient is the EVMClient implementation over HTTP JSON-RPC. It speaks plain eth_* methods,
 // so it works against any standard node (Besu is the acceptance backend, anvil the inner loop, and
 // an fabric-x-evm gateway is just another endpoint).
@@ -37,6 +52,9 @@ type JSONRPCClient struct {
 	http     *http.Client
 	// id is the JSON-RPC request counter, incremented atomically so concurrent calls never reuse an id.
 	id atomic.Uint64
+	// maxResponse is the response-body bound, held as a field rather than read from the constant so a
+	// test can exercise the limit without moving 64 MiB over the loopback interface.
+	maxResponse int
 }
 
 // Compile-time assertion that the client satisfies the frozen interface.
@@ -52,7 +70,7 @@ func NewJSONRPCClient(endpoint string, httpClient *http.Client) (*JSONRPCClient,
 		httpClient = &http.Client{Timeout: DefaultRequestTimeout}
 	}
 
-	return &JSONRPCClient{endpoint: endpoint, http: httpClient}, nil
+	return &JSONRPCClient{endpoint: endpoint, http: httpClient, maxResponse: maxResponseBytes}, nil
 }
 
 // ChainID returns the chain id reported by the node.
@@ -408,8 +426,19 @@ func (c *JSONRPCClient) invoke(ctx context.Context, method string, out any, para
 		return nil, errors.Errorf("%s call returned http %d", method, resp.StatusCode)
 	}
 
+	// Read through a bound rather than handing the decoder the body directly: one extra byte is
+	// allowed so an over-long body is reported as such instead of arriving as a truncated,
+	// syntactically broken document that reads like a node returning nonsense.
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, int64(c.maxResponse)+1))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read %s response", method)
+	}
+	if len(respBody) > c.maxResponse {
+		return nil, errors.Errorf("%s response exceeds the %d byte limit", method, c.maxResponse)
+	}
+
 	var rpcResp rpcResponse
-	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
 		return nil, errors.Wrapf(err, "failed to decode %s response", method)
 	}
 	if rpcResp.Error != nil {

--- a/x/token/services/network/evm/client/jsonrpc.go
+++ b/x/token/services/network/evm/client/jsonrpc.go
@@ -603,10 +603,19 @@ func parseHexUint(s string) (uint64, error) {
 }
 
 // parseHexBig parses a 0x/0X-prefixed hex quantity into a big.Int.
+//
+// A JSON-RPC quantity is an unsigned integer, so a leading sign is rejected rather than parsed.
+// big.Int.SetString accepts "-5" and "+5" happily, which would let a node hand back a negative base
+// fee or tip; those flow into the signed transaction, where rlpBigInt encodes a value's magnitude and
+// would drop the sign silently, signing a fee the driver did not compute. parseHexUint already
+// refuses both, via strconv.ParseUint, so this only brings the big.Int path to the same strictness.
 func parseHexBig(s string) (*big.Int, error) {
 	trimmed := trimHexPrefix(s)
 	if trimmed == "" {
 		return nil, errors.Errorf("empty hex quantity")
+	}
+	if trimmed[0] == '-' || trimmed[0] == '+' {
+		return nil, errors.Errorf("invalid hex quantity [%s]: quantities are unsigned", s)
 	}
 	v, ok := new(big.Int).SetString(trimmed, 16)
 	if !ok {

--- a/x/token/services/network/evm/client/jsonrpc_test.go
+++ b/x/token/services/network/evm/client/jsonrpc_test.go
@@ -534,3 +534,50 @@ func TestHexHelpers(t *testing.T) {
 		assert.Equal(t, []byte{0xde, 0xad}, gotBytes)
 	})
 }
+
+// TestResponseBodyIsBounded checks the client refuses a response larger than its cap instead of
+// buffering whatever the node decides to send. http.Client.Timeout bounds how long a response may
+// take, not how large it may be, so without the cap a node streaming an endless body makes the driver
+// allocate until it dies.
+func TestResponseBodyIsBounded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x`))
+		// Streamed rather than built up front: the point is that the client stops reading, so the test
+		// must not depend on the whole body being materialised anywhere.
+		chunk := make([]byte, 1024)
+		for i := range chunk {
+			chunk[i] = '0'
+		}
+		for range 64 {
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+		}
+		_, _ = w.Write([]byte(`"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := NewJSONRPCClient(srv.URL, srv.Client())
+	require.NoError(t, err)
+	c.maxResponse = 4096
+
+	_, err = c.ChainID(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds the 4096 byte limit")
+}
+
+// TestResponseAtTheBoundIsAccepted checks the cap rejects only what is genuinely over it, so a large
+// but legitimate answer (getPublicParameters is the real one) still decodes.
+func TestResponseAtTheBoundIsAccepted(t *testing.T) {
+	big := make([]byte, 2048)
+	for i := range big {
+		big[i] = 'a'
+	}
+	c, _ := newTestServer(t, map[string]string{"eth_chainId": `"0x7a69"`})
+	c.maxResponse = len(big)
+
+	id, err := c.ChainID(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(31337), id.Int64())
+}

--- a/x/token/services/network/evm/client/jsonrpc_test.go
+++ b/x/token/services/network/evm/client/jsonrpc_test.go
@@ -130,10 +130,15 @@ func TestCallClassifiesReverts(t *testing.T) {
 		message  string
 		reverted bool
 	}{
-		{name: "geth wording", code: -32000, message: "execution reverted", reverted: true},
+		// Code 3 is EIP-1474's execution error, which is what geth, anvil and everything built on them
+		// actually return for a revert. Captured from a live anvil node, custom-error data and all.
+		{name: "geth/anvil code", code: 3, message: "execution reverted", reverted: true},
+		{name: "anvil custom error", code: 3, message: "execution reverted: custom error 0xe74c68bb:", reverted: true},
 		{name: "besu wording", code: -32000, message: "Execution reverted", reverted: true},
+		{name: "elsewhere in the implementation range", code: -32015, message: "VM Exception: revert", reverted: true},
 		{name: "another server error", code: -32000, message: "header not found", reverted: false},
 		{name: "method not found", code: -32601, message: "method not found", reverted: false},
+		{name: "a non-revert code 3", code: 3, message: "out of gas", reverted: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := newErrorServer(t, tc.code, tc.message)
@@ -210,7 +215,16 @@ func TestEstimateGasClassifiesReverts(t *testing.T) {
 		message  string
 		reverted bool
 	}{
-		{name: "geth wording", code: -32000, message: "execution reverted", reverted: true},
+		// Code 3 is EIP-1474's execution error, what geth and anvil actually use for a revert. This is
+		// the case that matters most: misreading it makes the submitter tell the caller to retry a
+		// transaction the chain has permanently rejected.
+		{name: "geth/anvil code", code: 3, message: "execution reverted", reverted: true},
+		{
+			name:     "anvil custom error, as captured from a live node",
+			code:     3,
+			message:  "execution reverted: custom error 0xe74c68bb:",
+			reverted: true,
+		},
 		{name: "besu wording", code: -32000, message: "Execution reverted", reverted: true},
 		{
 			name:     "revert with a reason string",
@@ -218,6 +232,10 @@ func TestEstimateGasClassifiesReverts(t *testing.T) {
 			message:  "execution reverted: StalePublicParams",
 			reverted: true,
 		},
+		// Another node picking a different value from the same reserved range.
+		{name: "elsewhere in the implementation range", code: -32015, message: "VM Exception: revert", reverted: true},
+		// Code 3 without a revert: the code alone must not be enough to condemn a transaction.
+		{name: "a non-revert code 3", code: 3, message: "out of gas", reverted: false},
 		// Same implementation-defined code, a different server-side failure. Classifying this as a
 		// revert would make the submitter give up on a transaction the chain never judged.
 		{name: "another server error", code: -32000, message: "header not found", reverted: false},

--- a/x/token/services/network/evm/client/tx.go
+++ b/x/token/services/network/evm/client/tx.go
@@ -94,6 +94,22 @@ func SignTx(tx *DynamicFeeTx, key *secp256k1.PrivateKey) ([]byte, error) {
 	if tx.ChainID == nil || tx.ChainID.Sign() <= 0 {
 		return nil, errors.New("transaction chain id must be set and positive")
 	}
+	// rlpBigInt encodes a value's magnitude, so a negative field would be signed as its positive
+	// counterpart: the broadcast transaction would carry a fee the driver never computed, and nothing
+	// downstream would show the two had diverged. None of these fields has a meaningful negative
+	// value, so refusing one is strictly better than silently reinterpreting it.
+	for _, f := range []struct {
+		name  string
+		value *big.Int
+	}{
+		{"maxPriorityFeePerGas", tx.MaxPriorityFeePerGas},
+		{"maxFeePerGas", tx.MaxFeePerGas},
+		{"value", tx.Value},
+	} {
+		if f.value != nil && f.value.Sign() < 0 {
+			return nil, errors.Errorf("transaction %s must not be negative, got %s", f.name, f.value)
+		}
+	}
 
 	hash := tx.SigningHash()
 	// SignCompact returns {v, r, s} with v = 27 + recovery id, the same layout the endorsement

--- a/x/token/services/network/evm/client/tx_test.go
+++ b/x/token/services/network/evm/client/tx_test.go
@@ -162,3 +162,50 @@ func TestSignTxContractCreation(t *testing.T) {
 	assert.NotEqual(t, tx.SigningHash(), withZero.SigningHash(),
 		"contract creation must not encode like a call to the zero address")
 }
+
+// TestSignTxRejectsNegativeFields checks a negative fee or value is refused rather than signed.
+//
+// rlpBigInt encodes a value's magnitude, so a negative field would be signed as its positive
+// counterpart: the broadcast transaction would carry a fee the driver never computed, and nothing
+// downstream would reveal that the two had diverged. The reachable source is a node answering
+// eth_gasPrice or eth_getBlockByNumber with a signed quantity, which parseHexBig now also refuses;
+// this is the second half of the same guard, at the point the value is actually committed to.
+func TestSignTxRejectsNegativeFields(t *testing.T) {
+	key, err := secp256k1.GeneratePrivateKey()
+	require.NoError(t, err)
+	to := Address{0x01}
+
+	base := func() *DynamicFeeTx {
+		return &DynamicFeeTx{
+			ChainID:              big.NewInt(31337),
+			Nonce:                1,
+			MaxPriorityFeePerGas: big.NewInt(1),
+			MaxFeePerGas:         big.NewInt(2),
+			Gas:                  21000,
+			To:                   &to,
+			Value:                big.NewInt(0),
+		}
+	}
+
+	// The control: the same transaction with every field non-negative signs fine.
+	_, err = SignTx(base(), key)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		field string
+		set   func(*DynamicFeeTx)
+	}{
+		{"maxPriorityFeePerGas", func(tx *DynamicFeeTx) { tx.MaxPriorityFeePerGas = big.NewInt(-1) }},
+		{"maxFeePerGas", func(tx *DynamicFeeTx) { tx.MaxFeePerGas = big.NewInt(-2) }},
+		{"value", func(tx *DynamicFeeTx) { tx.Value = big.NewInt(-3) }},
+	} {
+		t.Run(tc.field, func(t *testing.T) {
+			tx := base()
+			tc.set(tx)
+
+			_, err := SignTx(tx, key)
+			require.Error(t, err, "a negative %s must not be signed as its magnitude", tc.field)
+			assert.Contains(t, err.Error(), tc.field)
+		})
+	}
+}

--- a/x/token/services/network/evm/driver.go
+++ b/x/token/services/network/evm/driver.go
@@ -380,8 +380,14 @@ func (d *Driver) registerEndorser(networkKey string, factory *endorsement.Servic
 	}
 
 	signer, err := config.EndorserSigner()
-	if err != nil || signer == nil {
+	if err != nil {
 		return errors.Wrap(err, "this node is configured as an endorser but its key is unusable")
+	}
+	// Separately from the error: errors.Wrap(nil, ...) is nil, so folding this into the branch above
+	// would report success and leave the node unregistered, which is the exact silent-endorser failure
+	// the comment above says must not happen.
+	if signer == nil {
+		return errors.New("this node is configured as an endorser but no signing key was loaded")
 	}
 	allowed, err := config.AllowedRequesters(d.resolveIdentity)
 	if err != nil {

--- a/x/token/services/network/evm/e2e_anvil_test.go
+++ b/x/token/services/network/evm/e2e_anvil_test.go
@@ -448,7 +448,7 @@ func TestRevertClassificationAgainstAnvil(t *testing.T) {
 	})
 
 	require.Error(t, err, "the chain must reject a bundle from an unregistered endorser")
-	assert.ErrorIs(t, err, ErrTransactionReverted,
+	require.ErrorIs(t, err, ErrTransactionReverted,
 		"a rejected transaction is permanent: the caller must re-derive it, not resend it")
 	assert.NotErrorIs(t, err, ErrNetworkUnavailable,
 		"classifying it as transient tells the caller to retry a transaction the chain will reject every time")

--- a/x/token/services/network/evm/e2e_anvil_test.go
+++ b/x/token/services/network/evm/e2e_anvil_test.go
@@ -8,13 +8,18 @@ package evm
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"math/big"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -452,4 +457,112 @@ func TestRevertClassificationAgainstAnvil(t *testing.T) {
 		"a rejected transaction is permanent: the caller must re-derive it, not resend it")
 	assert.NotErrorIs(t, err, ErrNetworkUnavailable,
 		"classifying it as transient tells the caller to retry a transaction the chain will reject every time")
+}
+
+// lossyProxy forwards every JSON-RPC call to the node but swallows the reply to the first
+// eth_sendRawTransaction: the node accepts and mines the transaction, the caller sees a failure.
+// That is what a client-side timeout or a dropped connection looks like from the driver's side, and
+// it is the one step where "the broadcast failed" is not evidence the chain never took it.
+type lossyProxy struct {
+	target  string
+	swallow atomic.Int32
+}
+
+func (p *lossyProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+	resp, err := http.Post(p.target, "application/json", bytes.NewReader(body))
+	if err != nil {
+		w.WriteHeader(http.StatusBadGateway)
+
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadGateway)
+
+		return
+	}
+
+	if strings.Contains(string(body), "eth_sendRawTransaction") && p.swallow.Add(-1) >= 0 {
+		// The node has the transaction. The caller will not hear that.
+		w.WriteHeader(http.StatusGatewayTimeout)
+
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(out)
+}
+
+// TestSubmitterRecoversFromALostBroadcastReply is a production failure reproduced against a real node.
+//
+// One broadcast whose reply is lost, an ordinary timeout or a dropped connection, used to wedge the
+// submitting account permanently. The chain had mined the transaction, so the nonce was spent, but the
+// driver saw a failure and kept reissuing that same nonce. Every later transaction failed "nonce too
+// low", and because that is also a failed broadcast the manager never re-read the chain to find out.
+// Only restarting the process recovered, and the failures were reported as ErrNetworkUnavailable, so a
+// caller obeying the contract retried forever.
+//
+// It runs through a proxy rather than a fake so the node genuinely accepts and mines the transaction
+// the driver believes it failed to send. A fake cannot produce that disagreement, which is the whole
+// bug.
+func TestSubmitterRecoversFromALostBroadcastReply(t *testing.T) {
+	node := startAnvil(t)
+
+	proxy := &lossyProxy{target: node}
+	proxy.swallow.Store(1)
+	srv := httptest.NewServer(proxy)
+	t.Cleanup(srv.Close)
+
+	keyBytes, err := hex.DecodeString(anvilKey1)
+	require.NoError(t, err)
+
+	viaProxy, err := client.NewJSONRPCClient(srv.URL, nil)
+	require.NoError(t, err)
+	direct, err := client.NewJSONRPCClient(node, nil)
+	require.NoError(t, err)
+
+	// A plain account as the target, with a fixed gas limit so nothing is estimated: every call is a
+	// mined, successful transaction that consumes a nonce, which is all the nonce question needs.
+	target, err := client.HexToAddress("0x000000000000000000000000000000000000dEaD")
+	require.NoError(t, err)
+	submitter, err := NewSubmitter(viaProxy, secp256k1.PrivKeyFromBytes(keyBytes), target,
+		big.NewInt(testChainID), GasConfig{Strategy: GasStrategyFixed, Limit: 200_000})
+	require.NoError(t, err)
+
+	send := func(n byte) error {
+		var anchor [32]byte
+		anchor[31] = n
+		_, _, err := submitter.Submit(t.Context(), &statedelta.StateDelta{
+			Anchor: anchor,
+			Outputs: []statedelta.OutputToken{{
+				TokenID: keys.ComputeTokenID(anchor, 0), TokenData: []byte{n},
+			}},
+			TokenRequestHash:    sha256Of("request"),
+			PublicParamsHash:    sha256Of("pp"),
+			PublicParamsVersion: 0,
+		}, [][]byte{make([]byte, 65)})
+
+		return err
+	}
+	chainNonce := func() uint64 {
+		n, err := direct.PendingNonceAt(t.Context(), submitter.Address())
+		require.NoError(t, err)
+
+		return n
+	}
+
+	require.Error(t, send(0x01), "the swallowed reply must surface as a failed broadcast")
+	require.Equal(t, uint64(1), chainNonce(), "but the chain did take the transaction")
+
+	// The account has to keep working. Before the fix every one of these failed "nonce too low".
+	for _, n := range []byte{0x02, 0x03, 0x04} {
+		require.NoError(t, send(n), "the submitter must recover its nonce from the chain, not wedge")
+	}
+	assert.Equal(t, uint64(4), chainNonce(), "every later transaction reached the chain")
 }

--- a/x/token/services/network/evm/e2e_anvil_test.go
+++ b/x/token/services/network/evm/e2e_anvil_test.go
@@ -43,6 +43,9 @@ const (
 	// anvilKey1 is anvil's first well-known development account, used here as endorser and submitter.
 	anvilKey1 = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 	anvilPort = "18545"
+	// anvilStrangerKey is anvil's second well-known account, used where a test needs a real key the
+	// deployed contracts do not know.
+	anvilStrangerKey = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
 )
 
 // startAnvil boots a local anvil node and returns its endpoint, skipping the test if anvil is absent.
@@ -375,3 +378,78 @@ func (l *e2eListener) OnStatus(_ context.Context, _ string, status int, _ string
 }
 
 func (l *e2eListener) OnError(context.Context, string, error) {}
+
+// TestRevertClassificationAgainstAnvil pins the permanent/transient split against a real node.
+//
+// It exists because the split cannot be trusted to a fake: nodes disagree on how they report a
+// revert, and the driver got it wrong for geth and anvil, which use EIP-1474's code 3 rather than the
+// -32000 Besu uses. That misread sent a permanently rejected transaction back to the caller as
+// ErrNetworkUnavailable, whose documented meaning is "the transaction is untouched, retry with
+// backoff" -- so a caller following the contract would retry a doomed transaction forever.
+//
+// A unit test over a handwritten error body cannot catch a wrong assumption about what nodes actually
+// send, which is precisely what the bug was, so this drives a genuine revert out of a genuine node.
+func TestRevertClassificationAgainstAnvil(t *testing.T) {
+	endpoint := startAnvil(t)
+
+	deployedKeyBytes, err := hex.DecodeString(anvilKey1)
+	require.NoError(t, err)
+	deployedSigner, err := eip712.NewSignerFromBytes(deployedKeyBytes)
+	require.NoError(t, err)
+
+	// anvilStranger is a real key the deployed verifier does not know, so a bundle it signs is
+	// rejected on chain: a genuine revert, reached through the driver's ordinary submission path.
+	strangerBytes, err := hex.DecodeString(anvilStrangerKey)
+	require.NoError(t, err)
+	stranger, err := eip712.NewSignerFromBytes(strangerBytes)
+	require.NoError(t, err)
+
+	pp0 := []byte("revert-classification-params")
+	tokenState := deployContracts(t, endpoint, deployedSigner.Address(), pp0)
+
+	evmClient, err := client.NewJSONRPCClient(endpoint, nil)
+	require.NoError(t, err)
+
+	cfg := validConfig()
+	cfg.Endpoint = endpoint
+	cfg.Contracts.TokenState = tokenState.Hex()
+	cfg.Finality.BlockTag = client.BlockTagLatest
+	cfg.Endorsement.Endorsers[0].Address = deployedSigner.Address().Hex()
+	cfg.applyDefaults()
+	require.NoError(t, cfg.Validate())
+
+	submitter, err := NewSubmitter(
+		evmClient, secp256k1.PrivKeyFromBytes(deployedKeyBytes), tokenState, big.NewInt(testChainID), cfg.Gas)
+	require.NoError(t, err)
+	n, err := NewNetwork("evm-net", cfg, evmClient, nil, submitter, nil)
+	require.NoError(t, err)
+
+	anchorID := n.ComputeTxID(&driver.TxID{Creator: []byte("issuer")})
+	anchor, err := keys.AnchorFromTxID(anchorID)
+	require.NoError(t, err)
+	tokenData := []byte("rejected-token")
+	delta := &statedelta.StateDelta{
+		Anchor: anchor,
+		Outputs: []statedelta.OutputToken{{
+			TokenID:   keys.ComputeTokenID(anchor, 0),
+			SNMarker:  keys.OutputSNMarker(anchor, 0, tokenData),
+			TokenData: tokenData,
+		}},
+		TokenRequestHash:    sha256Of("issue-request"),
+		PublicParamsHash:    sha256Of(string(pp0)),
+		PublicParamsVersion: 0,
+	}
+	domain := eip712.Domain{ChainID: big.NewInt(testChainID), VerifyingContract: tokenState}
+
+	err = n.Broadcast(t.Context(), &Envelope{
+		Anchor:       anchorID,
+		Delta:        delta,
+		Endorsements: endorse(t, stranger, domain, delta),
+	})
+
+	require.Error(t, err, "the chain must reject a bundle from an unregistered endorser")
+	assert.ErrorIs(t, err, ErrTransactionReverted,
+		"a rejected transaction is permanent: the caller must re-derive it, not resend it")
+	assert.NotErrorIs(t, err, ErrNetworkUnavailable,
+		"classifying it as transient tells the caller to retry a transaction the chain will reject every time")
+}

--- a/x/token/services/network/evm/e2e_anvil_test.go
+++ b/x/token/services/network/evm/e2e_anvil_test.go
@@ -156,6 +156,9 @@ func TestEndToEndAgainstAnvil(t *testing.T) {
 	cfg := validConfig()
 	cfg.Endpoint = endpoint
 	cfg.Contracts.TokenState = tokenState.Hex()
+	// The endorser set has to be the one actually seeded into the deployed verifier. validConfig's
+	// placeholder address is not, and Connect's policy check reads the real thing off the chain.
+	cfg.Endorsement.Endorsers[0].Address = signer.Address().Hex()
 	cfg.Finality.BlockTag = client.BlockTagLatest // anvil mines instantly; there is no finalized tag
 	cfg.Finality.PollInterval = 50 * time.Millisecond
 	cfg.Finality.Timeout = 15 * time.Second

--- a/x/token/services/network/evm/finality/manager.go
+++ b/x/token/services/network/evm/finality/manager.go
@@ -52,8 +52,12 @@ type Manager struct {
 	pollInterval time.Duration
 	timeout      time.Duration
 
+	// mu guards pending, which holds the listeners waiting on each anchor. A transaction can be
+	// waited on by more than one party at once - a node that both owns and audits a transaction
+	// registers a listener from each path - so this is a list per anchor rather than a set of anchors,
+	// matching what the Fabric driver's listener manager does.
 	mu      sync.Mutex
-	pending map[string]struct{}
+	pending map[string][]driver.FinalityListener
 }
 
 // NewManager returns a finality manager. Non-positive intervals fall back to sane defaults so a
@@ -84,7 +88,7 @@ func NewManager(
 		blockTag:     blockTag,
 		pollInterval: pollInterval,
 		timeout:      timeout,
-		pending:      map[string]struct{}{},
+		pending:      map[string][]driver.FinalityListener{},
 	}
 }
 
@@ -158,32 +162,51 @@ func (m *Manager) AddListener(ctx context.Context, anchor [32]byte, anchorID str
 		return nil
 	}
 
+	// A second listener for the same anchor joins the watch already running rather than being refused.
+	// Refusing it used to fail the caller outright, and both callers in the token layer treat that as
+	// fatal: a node that owns a transaction registers one listener through the ttx store and, if it
+	// also audits it, another through the audit store, so the second registration failed and took the
+	// whole Append with it.
 	m.mu.Lock()
-	if _, watching := m.pending[anchorID]; watching {
-		m.mu.Unlock()
-
-		return errors.Errorf("finality: already watching [%s]", anchorID)
-	}
-	m.pending[anchorID] = struct{}{}
+	_, watching := m.pending[anchorID]
+	m.pending[anchorID] = append(m.pending[anchorID], once(listener))
 	m.mu.Unlock()
+	if watching {
+		return nil
+	}
 
 	// The watcher deliberately outlives the caller's context: a listener registered during a
 	// short-lived request must still be notified when the transaction settles, typically long after
 	// that request returns. Its lifetime is bounded by the finality timeout instead.
-	go m.watch(anchor, anchorID, once(listener)) // #nosec G118 -- detached by design, bounded by the timeout
+	go m.watch(anchor, anchorID) // #nosec G118 -- detached by design, bounded by the timeout
 
 	return nil
 }
 
+// take removes and returns the listeners waiting on an anchor. Removing them under the same lock that
+// reads them is what makes each one fire exactly once: a listener registered after this point finds no
+// entry and starts a fresh watch rather than joining one that has already decided.
+func (m *Manager) take(anchorID string) []driver.FinalityListener {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	listeners := m.pending[anchorID]
+	delete(m.pending, anchorID)
+
+	return listeners
+}
+
 // watch polls until the anchor is applied or the timeout expires. It runs detached from the caller's
 // context so a listener registered during a short-lived request still gets its notification.
-func (m *Manager) watch(anchor [32]byte, anchorID string, listener driver.FinalityListener) {
+func (m *Manager) watch(anchor [32]byte, anchorID string) {
 	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
 	defer cancel()
+	// Anything still registered when this returns is dropped, so a watch that exits by a path which
+	// did not notify cannot leave a listener waiting forever on an anchor nobody is watching.
 	defer func() {
-		m.mu.Lock()
-		delete(m.pending, anchorID)
-		m.mu.Unlock()
+		for _, l := range m.take(anchorID) {
+			l.OnError(context.Background(), anchorID,
+				errors.New("finality: the watch ended without a verdict"))
+		}
 	}()
 
 	ticker := time.NewTicker(m.pollInterval)
@@ -204,7 +227,9 @@ func (m *Manager) watch(anchor [32]byte, anchorID string, listener driver.Finali
 			}
 			observed = true
 			if code == driver.Valid {
-				listener.OnStatus(ctx, anchorID, code, message, hash)
+				for _, l := range m.take(anchorID) {
+					l.OnStatus(ctx, anchorID, code, message, hash)
+				}
 
 				return
 			}
@@ -212,14 +237,18 @@ func (m *Manager) watch(anchor [32]byte, anchorID string, listener driver.Finali
 			if !observed {
 				// Every read attempt in the window errored: the chain was never actually reached, so
 				// there is no evidence the anchor is invalid, only that it could not be observed.
-				listener.OnError(context.Background(), anchorID,
-					errors.New("finality: could not reach the chain before the timeout"))
+				for _, l := range m.take(anchorID) {
+					l.OnError(context.Background(), anchorID,
+						errors.New("finality: could not reach the chain before the timeout"))
+				}
 
 				return
 			}
 			// The anchor never appeared, and at least one read genuinely confirmed its absence. A
 			// reverted apply emits nothing, so this is the only failure signal available by anchor.
-			listener.OnStatus(context.Background(), anchorID, driver.Invalid, "finality timeout", nil)
+			for _, l := range m.take(anchorID) {
+				l.OnStatus(context.Background(), anchorID, driver.Invalid, "finality timeout", nil)
+			}
 
 			return
 		}

--- a/x/token/services/network/evm/finality/manager_test.go
+++ b/x/token/services/network/evm/finality/manager_test.go
@@ -244,13 +244,43 @@ func TestListenerNotifiedExactlyOnce(t *testing.T) {
 	assert.Equal(t, 1, listener.notified, "a listener must be notified exactly once")
 }
 
-// TestAddListenerRejectsDuplicateWatch checks the manager does not spawn two watchers for one anchor.
-func TestAddListenerRejectsDuplicateWatch(t *testing.T) {
-	m := fastManager(&mock.EVMClient{}, &stubState{}, time.Second)
+// TestAddListenerJoinsAnExistingWatch checks a second listener for one anchor joins the watch already
+// running: it is accepted, it is notified, and it does not start a second poller.
+//
+// The manager used to refuse it. That failed the caller outright, and both registration sites in the
+// token layer treat the failure as fatal, so a node that owns a transaction (registering through the
+// ttx store) and also audits it (registering again through the audit store) had its second Append
+// fail and never wrote the audit record. The Fabric driver's listener manager appends listeners for
+// exactly this reason.
+//
+// Not spawning a second watcher, which is what the refusal was really protecting, still holds: watch
+// is started only for an anchor that had no entry, so one entry holding both listeners is what "one
+// watcher" means here.
+func TestAddListenerJoinsAnExistingWatch(t *testing.T) {
+	state := &stubState{}
+	m := fastManager(&mock.EVMClient{}, state, 5*time.Second)
 
-	require.NoError(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", newRecordingListener()))
-	err := m.AddListener(t.Context(), anchor(0x01), "anchor-1", newRecordingListener())
-	require.Error(t, err)
+	owner, auditor := newRecordingListener(), newRecordingListener()
+	require.NoError(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", owner))
+	require.NoError(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", auditor),
+		"a node that both owns and audits one transaction registers for it twice")
+
+	m.mu.Lock()
+	waiting, entries := len(m.pending["anchor-1"]), len(m.pending)
+	m.mu.Unlock()
+	assert.Equal(t, 2, waiting, "both listeners must be waiting on the one anchor")
+	assert.Equal(t, 1, entries, "and there must be exactly one watch")
+
+	state.apply([]byte("tr-hash"))
+	owner.wait(t)
+	auditor.wait(t)
+
+	for name, l := range map[string]*recordingListener{"owner": owner, "auditor": auditor} {
+		l.mu.Lock()
+		assert.Equal(t, driver.Valid, l.status, "%s must see the transaction as valid", name)
+		assert.Equal(t, 1, l.notified, "%s must be notified exactly once", name)
+		l.mu.Unlock()
+	}
 }
 
 func TestAddListenerRejectsNil(t *testing.T) {

--- a/x/token/services/network/evm/multitms_cross_contamination_test.go
+++ b/x/token/services/network/evm/multitms_cross_contamination_test.go
@@ -222,14 +222,18 @@ func TestMultiTMSCrossContamination_Live(t *testing.T) {
 	// QueryTokens takes a namespace argument (network.go:359) but never uses it to pick a
 	// TokenState: it reads through n.reader, built once in NewNetwork from whichever config ConfigFor
 	// resolved. Ask for TMS B's namespace and see whose contract actually gets called.
+	// Connect's endorsement-policy check reads the chain too, so the read under observation is counted
+	// from where that left off rather than from zero.
+	beforeQuery := evmClient.CallCallCount()
+
 	evmClient.CallReturns(abiBytes([]byte("owned-by-a")), nil)
 	out, err := n.QueryTokens(t.Context(), tmsB.Namespace, []*token.ID{{TxId: anchorHex(0x01), Index: 0}})
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, []byte("owned-by-a"), out[0])
 
-	require.Equal(t, 1, evmClient.CallCallCount())
-	_, calledTo, _, _ := evmClient.CallArgsForCall(0)
+	require.Equal(t, beforeQuery+1, evmClient.CallCallCount())
+	_, calledTo, _, _ := evmClient.CallArgsForCall(beforeQuery)
 	assert.Equal(t, addrA, calledTo,
 		"QueryTokens for the tms-b namespace silently reads through TMS A's TokenState clone")
 	assert.NotEqual(t, addrB, calledTo, "it must not be tms-b's own configured TokenState")

--- a/x/token/services/network/evm/network.go
+++ b/x/token/services/network/evm/network.go
@@ -134,9 +134,10 @@ func (n *Network) Normalize(opt *token2.ServiceOptions) (*token2.ServiceOptions,
 	return opt, nil
 }
 
-// Connect validates that the configured backend is reachable and is the chain the driver signs for,
-// then returns the service options that bind a TMS to this network. Checking here means a
-// misconfigured endpoint or chain id fails at startup rather than at the first transaction.
+// Connect validates that the configured backend is reachable, is the chain the driver signs for, and
+// enforces the endorsement policy this node is configured with, then returns the service options that
+// bind a TMS to this network. Checking here means a misconfigured endpoint, chain id or endorser set
+// fails at startup rather than at the first transaction.
 func (n *Network) Connect(ns string) ([]token2.ServiceOption, error) {
 	ctx := context.Background()
 	chainID, err := n.client.ChainID(ctx)
@@ -146,6 +147,9 @@ func (n *Network) Connect(ns string) ([]token2.ServiceOption, error) {
 	if chainID.Cmp(n.config.ChainIDBig()) != 0 {
 		return nil, errors.Errorf("evm network: node reports chain id %s, configuration says %d",
 			chainID, n.config.ChainID)
+	}
+	if err := n.verifyEndorsementPolicy(ctx); err != nil {
+		return nil, err
 	}
 
 	// Recovery completes transactions this node left Pending when it last stopped. Failing to start

--- a/x/token/services/network/evm/nonce.go
+++ b/x/token/services/network/evm/nonce.go
@@ -15,6 +15,16 @@ import (
 	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
 )
 
+// ErrNonceMayBeConsumed marks a failure that happened once the transaction had already been handed to
+// the node, where the failure is not evidence that the chain never took it. A broadcast that times out
+// or loses its connection is the case that matters: the node may well have accepted and mined the
+// transaction, and only the reply was lost.
+//
+// Everything before that point (gas estimation, fee suggestion, signing) either does not reach the
+// node or cannot consume a nonce, so those failures leave the sequence provably untouched and must not
+// carry this.
+var ErrNonceMayBeConsumed = errors.New("the nonce may have been consumed on chain")
+
 // NonceManager hands out the submitter account's Ethereum transaction nonces. Ethereum requires them
 // to be strictly sequential per account, so two broadcasts must never collide: WithNonce holds a lock
 // across the whole allocate-and-use step, not just the allocation, so nothing else can be mid-flight
@@ -64,6 +74,20 @@ func (n *NonceManager) WithNonce(ctx context.Context, use func(nonce uint64) err
 	}
 
 	if err := use(n.next); err != nil {
+		// A failure that reached the node leaves the local sequence unverifiable: the transaction may
+		// have been accepted and only the reply lost, in which case this nonce is spent and every later
+		// one derived from it is too low. Dropping the cached value makes the next allocation re-read
+		// the chain, which settles the question either way.
+		//
+		// Without this a single lost broadcast reply wedges the account permanently: the manager keeps
+		// reissuing a nonce the chain has already used, every send fails "nonce too low", and nothing
+		// ever re-reads the chain to notice. Re-reading is safe precisely because this lock is held
+		// across the whole step, so there is no other in-flight broadcast whose nonce a fresh read
+		// could fail to account for.
+		if errors.Is(err, ErrNonceMayBeConsumed) {
+			n.initialized = false
+		}
+
 		return err
 	}
 	n.next++

--- a/x/token/services/network/evm/nonce_test.go
+++ b/x/token/services/network/evm/nonce_test.go
@@ -167,3 +167,63 @@ func TestNonceHandlesConcurrentFailuresWithoutDuplicating(t *testing.T) {
 
 	assert.Len(t, got, callers/2, "every successful attempt must have consumed a distinct nonce")
 }
+
+// TestNonceReReadsAfterAnAmbiguousBroadcast covers the one failure that is not proof the chain never
+// saw the transaction.
+//
+// Everything before the broadcast (gas estimation, fee suggestion, signing) either never reaches the
+// node or cannot consume a nonce, so those failures leave the sequence provably untouched and the
+// manager reuses the nonce with no round trip, which TestNonceIsNotAdvancedOnFailure pins. A broadcast
+// that times out or loses its connection is different: the node may have accepted and mined the
+// transaction and only the reply was lost, in which case the nonce is spent.
+//
+// Reusing it there wedges the account for good. Every later send fails "nonce too low", and since that
+// is also a failed broadcast, nothing ever re-reads the chain to notice. Only a restart recovers.
+func TestNonceReReadsAfterAnAmbiguousBroadcast(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.PendingNonceAtReturns(5, nil)
+	n := NewNonceManager(evm, client.Address{})
+
+	// The broadcast fails, but the chain took the transaction: its pending nonce has moved on.
+	err := n.WithNonce(t.Context(), func(nonce uint64) error {
+		assert.Equal(t, uint64(5), nonce)
+
+		return errors.Wrapf(ErrNonceMayBeConsumed, "the reply was lost")
+	})
+	require.Error(t, err)
+	evm.PendingNonceAtReturns(6, nil)
+
+	err = n.WithNonce(t.Context(), func(nonce uint64) error {
+		assert.Equal(t, uint64(6), nonce, "the manager must take the chain's word, not its own stale count")
+
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, evm.PendingNonceAtCallCount(), "an ambiguous broadcast has to cost one re-read")
+
+	next, initialized := n.Cached()
+	assert.True(t, initialized)
+	assert.Equal(t, uint64(7), next)
+}
+
+// TestNonceKeepsItsSequenceWhenTheChainDidNotTakeIt is the other half: the same ambiguous failure when
+// the transaction really was not accepted must not skip a nonce, or the account is left with a gap
+// that stalls every transaction queued behind it.
+func TestNonceKeepsItsSequenceWhenTheChainDidNotTakeIt(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.PendingNonceAtReturns(5, nil)
+	n := NewNonceManager(evm, client.Address{})
+
+	err := n.WithNonce(t.Context(), func(uint64) error {
+		return errors.Wrapf(ErrNonceMayBeConsumed, "the reply was lost")
+	})
+	require.Error(t, err)
+
+	// The chain never took it, so its pending nonce is unchanged and the re-read returns the same value.
+	err = n.WithNonce(t.Context(), func(nonce uint64) error {
+		assert.Equal(t, uint64(5), nonce, "a nonce the chain never consumed must be reused, not skipped")
+
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/x/token/services/network/evm/policy.go
+++ b/x/token/services/network/evm/policy.go
@@ -1,0 +1,169 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"context"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/abi"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+)
+
+// EndorsementVerifier read methods, plus the TokenState accessor that names it. The signatures are
+// canonical ABI forms; their selectors are what the contracts dispatch on.
+const (
+	endorsementVerifierMethod = "endorsementVerifier()"
+	getThresholdMethod        = "getThreshold()"
+	isEndorserMethod          = "isEndorser(address)"
+)
+
+// verifyEndorsementPolicy checks that the endorsement policy this node is configured with is the one
+// the chain will actually enforce.
+//
+// The two are meant to agree, and the configuration says so in its own field comments: the threshold
+// "must match the threshold the EndorsementVerifier was constructed with", and an endorser address is
+// documented as one "registered in the EndorsementVerifier". Nothing checked it. Drift is easy to
+// introduce (a redeploy, a copied config, an endorser added to one side only) and expensive to
+// diagnose, because it does not look like a configuration problem from the outside: the initiator
+// collects what it believes is a quorum, spends a full endorsement round trip doing it, and the
+// transaction is then rejected by the contract. With the estimate gas strategy that surfaces as
+// ErrTransactionReverted, which reads as the chain refusing the delta rather than as this node
+// asking for the wrong number of signatures.
+//
+// This is the same startup guard Connect already applies to the chain id, for the same reason.
+//
+// Only a positively observed contradiction is fatal. A read that fails says nothing about the policy
+// (the contract may not be deployed yet, or the node may be briefly unhappy) and must not take a node
+// down over it, so it is logged and the connection proceeds; the pre-existing behaviour, no check at
+// all, is what a failed read falls back to.
+//
+// The reads are at the latest block rather than the configured tag on purpose. The endorser set and
+// threshold are immutable after the verifier's construction, so there is no value here that a later
+// block can change and no reorg exposure to speak of; reading at "finalized" instead would leave a
+// freshly deployed network unable to see its own verifier for the whole finalization window, turning
+// the common case into the one that gets no checking.
+func (n *Network) verifyEndorsementPolicy(ctx context.Context) error {
+	verifier, ok := n.endorsementVerifierAddress(ctx)
+	if !ok {
+		return nil
+	}
+
+	if configured := n.config.Contracts.EndorsementVerifier; configured != "" {
+		want, err := client.HexToAddress(configured)
+		if err != nil {
+			return errors.Wrap(err, "evm network: invalid endorsementVerifier address")
+		}
+		if want != verifier {
+			return errors.Errorf(
+				"evm network: tokenState [%s] calls verifier %s, configuration says %s",
+				n.tokenState, verifier, want)
+		}
+	}
+
+	if err := n.verifyThreshold(ctx, verifier); err != nil {
+		return err
+	}
+
+	return n.verifyEndorserSet(ctx, verifier)
+}
+
+// endorsementVerifierAddress reads the verifier the TokenState delegates signature checking to. The
+// TokenState holds the authoritative reference, which is why the configuration may leave it out
+// entirely, so it is read from there rather than taken from configuration. It reports false when the
+// answer could not be obtained, which is not an error: see verifyEndorsementPolicy.
+func (n *Network) endorsementVerifierAddress(ctx context.Context) (client.Address, bool) {
+	raw, err := n.client.Call(ctx, n.tokenState, abi.MethodID(endorsementVerifierMethod), client.BlockTagLatest)
+	if err != nil {
+		logger.Warnf("could not read the endorsement verifier of [%s]; skipping the policy check: %v", n.tokenState, err)
+
+		return client.Address{}, false
+	}
+	word, err := abi.DecodeBytes32(raw)
+	if err != nil {
+		logger.Warnf("could not decode the endorsement verifier of [%s]; skipping the policy check: %v", n.tokenState, err)
+
+		return client.Address{}, false
+	}
+	verifier := client.BytesToAddress(word[12:])
+	if verifier == (client.Address{}) {
+		logger.Warnf("tokenState [%s] names no endorsement verifier yet; skipping the policy check", n.tokenState)
+
+		return client.Address{}, false
+	}
+
+	return verifier, true
+}
+
+// verifyThreshold checks the configured quorum size is the one the contract enforces.
+func (n *Network) verifyThreshold(ctx context.Context, verifier client.Address) error {
+	raw, err := n.client.Call(ctx, verifier, abi.MethodID(getThresholdMethod), client.BlockTagLatest)
+	if err != nil {
+		logger.Warnf("could not read the on-chain endorsement threshold from %s: %v", verifier, err)
+
+		return nil
+	}
+	onChain, err := abi.DecodeUint64(raw)
+	if err != nil {
+		logger.Warnf("could not decode the on-chain endorsement threshold from %s: %v", verifier, err)
+
+		return nil
+	}
+	if onChain != uint64(n.config.Endorsement.Threshold) {
+		return errors.Errorf(
+			"evm network: verifier %s requires %d endorsements, configuration says %d; "+
+				"every transaction would collect a quorum this contract rejects",
+			verifier, onChain, n.config.Endorsement.Threshold)
+	}
+
+	return nil
+}
+
+// verifyEndorserSet checks every configured endorser is one the contract will actually accept a
+// signature from. A configured endorser the contract does not know is worse than useless: the
+// initiator routes requests to it and counts its reply toward the quorum, and the contract then
+// rejects the whole bundle as an unauthorized signer, so one stale entry can fail every transaction
+// even when enough genuine endorsers signed.
+//
+// It checks membership per address rather than reading the whole set back, because that needs only a
+// static-word decode of the codec this driver keeps deliberately minimal. The opposite direction, an
+// endorser on chain that this node does not know about, needs no check: the threshold comparison
+// above already catches the case where it matters.
+func (n *Network) verifyEndorserSet(ctx context.Context, verifier client.Address) error {
+	for _, binding := range n.config.Endorsement.Endorsers {
+		address, err := client.HexToAddress(binding.Address)
+		if err != nil {
+			// Validate already rejected this at load time; reaching it here means the configuration was
+			// not loaded through LoadConfig, which is not this check's business to police.
+			return errors.Wrapf(err, "evm network: endorser [%s] has an invalid address", binding.FSCIdentity)
+		}
+
+		var arg [32]byte
+		copy(arg[12:], address[:])
+		raw, err := n.client.Call(ctx, verifier, abi.EncodeBytes32Call(isEndorserMethod, arg), client.BlockTagLatest)
+		if err != nil {
+			logger.Warnf("could not check endorser %s against verifier %s: %v", address, verifier, err)
+
+			return nil
+		}
+		registered, err := abi.DecodeUint64(raw)
+		if err != nil {
+			logger.Warnf("could not decode the endorser check for %s from %s: %v", address, verifier, err)
+
+			return nil
+		}
+		if registered == 0 {
+			return errors.Errorf(
+				"evm network: endorser [%s] at %s is not registered in verifier %s; "+
+					"the contract rejects any bundle carrying its signature",
+				binding.FSCIdentity, address, verifier)
+		}
+	}
+
+	return nil
+}

--- a/x/token/services/network/evm/policy_test.go
+++ b/x/token/services/network/evm/policy_test.go
@@ -1,0 +1,294 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"math/big"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/abi"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client/mock"
+)
+
+const (
+	testVerifier   = "0x1111111111111111111111111111111111111111"
+	testEndorser   = "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"
+	otherEndorser  = "0x2222222222222222222222222222222222222222"
+	unknownAddress = "0x3333333333333333333333333333333333333333"
+)
+
+// abiWord encodes a single static 32-byte return value: an address, a uint256 or a bool, all of which
+// the verifier's reads return in one word.
+func abiWord(b []byte) []byte {
+	out := make([]byte, 32)
+	copy(out[32-len(b):], b)
+
+	return out
+}
+
+func abiUint(v uint64) []byte {
+	out := make([]byte, 32)
+	binary.BigEndian.PutUint64(out[24:], v)
+
+	return out
+}
+
+func addressWord(t *testing.T, hexAddr string) []byte {
+	t.Helper()
+	a, err := client.HexToAddress(hexAddr)
+	require.NoError(t, err)
+
+	return abiWord(a[:])
+}
+
+// policyChain answers the three reads the policy check makes, so a test states the chain's side of
+// the policy declaratively instead of matching selectors by hand.
+type policyChain struct {
+	verifier   string
+	threshold  uint64
+	registered map[string]bool
+	// failOn, when set, makes the named read fail, for the degraded paths.
+	failOn string
+}
+
+func (p policyChain) install(t *testing.T, evm *mock.EVMClient) {
+	t.Helper()
+	verifierSel := abi.MethodID(endorsementVerifierMethod)
+	thresholdSel := abi.MethodID(getThresholdMethod)
+	isEndorserSel := abi.MethodID(isEndorserMethod)
+
+	evm.CallStub = func(_ context.Context, _ client.Address, data []byte, _ string) ([]byte, error) {
+		switch {
+		case bytes.HasPrefix(data, verifierSel):
+			if p.failOn == endorsementVerifierMethod {
+				return nil, errors.New("node is unhappy")
+			}
+
+			return addressWord(t, p.verifier), nil
+		case bytes.HasPrefix(data, thresholdSel):
+			if p.failOn == getThresholdMethod {
+				return nil, errors.New("node is unhappy")
+			}
+
+			return abiUint(p.threshold), nil
+		case bytes.HasPrefix(data, isEndorserSel):
+			if p.failOn == isEndorserMethod {
+				return nil, errors.New("node is unhappy")
+			}
+			queried := client.BytesToAddress(data[len(isEndorserSel)+12:])
+			if p.registered[queried.Hex()] {
+				return abiUint(1), nil
+			}
+
+			return abiUint(0), nil
+		}
+
+		return nil, errors.Errorf("unexpected call %x", data)
+	}
+}
+
+// policyNetwork builds a Network whose configuration is mutated by tweak before it is validated.
+func policyNetwork(t *testing.T, evm *mock.EVMClient, tweak func(*Config)) *Network {
+	t.Helper()
+	evm.ChainIDReturns(big.NewInt(testChainID), nil)
+
+	c := validConfig()
+	if tweak != nil {
+		tweak(c)
+	}
+	c.applyDefaults()
+	require.NoError(t, c.Validate())
+
+	n, err := NewNetwork("evm-net", c, evm, nil, nil, nil)
+	require.NoError(t, err)
+
+	return n
+}
+
+func registered(addrs ...string) map[string]bool {
+	out := map[string]bool{}
+	for _, a := range addrs {
+		out[a] = true
+	}
+
+	return out
+}
+
+// TestConnectAcceptsAMatchingPolicy is the control: a configuration that agrees with the chain
+// connects, so the checks below are failing on the disagreement and not on the check itself.
+func TestConnectAcceptsAMatchingPolicy(t *testing.T) {
+	evm := &mock.EVMClient{}
+	policyChain{
+		verifier:   testVerifier,
+		threshold:  1,
+		registered: registered(mustAddr(t, testEndorser)),
+	}.install(t, evm)
+
+	n := policyNetwork(t, evm, nil)
+
+	_, err := n.Connect("token")
+	assert.NoError(t, err)
+}
+
+// TestConnectRejectsAThresholdTheChainDoesNotEnforce covers the drift that is hardest to read from
+// the outside: the node collects what it believes is a quorum, and the contract rejects the bundle
+// for being one signature short, which surfaces as a revert rather than as a misconfiguration.
+func TestConnectRejectsAThresholdTheChainDoesNotEnforce(t *testing.T) {
+	evm := &mock.EVMClient{}
+	policyChain{
+		verifier:   testVerifier,
+		threshold:  2,
+		registered: registered(mustAddr(t, testEndorser)),
+	}.install(t, evm)
+
+	n := policyNetwork(t, evm, nil)
+
+	_, err := n.Connect("token")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires 2 endorsements, configuration says 1")
+}
+
+// TestConnectRejectsAnEndorserTheVerifierDoesNotKnow covers a stale entry in the endorser set. The
+// initiator routes to it and counts its reply, and the contract then rejects the whole bundle as an
+// unauthorized signer, so one wrong address can fail every transaction even with enough real signers.
+func TestConnectRejectsAnEndorserTheVerifierDoesNotKnow(t *testing.T) {
+	evm := &mock.EVMClient{}
+	policyChain{
+		verifier:   testVerifier,
+		threshold:  2,
+		registered: registered(mustAddr(t, testEndorser)),
+	}.install(t, evm)
+
+	n := policyNetwork(t, evm, func(c *Config) {
+		c.Endorsement.Threshold = 2
+		c.Endorsement.Endorsers = append(c.Endorsement.Endorsers,
+			EndorserBinding{Address: unknownAddress, FSCIdentity: "endorser-2"})
+	})
+
+	_, err := n.Connect("token")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not registered in verifier")
+	assert.Contains(t, err.Error(), "endorser-2")
+}
+
+// TestConnectRejectsAVerifierTheConfigurationDisagreesWith checks the optional configured verifier is
+// held to the TokenState's own answer, which is the authoritative one.
+func TestConnectRejectsAVerifierTheConfigurationDisagreesWith(t *testing.T) {
+	evm := &mock.EVMClient{}
+	policyChain{
+		verifier:   testVerifier,
+		threshold:  1,
+		registered: registered(mustAddr(t, testEndorser)),
+	}.install(t, evm)
+
+	n := policyNetwork(t, evm, func(c *Config) {
+		c.Contracts.EndorsementVerifier = otherEndorser
+	})
+
+	_, err := n.Connect("token")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "calls verifier")
+}
+
+// TestConnectProceedsWhenThePolicyCannotBeRead pins the deliberate asymmetry: only a positively
+// observed contradiction is fatal. A read that fails says nothing about the policy -- the contract may
+// not be deployed yet, or the node may be briefly unhappy -- and must not take a node down, since no
+// check at all is what the driver did before this existed.
+//
+// Each case makes exactly one read unreadable and puts the contradiction behind that same read, with
+// everything else agreeing. That way a passing case is evidence the unreadable check was skipped
+// rather than evidence there was nothing to catch.
+func TestConnectProceedsWhenThePolicyCannotBeRead(t *testing.T) {
+	for _, tc := range []struct {
+		failOn string
+		chain  policyChain
+	}{
+		{
+			// The verifier address is unreachable, so nothing downstream of it can be checked at all.
+			failOn: endorsementVerifierMethod,
+			chain:  policyChain{threshold: 99, registered: map[string]bool{}},
+		},
+		{
+			// A threshold that would be refused, behind a read that fails.
+			failOn: getThresholdMethod,
+			chain:  policyChain{verifier: testVerifier, threshold: 99, registered: registered(mustAddr(t, testEndorser))},
+		},
+		{
+			// An endorser set that would be refused, behind a read that fails.
+			failOn: isEndorserMethod,
+			chain:  policyChain{verifier: testVerifier, threshold: 1, registered: map[string]bool{}},
+		},
+	} {
+		t.Run(tc.failOn, func(t *testing.T) {
+			evm := &mock.EVMClient{}
+			chain := tc.chain
+			chain.failOn = tc.failOn
+			chain.install(t, evm)
+
+			n := policyNetwork(t, evm, nil)
+
+			_, err := n.Connect("token")
+			assert.NoError(t, err, "an unreadable policy must not refuse the connection")
+		})
+	}
+}
+
+// TestConnectRefusesTheSameContradictionsWhenTheyAreReadable is the counterpart to the case above: the
+// exact chain states it tolerates while unreadable are refused once they can actually be read, so the
+// tolerance is about the failed read and not about the check being toothless.
+func TestConnectRefusesTheSameContradictionsWhenTheyAreReadable(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		chain policyChain
+	}{
+		{"threshold", policyChain{verifier: testVerifier, threshold: 99, registered: registered(mustAddr(t, testEndorser))}},
+		{"endorser set", policyChain{verifier: testVerifier, threshold: 1, registered: map[string]bool{}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			evm := &mock.EVMClient{}
+			tc.chain.install(t, evm)
+
+			n := policyNetwork(t, evm, nil)
+
+			_, err := n.Connect("token")
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestConnectSkipsAnUninitializedTokenState covers a TokenState that names no verifier yet, which is
+// the shape a clone has before initialize runs rather than a policy disagreement.
+func TestConnectSkipsAnUninitializedTokenState(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.ChainIDReturns(big.NewInt(testChainID), nil)
+	evm.CallReturns(make([]byte, 32), nil) // the zero address
+
+	c := validConfig()
+	c.applyDefaults()
+	require.NoError(t, c.Validate())
+	n, err := NewNetwork("evm-net", c, evm, nil, nil, nil)
+	require.NoError(t, err)
+
+	_, err = n.Connect("token")
+	assert.NoError(t, err)
+}
+
+func mustAddr(t *testing.T, hexAddr string) string {
+	t.Helper()
+	a, err := client.HexToAddress(hexAddr)
+	require.NoError(t, err)
+
+	return a.Hex()
+}

--- a/x/token/services/network/evm/pp/watcher.go
+++ b/x/token/services/network/evm/pp/watcher.go
@@ -56,8 +56,8 @@ type Watcher struct {
 	mu      sync.Mutex
 	cancel  context.CancelFunc
 	stopped chan struct{}
-	// seen is the last version handed to the handler. It starts unset so the first observation
-	// establishes a baseline instead of replaying the parameters the node already started with.
+	// seen is the last version successfully applied by the handler. It starts unset, and the first
+	// observation is applied rather than merely recorded: see poll.
 	seen    uint64
 	hasSeen bool
 }
@@ -135,9 +135,18 @@ func (w *Watcher) run(ctx context.Context, stopped chan struct{}) {
 	}
 }
 
-// poll checks the version once and, if it moved, reads the new parameters and calls the handler. A
-// failed read is logged and retried on the next tick rather than ending the watch: the node is worse
-// off with stale parameters, but far worse off if a transient RPC error stopped it noticing forever.
+// poll checks the version and, if it is not the one already applied, reads the parameters and calls
+// the handler. A failed read is logged and retried on the next tick rather than ending the watch: the
+// node is worse off with stale parameters, but far worse off if a transient RPC error stopped it
+// noticing forever.
+//
+// The very first observation is applied rather than taken as a baseline. It used to be recorded
+// silently, on the reasoning that the node already has whatever the chain has, but that is exactly
+// what is not true after a restart: the token layer resolves public parameters from its own storage
+// before it ever asks the chain (see loadPublicParams), so a node that was down when an update landed
+// comes back holding the old parameters, and a watcher that only reports later changes would leave it
+// there indefinitely. Applying the first observation costs nothing when the two already agree, because
+// the handler is a no-op for parameters the node is already running.
 func (w *Watcher) poll(ctx context.Context) {
 	w.versions.Invalidate()
 	version, err := w.versions.GetVersion(ctx)
@@ -149,12 +158,9 @@ func (w *Watcher) poll(ctx context.Context) {
 
 	w.mu.Lock()
 	seen, hasSeen := w.seen, w.hasSeen
-	if !hasSeen {
-		w.seen, w.hasSeen = version, true
-	}
 	w.mu.Unlock()
 
-	if !hasSeen || version == seen {
+	if hasSeen && version == seen {
 		return
 	}
 
@@ -178,7 +184,7 @@ func (w *Watcher) poll(ctx context.Context) {
 	// Record what was actually applied rather than what the version poll reported. They can differ if
 	// another update landed in between, and the parameters are the thing that matters.
 	w.mu.Lock()
-	w.seen = actual
+	w.seen, w.hasSeen = actual, true
 	w.mu.Unlock()
 	logger.Infof("public parameters updated to version %d", actual)
 }

--- a/x/token/services/network/evm/pp/watcher_test.go
+++ b/x/token/services/network/evm/pp/watcher_test.go
@@ -82,13 +82,13 @@ func newWatcherHarness(t *testing.T, state *chainState) (*Watcher, *[]update, *s
 	return w, &got, &mu
 }
 
-// baselineSet reports whether the watcher has observed the chain at least once, which is when it
-// starts treating a version change as an update rather than as its starting point. Tests wait on it
-// before changing the chain, so that the change is seen as an update and not as the baseline.
+// applied reports whether the watcher has successfully applied a version. Tests wait on it before
+// moving the chain, so the move is observed as a change from a settled state rather than racing the
+// watcher's first read.
 //
 // It lives here rather than on Watcher because only tests need it, and it takes the lock because the
 // polling goroutine is what writes the fields.
-func baselineSet(w *Watcher) bool {
+func applied(w *Watcher) bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -105,39 +105,50 @@ func TestWatcherReportsAnUpdate(t *testing.T) {
 	w.Start(context.Background())
 	defer w.Stop()
 
-	// let it establish a baseline, then move the chain on
-	require.Eventually(t, func() bool { return baselineSet(w) }, time.Second, 5*time.Millisecond)
+	// let it settle on what the chain already has, then move the chain on
+	require.Eventually(t, func() bool { return applied(w) }, time.Second, 5*time.Millisecond)
 	state.set("params-v1", 1)
 
 	require.Eventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 
-		return len(*got) == 1
+		return len(*got) == 2
 	}, 2*time.Second, 5*time.Millisecond)
 
 	mu.Lock()
 	defer mu.Unlock()
-	assert.Equal(t, update{raw: "params-v1", version: 1}, (*got)[0])
+	assert.Equal(t, update{raw: "params-v0", version: 0}, (*got)[0], "the startup state is applied first")
+	assert.Equal(t, update{raw: "params-v1", version: 1}, (*got)[1], "then the change is reported")
 }
 
-// TestWatcherDoesNotReplayTheStartingParameters checks the first observation only establishes a
-// baseline. A node already holds the parameters it started with, so announcing them as an update
-// would reload every TMS for nothing on every start.
-func TestWatcherDoesNotReplayTheStartingParameters(t *testing.T) {
+// TestWatcherAppliesWhatTheChainHasAtStartup covers the restart a node does not otherwise recover
+// from.
+//
+// The first observation used to be recorded as a baseline and not applied, on the reasoning that a
+// node already holds whatever the chain holds. That is exactly what is false after a restart: the
+// token layer resolves public parameters from its own storage before it ever asks the chain
+// (loadPublicParams priorities 2 and 4), so a node that was down when an update landed comes back
+// holding the old parameters. Reporting only later changes left it there indefinitely, endorsing and
+// validating against parameters the chain had already replaced.
+//
+// A chain sitting at version 3 makes the point: this node cannot have been present for versions 1 to
+// 3, so treating what it finds as "what we already have" is not a safe assumption.
+func TestWatcherAppliesWhatTheChainHasAtStartup(t *testing.T) {
 	state := &chainState{}
-	state.set("params-v0", 3)
+	state.set("params-v3", 3)
 
 	w, got, mu := newWatcherHarness(t, state)
 	w.Start(context.Background())
 	defer w.Stop()
 
-	require.Eventually(t, func() bool { return baselineSet(w) }, time.Second, 5*time.Millisecond)
+	require.Eventually(t, func() bool { return applied(w) }, time.Second, 5*time.Millisecond)
 	time.Sleep(50 * time.Millisecond)
 
 	mu.Lock()
 	defer mu.Unlock()
-	assert.Empty(t, *got, "a steady chain must produce no updates")
+	require.Len(t, *got, 1, "the chain's current parameters must be applied exactly once at startup")
+	assert.Equal(t, update{raw: "params-v3", version: 3}, (*got)[0])
 }
 
 // TestWatcherReportsEachUpdateOnce checks a version that stays put is not re-reported, so a handler
@@ -150,7 +161,7 @@ func TestWatcherReportsEachUpdateOnce(t *testing.T) {
 	w.Start(context.Background())
 	defer w.Stop()
 
-	require.Eventually(t, func() bool { return baselineSet(w) }, time.Second, 5*time.Millisecond)
+	require.Eventually(t, func() bool { return applied(w) }, time.Second, 5*time.Millisecond)
 	state.set("params-v1", 1)
 	require.Eventually(t, func() bool {
 		mu.Lock()
@@ -221,7 +232,7 @@ func TestWatcherSurvivesAFailedRead(t *testing.T) {
 	w.Start(context.Background())
 	defer w.Stop()
 
-	require.Eventually(t, func() bool { return baselineSet(w) }, time.Second, 5*time.Millisecond)
+	require.Eventually(t, func() bool { return applied(w) }, time.Second, 5*time.Millisecond)
 	state.set("params-v1", 1)
 
 	require.Eventually(t, func() bool {
@@ -239,12 +250,11 @@ func TestWatcherRetriesAFailedHandler(t *testing.T) {
 	state := &chainState{}
 	state.set("params-v0", 0)
 
+	state.set("params-v1", 1)
+
 	w, attempts, mu := newFailingWatcherHarness(t, state, 3)
 	w.Start(context.Background())
 	defer w.Stop()
-
-	require.Eventually(t, func() bool { return baselineSet(w) }, time.Second, 5*time.Millisecond)
-	state.set("params-v1", 1)
 
 	require.Eventually(t, func() bool {
 		mu.Lock()
@@ -308,17 +318,21 @@ func TestWatcherStopIsIdempotentAndBlocks(t *testing.T) {
 	w, got, mu := newWatcherHarness(t, state)
 	w.Start(context.Background())
 	w.Start(context.Background()) // second start must be a no-op
-	require.Eventually(t, func() bool { return baselineSet(w) }, time.Second, 5*time.Millisecond)
+	require.Eventually(t, func() bool { return applied(w) }, time.Second, 5*time.Millisecond)
 
 	w.Stop()
 	w.Stop() // stopping twice must not panic
+
+	mu.Lock()
+	before := len(*got)
+	mu.Unlock()
 
 	state.set("params-v1", 1)
 	time.Sleep(50 * time.Millisecond)
 
 	mu.Lock()
 	defer mu.Unlock()
-	assert.Empty(t, *got, "a stopped watcher must not report anything")
+	assert.Len(t, *got, before, "a stopped watcher must not report anything further")
 }
 
 func TestNewWatcherValidatesItsInput(t *testing.T) {

--- a/x/token/services/network/evm/recovery.go
+++ b/x/token/services/network/evm/recovery.go
@@ -210,6 +210,13 @@ func (n settledNetwork) age(ctx context.Context, txID string) (time.Duration, bo
 	if record == nil {
 		return 0, false, nil
 	}
+	// An unset timestamp would read as an age of two thousand years and condemn the transaction on the
+	// very first sweep. "Not known" is the honest answer and the safe one: the caller leaves the
+	// transaction Unknown and looks again, which is what it already does when the store cannot be read
+	// at all.
+	if record.Timestamp.IsZero() {
+		return 0, false, nil
+	}
 
 	return time.Since(record.Timestamp), true, nil
 }

--- a/x/token/services/network/evm/recovery_test.go
+++ b/x/token/services/network/evm/recovery_test.go
@@ -143,6 +143,23 @@ func TestSettledNetworkResolvesAnAbsentAnchor(t *testing.T) {
 		assert.Equal(t, hash, got, "the token request hash must reach the handler intact")
 	})
 
+	// A record with no timestamp is the one input that reads as catastrophically old: time.Since of
+	// the zero time is two thousand years, which would clear the timeout on the very first sweep and
+	// condemn a transaction that may have been submitted seconds ago. "Not known" is the honest answer
+	// and the safe one, matching what an unreadable store already does.
+	t.Run("a record with no timestamp stays unknown", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.ChainIDReturns(bigInt(testChainID), nil)
+		evm.CallReturns(absent, nil)
+		n := testNetwork(t, evm, nil)
+		settled := settledNetwork{Network: n, store: &agedStore{unset: true}, timeout: timeout}
+		txID := n.ComputeTxID(&driver.TxID{Creator: []byte("creator")})
+
+		status, _, _, err := settled.GetTransactionStatus(t.Context(), "token", txID)
+		require.NoError(t, err)
+		assert.Equal(t, driver.Unknown, status, "an unknown age must not be read as an infinite one")
+	})
+
 	// A node that could not be reached has established nothing about the transaction, so it stays a
 	// failure to be retried rather than becoming a verdict.
 	t.Run("an unreachable node is not a verdict", func(t *testing.T) {
@@ -171,6 +188,9 @@ type agedStore struct {
 	recoveryStore
 	age time.Duration
 	err error
+	// unset makes the record come back with no timestamp, the shape a store that never populated the
+	// column would produce.
+	unset bool
 }
 
 func (s *agedStore) Transactions(
@@ -182,8 +202,13 @@ func (s *agedStore) Transactions(
 		return nil, s.err
 	}
 
+	record := &dbdriver.TransactionRecord{Timestamp: time.Now().Add(-s.age)}
+	if s.unset {
+		record.Timestamp = time.Time{}
+	}
+
 	return &cdriver.PageIterator[*dbdriver.TransactionRecord]{
-		Items: iterators.Slice([]*dbdriver.TransactionRecord{{Timestamp: time.Now().Add(-s.age)}}),
+		Items: iterators.Slice([]*dbdriver.TransactionRecord{record}),
 	}, nil
 }
 

--- a/x/token/services/network/evm/statedelta/translator.go
+++ b/x/token/services/network/evm/statedelta/translator.go
@@ -188,9 +188,15 @@ func (t *Translator) writeTransfer(action translator.TransferAction) error {
 	}
 	// Redeem outputs are skipped but their slot still consumes an output index, exactly as the
 	// Fabric translator enumerates them.
-	// Read once, outside the loop: see the matching comment in writeIssue.
+	// Read once, outside the loop: see the matching comment in writeIssue. numOutputs is read once
+	// for the same reason and additionally because it is used twice, to bound the loop and to advance
+	// the counter: reading it again for the second use would let an action whose NumOutputs() is not
+	// perfectly idempotent enumerate one range of indexes and advance the counter by another, so every
+	// later action in the request would derive its token ids at the wrong offsets, and two endorsers
+	// reading different values would emit different deltas and never assemble a quorum.
 	graphHiding := action.IsGraphHiding()
-	for i := range action.NumOutputs() {
+	numOutputs := action.NumOutputs()
+	for i := range numOutputs {
 		if action.IsRedeemAt(i) {
 			continue
 		}
@@ -200,7 +206,7 @@ func (t *Translator) writeTransfer(action translator.TransferAction) error {
 		}
 		t.appendOutput(t.counter+uint64(i), output, graphHiding) // #nosec G115 -- i is a small output index
 	}
-	t.counter += uint64(action.NumOutputs()) // #nosec G115 -- output counts are small
+	t.counter += uint64(numOutputs) // #nosec G115 -- output counts are small
 
 	if err := t.appendSpentRefs(action); err != nil {
 		return err

--- a/x/token/services/network/evm/statedelta/translator_test.go
+++ b/x/token/services/network/evm/statedelta/translator_test.go
@@ -9,6 +9,7 @@ package statedelta
 import (
 	"context"
 	"encoding/hex"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -299,7 +300,7 @@ func TestTransferReadsNumOutputsOnce(t *testing.T) {
 	first.NumOutputsReturns(99)
 	first.NumOutputsReturnsOnCall(0, 2)
 	first.IsRedeemAtCalls(func(int) bool { return false })
-	first.SerializeOutputAtCalls(func(i int) ([]byte, error) { return []byte{byte(i)}, nil })
+	first.SerializeOutputAtCalls(func(i int) ([]byte, error) { return []byte("out-" + strconv.Itoa(i)), nil })
 	first.IsGraphHidingReturns(false)
 
 	tr := NewTranslator(anchor, testPP, 1)

--- a/x/token/services/network/evm/statedelta/translator_test.go
+++ b/x/token/services/network/evm/statedelta/translator_test.go
@@ -281,3 +281,35 @@ func TestErrorPaths(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// TestTransferReadsNumOutputsOnce pins that writeTransfer consults NumOutputs() a single time.
+//
+// It is used twice, to bound the output loop and to advance the shared output counter. NumOutputs is
+// an interface method rather than a field, so an implementation whose answer moves between the two
+// reads would enumerate one range of indexes and advance the counter by another. Every later action
+// in the same request would then derive its token ids at the wrong offsets, and two endorsers that
+// happened to read different values would emit different deltas and never assemble a quorum.
+//
+// The fake answers 2 on the first call and 99 on any later one, so the second transfer's output must
+// land at index 2 for the counter to have followed the range actually enumerated.
+func TestTransferReadsNumOutputsOnce(t *testing.T) {
+	anchor := testAnchor(0x42)
+
+	first := &mock.TransferAction{}
+	first.NumOutputsReturns(99)
+	first.NumOutputsReturnsOnCall(0, 2)
+	first.IsRedeemAtCalls(func(int) bool { return false })
+	first.SerializeOutputAtCalls(func(i int) ([]byte, error) { return []byte{byte(i)}, nil })
+	first.IsGraphHidingReturns(false)
+
+	tr := NewTranslator(anchor, testPP, 1)
+	require.NoError(t, tr.Write(context.Background(), first))
+	require.NoError(t, tr.Write(context.Background(),
+		transferAction(nil, nil, [][]byte{[]byte("second")}, nil, nil)))
+
+	d := finish(t, tr)
+
+	require.Len(t, d.Outputs, 3)
+	assert.Equal(t, keys.ComputeTokenID(anchor, 2), d.Outputs[2].TokenID,
+		"the counter must advance by the output count the loop actually enumerated")
+}

--- a/x/token/services/network/evm/submitter.go
+++ b/x/token/services/network/evm/submitter.go
@@ -120,8 +120,15 @@ func (s *Submitter) Submit(
 			// A transaction the node refused to accept was never judged by the chain, so this is the
 			// transient class: the delta is still valid and the caller should retry rather than
 			// re-derive it. A node that executed it and rejected it comes back through gasLimit instead.
+			//
+			// It also carries ErrNonceMayBeConsumed. This is the one step that can fail after the node
+			// has the transaction, so "the broadcast failed" is not proof the chain never took it: a
+			// timeout or a dropped connection looks identical to a node that accepted and mined it and
+			// then lost the reply. The nonce manager re-reads the chain rather than reissuing a nonce
+			// that may already be spent.
 			return errors.Wrapf(
-				ErrNetworkUnavailable, "submitter: failed to broadcast the transaction: %v", sendErr)
+				errors.Join(ErrNetworkUnavailable, ErrNonceMayBeConsumed),
+				"submitter: failed to broadcast the transaction: %v", sendErr)
 		}
 
 		rawTx, txHash = signed, hash

--- a/x/token/services/network/evm/submitter_test.go
+++ b/x/token/services/network/evm/submitter_test.go
@@ -115,12 +115,16 @@ func TestSubmitFixedGasStrategy(t *testing.T) {
 	assert.Zero(t, evm.EstimateGasCallCount(), "a fixed limit must not consult the node")
 }
 
-// TestSubmitDoesNotAdvanceTheNonceOnFailure is the production trap: a nonce allocated for a
-// transaction that never reached the node must not be lost, or every later transaction sits
-// unmineable behind the gap. Submit runs the whole attempt under the nonce manager's lock, so a
-// failure simply leaves the nonce exactly where it was, ready to be reused without asking the chain
-// again.
-func TestSubmitDoesNotAdvanceTheNonceOnFailure(t *testing.T) {
+// TestSubmitDoesNotSkipTheNonceOnAFailedBroadcast is the production trap: a nonce allocated for a
+// transaction the chain never took must not be lost, or every later transaction sits unmineable
+// behind the gap.
+//
+// The assertion is on the nonce the next attempt actually gets, not on how the submitter arrived at
+// it. A failed broadcast is the one step that may have reached the chain, so the manager re-reads the
+// node rather than trusting its own count; when the chain never took the transaction, as here, that
+// read returns the same nonce and no gap appears. The recovery direction, where the chain did take it,
+// is TestNonceReReadsAfterAnAmbiguousBroadcast.
+func TestSubmitDoesNotSkipTheNonceOnAFailedBroadcast(t *testing.T) {
 	evm := readySubmitterClient()
 	evm.SendRawTransactionReturns(client.Hash{}, errors.New("broadcast rejected"))
 	s := testSubmitter(t, evm, estimateGas())
@@ -128,9 +132,14 @@ func TestSubmitDoesNotAdvanceTheNonceOnFailure(t *testing.T) {
 	_, _, err := s.Submit(t.Context(), testDelta(), [][]byte{make([]byte, 65)})
 	require.Error(t, err)
 
-	next, initialized := s.nonces.Cached()
-	assert.True(t, initialized, "the manager still knows its sequence; there was nothing to lose")
-	assert.Equal(t, uint64(3), next, "the nonce this attempt held must still be the next one handed out")
+	// The chain never took it, so its pending nonce has not moved.
+	var reused uint64
+	evm.SendRawTransactionReturns(client.Hash{}, nil)
+	_, _, err = s.Submit(t.Context(), testDelta(), [][]byte{make([]byte, 65)})
+	require.NoError(t, err)
+	reused, _ = s.nonces.Cached()
+
+	assert.Equal(t, uint64(4), reused, "the retry must consume the nonce the failed attempt held, leaving no gap")
 }
 
 // TestSubmitClassifiesARevertedEstimate covers the verdict the shared fungible bodies actually read.


### PR DESCRIPTION
Another self-review pass over the evm driver, this time against the merged tip. Twelve fixes, one commit each.

Three of them are the ones that matter.

A single lost broadcast reply used to wedge the submitting account for good. `WithNonce` only advances on success, on the reasoning that a failure means the chain never took the transaction. That holds everywhere except `eth_sendRawTransaction`, where a timeout looks exactly like a node that accepted and mined it and then lost the reply. The nonce was spent on chain, the driver kept reissuing it, every later send failed "nonce too low", and since that is itself a failed broadcast nothing ever re-read the chain. Only restarting the process recovered.

`isReverted` only knew Besu's revert code, so on geth or anvil a permanently rejected transaction came back as `ErrNetworkUnavailable`, whose contract is "retry with backoff". A caller following that would retry a doomed transaction forever. The existing table test hid it, because its "geth wording" case used Besu's code.

A node that was down when public parameters changed never caught up. The watcher took its first observation as a baseline instead of applying it, assuming a node already holds whatever the chain holds. The token layer resolves parameters from its own storage before it ever asks the chain, so that assumption breaks on exactly the restart where it matters.

The rest:

* `Connect` never checked the configured endorser set or threshold against the chain, although the config comments say both have to match. Drift only surfaced as a revert, after a full endorsement round trip had already been spent.
* `finality.Manager` refused a second listener per transaction. Both registration sites in the token layer treat that as fatal, so a node that owns and also audits one transaction never wrote its audit record.
* `parseHexBig` accepted signed quantities, and `rlpBigInt` encodes magnitude, so a negative fee from a node would have been signed as a positive one.
* The JSON-RPC response body was unbounded.
* Both nwo node starters leaked their container when the node never became ready, and `Cleanup` stopped a shared node once per TMS.

Two of the twelve are hardening rather than reachable bugs, and their commit messages say so.

Every finding was reproduced before it was fixed. The nonce wedge, the revert classification and the endorsement policy check are all tested against a real anvil node, since none of them could be caught with a handwritten error body.
