### PR TITLE
network-driver: ppfetcher.go Fetch panics on a non-[]byte view result (unchecked type assertion)

### DIFF
--- a/token/services/network/fabric/ppfetcher.go
+++ b/token/services/network/fabric/ppfetcher.go
@@ -9,6 +9,7 @@ package fabric
 import (
 	"context"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/chaincode"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view"
@@ -31,5 +32,10 @@ func (f *chaincodePublicParamsFetcher) Fetch(network driver2.Network, channel dr
 		return nil, err
 	}
 
-	return ppBoxed.([]byte), nil
+	pp, ok := ppBoxed.([]byte)
+	if !ok {
+		return pp, errors.Errorf("unexpected public params type %T, expected []byte", ppBoxed)
+	}
+
+	return pp, nil
 }

--- a/token/services/network/fabric/ppfetcher_test.go
+++ b/token/services/network/fabric/ppfetcher_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fabric
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testNetwork   = "test-network"
+	testChannel   = "test-channel"
+	testNamespace = "test-namespace"
+)
+
+// fakeViewManager is a test double for ViewManager that returns a fixed result
+// and error from InitiateView, letting us drive Fetch down each of its branches.
+type fakeViewManager struct {
+	result any
+	err    error
+}
+
+func (m *fakeViewManager) InitiateView(context.Context, view.View) (any, error) {
+	return m.result, m.err
+}
+
+// TestFetchRejectsNonByteSliceResult is the regression test for #2061: when
+// InitiateView returns a non-[]byte value on the success path, Fetch must
+// surface a diagnosable error instead of panicking on an unchecked type
+// assertion.
+func TestFetchRejectsNonByteSliceResult(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		result any
+	}{
+		{"string result", "not-a-byte-slice"},
+		{"int result", 42},
+		{"nil result", nil},
+		{"struct result", struct{ X int }{X: 1}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &chaincodePublicParamsFetcher{viewManager: &fakeViewManager{result: tt.result}}
+			require.NotPanics(t, func() { _, _ = f.Fetch(testNetwork, testChannel, testNamespace) })
+
+			pp, err := f.Fetch(testNetwork, testChannel, testNamespace)
+			require.Error(t, err)
+			assert.Nil(t, pp)
+		})
+	}
+}
+
+// TestFetchReturnsByteSliceResult confirms the happy path: a genuine []byte
+// result is returned unchanged.
+func TestFetchReturnsByteSliceResult(t *testing.T) {
+	want := []byte("public-params")
+	f := &chaincodePublicParamsFetcher{viewManager: &fakeViewManager{result: want}}
+
+	pp, err := f.Fetch(testNetwork, testChannel, testNamespace)
+	require.NoError(t, err)
+	assert.Equal(t, want, pp)
+}
+
+// TestFetchPropagatesInitiateViewError confirms an InitiateView error is
+// propagated before the type assertion is ever reached.
+func TestFetchPropagatesInitiateViewError(t *testing.T) {
+	expected := errors.New("initiate view failed")
+	f := &chaincodePublicParamsFetcher{viewManager: &fakeViewManager{err: expected}}
+
+	pp, err := f.Fetch(testNetwork, testChannel, testNamespace)
+	require.ErrorIs(t, err, expected)
+	assert.Nil(t, pp)
+}


### PR DESCRIPTION
Fixes #2061

### Summary

`chaincodePublicParamsFetcher.Fetch` converts the result of `viewManager.InitiateView(...)` to `[]byte` with an unchecked, single-value type assertion. If `InitiateView` ever returns a non-`[]byte` value on success, this panics instead of returning an error.

### Where

`token/services/network/fabric/ppfetcher.go` (`chaincodePublicParamsFetcher.Fetch`):

```go
ppBoxed, err := f.viewManager.InitiateView(ctx, view)
if err != nil {
    return nil, err
}
return ppBoxed.([]byte), nil   // ppfetcher.go — single-value assertion, panics if ppBoxed is not []byte
```

### Impact

Anything able to influence what the public-params view returns on the success path (a bug in the view implementation, a future incompatible change to its return type, or a compromised peer/responder on the other end of the view call) turns a data-shape mismatch into an immediate panic on the fetch path used to retrieve chaincode public parameters, rather than a diagnosable error.

This finding was independently discovered twice during the hardening pass — once by direct code review, and again independently by an automated audit of the core-network root files — converging on the same root cause.

### Reproduction

Reproduced locally with a table-driven unit test (not yet committed) over four non-`[]byte` results (string, int, nil, struct), each asserted to panic; plus two contrast tests confirming a genuine `[]byte` result succeeds and an `InitiateView` error is propagated without reaching the assertion:

```go
for _, tt := range []struct{ name string; result any }{
    {"string result", "not-a-byte-slice"}, {"int result", 42},
    {"nil result", nil}, {"struct result", struct{ X int }{X: 1}},
} {
    f := &chaincodePublicParamsFetcher{viewManager: &fakeViewManager{result: tt.result}}
    require.Panics(t, func() { _, _ = f.Fetch(network, channel, namespace) })
}
```

Happy to include this regression test in the fix PR.

### Suggested fix

Use the two-value form of the type assertion (`ppBoxed, ok := ppBoxed.([]byte)`) and return an error when `ok` is false, instead of panicking.

### Severity

LOW-MEDIUM