### PR TITLE
identity: getSignerAndCache can return (nil, nil) because secondcache.Delete does not delete

### DIFF
--- a/token/services/identity/provider.go
+++ b/token/services/identity/provider.go
@@ -176,6 +176,13 @@ func (p *Provider) GetSigner(ctx context.Context, identity driver.Identity) (dri
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get signer for identity [%s], it is neither register nor deserialazable", identity.String())
 	}
+	if signer == nil {
+		// Defense in depth: no resolution path may report success with a nil signer. Returning
+		// (nil, nil) here would defer the failure to the caller's first Sign() call, panicking far
+		// from the actual cause. See getSignerAndCache for the cache-tombstone case that makes a
+		// nil signer reachable.
+		return nil, errors.Errorf("no signer available for identity [%s]", identity.String())
+	}
 
 	return signer, nil
 }
@@ -296,8 +303,11 @@ func (p *Provider) getSigner(ctx context.Context, identity driver.Identity, idHa
 // unchanged rather than overwritten, since that recursion is an implementation detail of the
 // fallback resolution, not a resolution of its own.
 func (p *Provider) getSignerAndCache(ctx context.Context, identity driver.Identity, idHash string, shouldCache bool) (driver.Signer, bool, string, error) {
-	// check cache
-	if entry, ok := p.signers.Get(idHash); ok {
+	// check cache. A cache hit carrying a nil entry is a tombstone left by secondcache.Delete,
+	// which zeroes the stored value in place rather than removing the key, so a later Get returns
+	// (nil, true). Treat that as a miss and re-resolve, instead of dereferencing entry.Signer on a
+	// nil *SignerEntry and panicking.
+	if entry, ok := p.signers.Get(idHash); ok && entry != nil {
 		p.Logger.DebugfContext(ctx, "signer for [%s] found", idHash)
 
 		return entry.Signer, false, "cache", nil

--- a/token/services/identity/provider_test.go
+++ b/token/services/identity/provider_test.go
@@ -9,7 +9,9 @@ package identity_test
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
+	"unsafe"
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	drvmock "github.com/LFDT-Panurus/panurus/token/driver/mock"
@@ -206,6 +208,73 @@ func TestProvider_GetAuditInfo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, audit, ai)
 	require.Equal(t, 1, storage.GetAuditInfoCallCount())
+}
+
+// tombstoneSigner reproduces the state FSC's secondcache.Delete leaves behind: the signers-cache
+// key for id survives, but its stored *SignerEntry is zeroed to nil, so a later Get returns
+// (nil, true). The signers cache is an unexported field of Provider with no public invalidation
+// API, so from this black-box test package the only way to create the tombstone is to reach the
+// field via reflection and invoke its exported Delete. The reflect.NewAt+UnsafeAddr dance strips
+// the read-only flag that reflection puts on values read from unexported fields, making the
+// interface value callable.
+func tombstoneSigner(t *testing.T, p *identity.Provider, id driver.Identity) {
+	t.Helper()
+	field := reflect.ValueOf(p).Elem().FieldByName("signers")
+	field = reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
+	field.MethodByName("Delete").Call([]reflect.Value{reflect.ValueOf(id.UniqueID())})
+}
+
+// TestProvider_GetSigner_TombstonedCacheEntryIsMiss reproduces the latent nil-pointer footgun
+// behind issue #2065: FSC's secondcache.Delete does not remove the key, it zeroes the stored value
+// in place, so a later Get returns (nil, true). getSignerAndCache must treat that nil entry as a
+// cache miss and re-resolve, rather than dereferencing entry.Signer on a nil *SignerEntry (which
+// panicked before the fix).
+func TestProvider_GetSigner_TombstonedCacheEntryIsMiss(t *testing.T) {
+	storage := &idmock.Storage{}
+	des := &idmock.Deserializer{}
+	nbs := &idmock.NetworkBinderService{}
+	eidu := &idmock.EnrollmentIDUnmarshaler{}
+
+	p := identity.NewProvider(logging.MustGetLogger(), storage, des, nbs, eidu, nil)
+
+	id := driver.Identity("an_identity")
+	expected := &drvmock.Signer{}
+	des.DeserializeSignerReturns(expected, nil)
+	storage.StoreSignerInfoReturns(nil)
+
+	// first resolution caches the signer under id
+	s, err := p.GetSigner(t.Context(), id)
+	require.NoError(t, err)
+	require.Equal(t, expected, s)
+
+	// simulate FSC secondcache.Delete: the key survives with a nil value, so the next Get is a
+	// (nil, true) tombstone
+	tombstoneSigner(t, p, id)
+
+	// must not panic; the tombstone is treated as a miss and the signer is re-resolved
+	s, err = p.GetSigner(t.Context(), id)
+	require.NoError(t, err)
+	require.Equal(t, expected, s)
+}
+
+// TestProvider_GetSigner_NilSignerReturnsError checks the defense-in-depth guard: when resolution
+// yields a nil signer without an error (e.g. a deserializer that returns (nil, nil)), GetSigner
+// returns an error instead of propagating a nil signer that would panic on the caller's first Sign.
+func TestProvider_GetSigner_NilSignerReturnsError(t *testing.T) {
+	storage := &idmock.Storage{}
+	des := &idmock.Deserializer{}
+	nbs := &idmock.NetworkBinderService{}
+	eidu := &idmock.EnrollmentIDUnmarshaler{}
+
+	p := identity.NewProvider(logging.MustGetLogger(), storage, des, nbs, eidu, nil)
+
+	// deserializer succeeds but hands back a nil signer
+	des.DeserializeSignerReturns(nil, nil)
+	storage.StoreSignerInfoReturns(nil)
+
+	s, err := p.GetSigner(t.Context(), driver.Identity("an_identity"))
+	require.Error(t, err)
+	assert.Nil(t, s)
 }
 
 // fakeSignerDeserializer is a minimal idriver.SignerDeserializer for router registration in


### PR DESCRIPTION
Fixes #2065

### Summary

FSC's `secondcache.Delete` does not remove the entry from its backing table — it zeroes the stored
value in place and marks it referenced, so the key stays present and future `Get` calls return
`ok == true` with a zero-value payload. The `identity.Provider`'s local `cache[T]` interface exposes
`Delete`, and `getSignerAndCache`/`GetSigner` only check the returned `bool`/`error`, not whether the
returned pointer is nil — so if `Delete` is ever called on this cache, the next `GetSigner` for that
identity returns `(nil, nil)` instead of an error, and the caller's first `Sign()` call panics with a
nil-pointer dereference far from the actual cause.

### Where

FSC `platform/common/utils/cache/secondcache/second_chance.go:152-161` (dependency, not in this
repo) — `Delete` zeroes the entry's value and sets `referenced = 1` but leaves the key in `table`.

`token/services/identity/provider.go:59-63`:

```go
type cache[T any] interface {
	Get(key string) (T, bool)
	Add(key string, value T)
	Delete(key string)
}
```

`provider.go:300-303`:

```go
if entry, ok := p.signers.Get(idHash); ok {
	p.Logger.DebugfContext(ctx, "signer for [%s] found", idHash)
	return entry.Signer, false, "cache", nil
}
```

If `entry` is the zeroed tombstone left by `Delete`, `entry` is a nil `*SignerEntry`, and
`entry.Signer` on a nil pointer... `SignerEntry` is a struct (not accessed via pointer receiver
methods here), so `entry` itself being nil means this line would need `entry != nil` guarding. `GetSigner`
(`provider.go:173-181`) checks only `err`:

```go
signer, err := p.getSigner(ctx, identity, idHash)
if err != nil {
	return nil, errors.Wrapf(err, ...)
}
return signer, nil
```

so a nil `signer` with nil `err` is returned as a "successful" result.

This is compounded by `updateCaches` (`provider.go:377-393`), which registers the **same**
`*SignerEntry` pointer under two different keys (`id` and, when an alias is set, `aliasID`) — so a
single `Delete(id)` call, if ever made, tombstones the entry reachable from *both* keys simultaneously
(since the second_chance cache stores per-key slots, this specifically means: deleting one key's slot
zeroes only that slot's value, but since both keys' slots reference-copy from the same `*SignerEntry`
at Add time, the underlying object referenced by the other key's slot is unaffected by `Delete` on
the first — worth re-verifying against the exact `Add`/`Delete` semantics before fixing, but the
double-registration itself is real and worth calling out).

### Impact

Today, nothing in this package calls `.Delete` on the signers cache (verified: no call sites for
`p.signers.Delete` in `token/services/identity/`), so this is currently **latent**, not live. It's
filed because: (a) the `cache[T]` interface exposes `Delete` as part of its public contract, inviting
future use without the caller knowing about this footgun; (b) any future maintenance that adds
signer invalidation (e.g. on key rotation) will hit this immediately and produce a nil-signer panic
that looks unrelated to the invalidation code that caused it.

### Reproduction

Not yet committed. Would require either: instantiate the real `secondcache.NewTyped[*SignerEntry]`,
`Add` an entry, `Delete` it, then `Get` it back and observe `ok == true` with a nil value — this
demonstrates the underlying cache behavior (best filed as a note/comment, since it's FSC's behavior,
not this repo's) — and/or add a test that calls a hypothetical future `Provider.InvalidateSigner`
(if added) and confirms `GetSigner` afterward returns an error, not a nil signer.

### Suggested fix

Guard the cache read for a nil payload and treat it as a miss, not a hit:

```go
if entry, ok := p.signers.Get(idHash); ok && entry != nil {
	return entry.Signer, false, "cache", nil
}
```

And in `GetSigner`, treat a nil signer with nil error as an error condition rather than propagating
it silently:

```go
signer, err := p.getSigner(ctx, identity, idHash)
if err != nil {
	return nil, errors.Wrapf(err, ...)
}
if signer == nil {
	return nil, errors.Errorf("no signer available for identity [%s]", identity.String())
}
return signer, nil
```

### Severity

MEDIUM — currently latent (no live call path), but the interface contract invites a footgun for any
future cache-invalidation feature, and the failure mode (nil-pointer panic far from the cause) is
expensive to debug.