### PR TITLE
network-driver: tcc AreTokensSpent dereferences a nil PublicParameters, panicking

### DIFF
--- a/token/services/network/fabric/tcc/tcc.go
+++ b/token/services/network/fabric/tcc/tcc.go
@@ -337,6 +337,15 @@ func (cc *TokenChaincode) AreTokensSpent(idsRaw []byte, stub shim.ChaincodeStubI
 		return shim.Error(err.Error())
 	}
 
+	// GetValidator guarantees a non-nil validator, but not non-nil public parameters: a
+	// TokenServicesFactory may report a successful initialization while handing back a nil
+	// PublicParameters.
+	if cc.PublicParameters == nil {
+		logger.Errorf("public parameters not initialized")
+
+		return shim.Error("public parameters not initialized")
+	}
+
 	var ids []string
 	if err := json.Unmarshal(idsRaw, &ids); err != nil {
 		logger.Errorf("failed unmarshalling tokens ids: [%s]", err)

--- a/token/services/network/fabric/tcc/tcc_init_test.go
+++ b/token/services/network/fabric/tcc/tcc_init_test.go
@@ -142,6 +142,29 @@ func TestInvokeReportsInitializationErrorOnEveryCall(t *testing.T) {
 	}
 }
 
+// TestAreTokensSpentFailsGracefullyOnNilPublicParameters checks that AreTokensSpent refuses to
+// dereference a nil PublicParameters: a TokenServicesFactory may report a successful initialization
+// (non-nil validator, nil error) while handing back a nil PublicParameters, and the GraphHiding()
+// call must not dereference it. Instead of panicking, it answers with an error response.
+func TestAreTokensSpentFailsGracefullyOnNilPublicParameters(t *testing.T) {
+	writePublicParamsFile(t)
+
+	cc := &tcc.TokenChaincode{
+		TokenServicesFactory: func([]byte) (tcc.PublicParameters, tcc.Validator, error) {
+			return nil, &mock.Validator{}, nil // "successful" init, nil PublicParameters
+		},
+	}
+
+	stub := &mock.ChaincodeStubInterface{}
+	stub.GetTxIDReturns("txid")
+
+	require.NotPanics(t, func() {
+		resp := cc.AreTokensSpent([]byte(`["id1"]`), stub)
+		require.Equal(t, int32(500), resp.Status)
+		require.Contains(t, resp.Message, "public parameters not initialized")
+	})
+}
+
 // TestGetValidatorConcurrentInitialization checks that concurrent callers initialize once and all
 // observe the same validator.
 func TestGetValidatorConcurrentInitialization(t *testing.T) {


### PR DESCRIPTION
Fixes #2053

### Summary

`AreTokensSpent` calls `cc.PublicParameters.GraphHiding()` without ever checking that `PublicParameters` is non-nil. If `TokenServicesFactory` succeeds (returns a `nil` error, so `Initialize` does not fail) but yields a `nil` `PublicParameters` value — a state production code never guards against — the very next `areTokensSpent` request panics on a method call through a nil interface.

### Where

`token/services/network/fabric/tcc/tcc.go:328`

### Impact

Any code path where public-parameters initialization can report success while leaving `PublicParameters` nil (e.g. a driver bug, or a factory implementation that forgets to populate it in some branch) turns every subsequent `areTokensSpent` call into a guaranteed panic. Combined with #2052 (`GetValidator`'s poisoned `sync.Once`), there is also no way to recover from this state at runtime.

### Reproduction

Reproduced locally with a unit test (not yet committed):

```go
cc := &chaincode2.TokenChaincode{
    TokenServicesFactory: func(_ []byte) (PublicParameters, Validator, error) {
        return nil, &mock.Validator{}, nil   // "successful" init, nil PublicParameters
    },
}
require.Panics(t, func() { cc.AreTokensSpent([]byte(`["id1"]`), fakestub) })
```

Happy to include this regression test in the fix PR.

### Suggested fix

Add a nil check on `cc.PublicParameters` before calling `GraphHiding()`, returning an error (e.g. "chaincode not properly initialized") instead of panicking.

### Severity

MEDIUM (dampened by the top-level `recover()` in `Invoke`, but leaves the chaincode permanently non-functional for this call with no diagnosable error)