### PR TITLE
token: Quantity doc comment claims hex-only encoding but parser accepts decimal/hex/octal/binary

### DIFF
--- a/token/services/storage/db/driver/token.go
+++ b/token/services/storage/db/driver/token.go
@@ -42,7 +42,10 @@ type TokenRecord struct {
 	// LedgerMetadata is the metadata associated to the content of Ledger
 	LedgerMetadata []byte
 	// Quantity is the number of units of Type carried in the token.
-	// It is encoded as a string containing a number in base 16. The string has prefix ``0x''.
+	// It is encoded as a string containing a non-negative integer. The value is parsed
+	// with big.Int base-0 auto-detection, so the base is inferred from the string's prefix:
+	// decimal by default, hexadecimal with a "0x"/"0X" prefix, octal with a "0o"/"0O" prefix
+	// (or a leading "0"), and binary with a "0b"/"0B" prefix.
 	Quantity string
 	// Type is the type of token
 	Type token.Type

--- a/token/token/token.go
+++ b/token/token/token.go
@@ -45,7 +45,10 @@ type Token struct {
 	// Type is the type of the token
 	Type Type `json:"type,omitempty" protobuf:"bytes,2,opt,name=type,proto3"`
 	// Quantity is the number of units of Type carried in the token.
-	// It is encoded as a string containing a number in base 16. The string has prefix ``0x''.
+	// It is encoded as a string containing a non-negative integer. The value is parsed
+	// with big.Int base-0 auto-detection, so the base is inferred from the string's prefix:
+	// decimal by default, hexadecimal with a "0x"/"0X" prefix, octal with a "0o"/"0O" prefix
+	// (or a leading "0"), and binary with a "0b"/"0B" prefix.
 	Quantity string `json:"quantity,omitempty" protobuf:"bytes,3,opt,name=quantity,proto3"`
 }
 


### PR DESCRIPTION
Fixes #2030

### Summary

`token.Token.Quantity`'s doc comment states the field is "encoded as a string containing a number in base 16" with a `0x` prefix. The actual parsing helpers accept decimal, hex (`0x`), octal (leading `0`), and binary (`0b`) — any base Go's `big.Int.SetString` auto-detects — silently. This is a documentation/implementation mismatch in shared code used by both fabtoken and zkatdlog, discovered while auditing fabtoken's quantity handling.

### Where

Doc comment (`token/token/token.go:47-49`):
```go
// Quantity is the number of units of Type carried in the token.
// It is encoded as a string containing a number in base 16. The string has prefix ``0x''.
Quantity string `json:"quantity,omitempty" protobuf:"bytes,3,opt,name=quantity,proto3"`
```

Actual parsing (`token/token/quantity.go:67-71` and `:152-156`):
```go
func ToQuantity(q string, precision uint64) (Quantity, error) {
	...
	v, success := big.NewInt(0).SetString(q, 0)   // base 0 = auto-detect: decimal, 0x hex, 0 octal, 0b binary
	...
}

func NewUBigQuantity(q string, precision uint64) (*BigQuantity, error) {
	...
	v, success := big.NewInt(0).SetString(q, 0)
	...
}
```

### Why this matters

Anywhere a `Quantity` string is compared, parsed, or serialized under the assumption it is *always* hex-prefixed `0x...` (per the doc), while another component accepts/produces a differently-based numeric string, there is room for a quantity-format confusion. This review did not find a concrete raw string/byte-level quantity comparison that bypasses the parsed `Quantity` type (all comparisons found go through `ToQuantity`/`Cmp`, which are self-consistent regardless of base) — so no live exploit is confirmed — but the doc/implementation mismatch itself is worth closing before it's relied upon incorrectly elsewhere.

### Suggested fix

Pick one and align the other:
- Make parsing strict to base-16 (`SetString(q, 16)`, handling the `0x` prefix explicitly) to match the documented format, or
- Update the doc comment to accurately describe the accepted formats (decimal/hex/octal/binary) if permissive parsing is intentional.

### Severity

LOW-MEDIUM — no confirmed exploit path found in this review, but a doc/implementation mismatch in shared token-quantity handling that both drivers depend on.