### PR TITLE
fix(metrics): make the Grafana overview dashboard work by default

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,8 +119,6 @@ linters:
         - go.opentelemetry.io/otel/trace.Span
         - github.com/hyperledger/fabric-lib-go/common/metrics.Gauge
         - github.com/hyperledger/fabric-lib-go/common/metrics.Histogram
-        - github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics.Gauge
-        - github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics.Histogram
         - github.com/hyperledger-labs/fabric-smart-client/platform/common/driver.ConfigService
         - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.ViewClient
         - github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api.Platform

--- a/docs/development/metrics.md
+++ b/docs/development/metrics.md
@@ -8,8 +8,10 @@ in the SDK the way production wiring does, reads the resulting names back out of
 and compares them against `token/services/metricsdoc/testdata/metrics.golden` and against this page.
 Adding, renaming or moving a metric fails that test until this page is updated. Because a name also
 depends on *which* provider production hands the constructor, the same test pins that wiring: it
-asserts that the token drivers are the only place a TMS-scoped provider is built, so dropping or
-relocating the wrapper fails too rather than silently invalidating the names below.
+asserts that the token drivers are the only place a TMS-scoped provider is built, and that the provider
+they get from the dependency-injection container reaches nothing but that wrapper. Dropping the wrapper,
+or routing the plain provider past it, therefore fails too rather than silently invalidating the names
+below.
 
 See [Monitoring](./monitoring.md) for the wider monitoring setup and [Driver Metrics](../drivers/metrics.md)
 for how the driver instrumentation is wired. Every metric below already has a panel in the importable
@@ -52,7 +54,7 @@ Two consequences are worth internalising before writing a query or a dashboard:
 - **Some names stutter**, because the metric name repeats its package: hence
   `panurus_services_auditor_auditor_audit_duration_seconds` and
   `panurus_services_network_fabricx_finality_queue_finality_queue_pending_events`. They are correct as
-  listed; see [Coverage gaps](#metric-hygiene) for why they are not renamed here.
+  listed; see [Metric hygiene](#metric-hygiene) for why they are not renamed here.
 
 ### The TMS-scoped provider changes the prefix
 
@@ -160,7 +162,7 @@ Source: `token/services/utils/json/session/metrics.go`. Wired in `token/sdk/dig/
 
 Recorded by the auditor around `Audit()`, `Append()` and `Release()`. These metrics carry **no TMS
 labels**, so a node auditing several TMSs reports them aggregated; see
-[Coverage gaps](#metric-hygiene).
+[Metric hygiene](#metric-hygiene).
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|

--- a/docs/monitoring/grafana/README.md
+++ b/docs/monitoring/grafana/README.md
@@ -14,10 +14,15 @@ queue).
    `DS_PROMETHEUS`.
 
 The dashboard declares four template variables — `network`, `channel`, `namespace` and `method` — whose
-values are discovered with `label_values` against
-`panurus_core_common_metrics_transfer_service_operations_total`. A node that has never issued or
-transferred a token exports no series for that metric, so the pickers stay empty until the first
-transaction; the unfiltered panels still work.
+values are discovered with `label_values`. `network`, `channel` and `namespace` come from
+`panurus_core_common_metrics_transfer_service_operations_total`; `method` is unioned across all five
+driver services with a `__name__` matcher, because each service reports a disjoint set of method names
+and a `method` list taken from one of them would filter the other four down to nothing.
+
+All four set `allValue: ".*"`, so the default “All” selection matches every series rather than
+interpolating to an empty string. This matters on a node that has never transferred a token: it exports
+no series for the source metric, the pickers stay empty, and without `allValue` a selector such as
+`network=~""` would match nothing and blank every filtered panel.
 
 Requires Grafana 9.0 or later (`schemaVersion` 37).
 

--- a/docs/monitoring/grafana/panurus.json
+++ b/docs/monitoring/grafana/panurus.json
@@ -198,27 +198,27 @@
       "targets": [
         {
           "refId": "issue",
-          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_issue_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_issue_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval])))",
           "legendFormat": "issue.{{method}}"
         },
         {
           "refId": "transfer",
-          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_transfer_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_transfer_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval])))",
           "legendFormat": "transfer.{{method}}"
         },
         {
           "refId": "tokens",
-          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_tokens_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_tokens_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval])))",
           "legendFormat": "tokens.{{method}}"
         },
         {
           "refId": "auditor",
-          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_auditor_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_auditor_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval])))",
           "legendFormat": "auditor.{{method}}"
         },
         {
           "refId": "upgrade",
-          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_tokens_upgrade_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, method) (rate(panurus_core_common_metrics_tokens_upgrade_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval])))",
           "legendFormat": "upgrade.{{method}}"
         }
       ]
@@ -309,17 +309,17 @@
       "targets": [
         {
           "refId": "e",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_ttx_endorsement_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_ttx_endorsement_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval])))",
           "legendFormat": "endorsement p95"
         },
         {
           "refId": "a",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_ttx_audit_approval_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_ttx_audit_approval_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval])))",
           "legendFormat": "audit_approval p95"
         },
         {
           "refId": "o",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_ttx_ordering_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_ttx_ordering_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval])))",
           "legendFormat": "ordering p95"
         }
       ]
@@ -415,12 +415,12 @@
       "targets": [
         {
           "refId": "p50",
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(panurus_services_ttx_finality_finality_listener_on_status_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(panurus_services_ttx_finality_finality_listener_on_status_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "p50"
         },
         {
           "refId": "p95",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_ttx_finality_finality_listener_on_status_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_ttx_finality_finality_listener_on_status_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "p95"
         }
       ]
@@ -495,7 +495,36 @@
         "defaults": {
           "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "err"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ops"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "size"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "legend": {
@@ -511,7 +540,7 @@
         },
         {
           "refId": "size",
-          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(panurus_services_utils_json_session_ttx_envelope_body_bytes_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(panurus_services_utils_json_session_ttx_envelope_body_bytes_bucket[$__rate_interval])))",
           "legendFormat": "body p95 {{type}} (bytes)"
         }
       ]
@@ -547,7 +576,56 @@
         "defaults": {
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "lc"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ops"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "ae"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ops"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "rl"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ops"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "legend": {
@@ -558,12 +636,12 @@
       "targets": [
         {
           "refId": "ad",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_auditor_auditor_audit_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_auditor_auditor_audit_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "audit p95"
         },
         {
           "refId": "ap",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_auditor_auditor_append_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_auditor_auditor_append_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "append p95"
         },
         {
@@ -614,7 +692,24 @@
         "defaults": {
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "out"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ops"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "legend": {
@@ -625,7 +720,7 @@
       "targets": [
         {
           "refId": "p95",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_selector_sherdlock_selection_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_selector_sherdlock_selection_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "duration p95"
         },
         {
@@ -653,7 +748,36 @@
         "defaults": {
           "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "f"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ops"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "r"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "legend": {
@@ -669,7 +793,7 @@
         },
         {
           "refId": "r",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_selector_sherdlock_selection_immediate_retries_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_selector_sherdlock_selection_immediate_retries_bucket[$__rate_interval])))",
           "legendFormat": "retries p95"
         }
       ]
@@ -705,7 +829,24 @@
         "defaults": {
           "unit": "ops"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "p"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "legend": {
@@ -731,7 +872,7 @@
         },
         {
           "refId": "p",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_certifier_interactive_certification_request_duration_seconds_bucket{channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_certifier_interactive_certification_request_duration_seconds_bucket{channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval])))",
           "legendFormat": "request p95 (s)"
         }
       ]
@@ -766,12 +907,12 @@
         {
           "refId": "ic",
           "expr": "panurus_core_common_metrics_cache_level{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}",
-          "legendFormat": "idemix panurus_core_common_metrics_cache_level"
+          "legendFormat": "idemix cache"
         },
         {
           "refId": "rc",
           "expr": "panurus_core_common_metrics_recipient_data_cache_level{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}",
-          "legendFormat": "panurus_core_common_metrics_recipient_data_cache_level"
+          "legendFormat": "recipient data cache"
         },
         {
           "refId": "pt",
@@ -854,7 +995,7 @@
       "targets": [
         {
           "refId": "p95",
-          "expr": "histogram_quantile(0.95, sum by (le, path) (rate(panurus_core_common_metrics_identity_get_signer_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, path) (rate(panurus_core_common_metrics_identity_get_signer_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval])))",
           "legendFormat": "p95 {{path}}"
         }
       ]
@@ -1008,7 +1149,7 @@
       "targets": [
         {
           "refId": "p",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_network_fabricx_finality_queue_finality_queue_processing_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(panurus_services_network_fabricx_finality_queue_finality_queue_processing_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "p95"
         }
       ]
@@ -1018,7 +1159,6 @@
   "schemaVersion": 37,
   "style": "dark",
   "tags": [
-    "panurus",
     "panurus",
     "lfdt"
   ],
@@ -1045,6 +1185,7 @@
           "query": "label_values(panurus_core_common_metrics_transfer_service_operations_total, network)",
           "refId": "v"
         },
+        "allValue": ".*",
         "includeAll": true,
         "multi": true,
         "current": {
@@ -1067,6 +1208,7 @@
           "query": "label_values(panurus_core_common_metrics_transfer_service_operations_total{network=~\"$network\"}, channel)",
           "refId": "v"
         },
+        "allValue": ".*",
         "includeAll": true,
         "multi": true,
         "current": {
@@ -1089,6 +1231,7 @@
           "query": "label_values(panurus_core_common_metrics_transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\"}, namespace)",
           "refId": "v"
         },
+        "allValue": ".*",
         "includeAll": true,
         "multi": true,
         "current": {
@@ -1106,11 +1249,12 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(panurus_core_common_metrics_transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}, method)",
+        "definition": "label_values({__name__=~\"panurus_core_common_metrics_(issue|transfer|tokens|tokens_upgrade|auditor)_service_operations_total\",network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}, method)",
         "query": {
-          "query": "label_values(panurus_core_common_metrics_transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}, method)",
+          "query": "label_values({__name__=~\"panurus_core_common_metrics_(issue|transfer|tokens|tokens_upgrade|auditor)_service_operations_total\",network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}, method)",
           "refId": "v"
         },
+        "allValue": ".*",
         "includeAll": true,
         "multi": true,
         "current": {

--- a/token/services/identity/idemix/cache/cache_test.go
+++ b/token/services/identity/idemix/cache/cache_test.go
@@ -338,6 +338,7 @@ func TestIdentityCache_CountsProvisionFailures(t *testing.T) {
 // noopGauge is a metrics.Gauge that discards everything.
 type noopGauge struct{}
 
+//nolint:ireturn // implements metrics.Gauge; the interface fixes the return type
 func (g *noopGauge) With(...string) metrics.Gauge { return g }
 
 func (g *noopGauge) Add(float64) {}

--- a/token/services/identity/role/cache_test.go
+++ b/token/services/identity/role/cache_test.go
@@ -311,6 +311,7 @@ type countingGauge struct {
 	total atomic.Int64
 }
 
+//nolint:ireturn // implements metrics.Gauge; the interface fixes the return type
 func (g *countingGauge) With(...string) metrics.Gauge { return g }
 
 func (g *countingGauge) Add(delta float64) { g.total.Add(int64(delta)) }

--- a/token/services/metricsdoc/dashboard_test.go
+++ b/token/services/metricsdoc/dashboard_test.go
@@ -73,6 +73,12 @@ func TestDashboardQueriesReferenceRegisteredMetrics(t *testing.T) {
 	referenced := make(map[string]struct{})
 	for _, s := range values {
 		for _, match := range metricNamePattern.FindAllStringSubmatch(s, -1) {
+			if strings.HasSuffix(match[2], "_") {
+				// A bare namespace prefix: prose in a panel description, or the
+				// alternation inside a __name__ matcher. Not a metric, exactly as
+				// extractMetricNames treats it in the reference page.
+				continue
+			}
 			name := foldPromQLSuffix(match[2], registered)
 			referenced[name] = struct{}{}
 			assert.Contains(t, registered, name,

--- a/token/services/metricsdoc/doc.go
+++ b/token/services/metricsdoc/doc.go
@@ -20,9 +20,11 @@ SPDX-License-Identifier: Apache-2.0
 // test until the documentation is updated.
 //
 // Which provider a constructor receives is as much a part of the exported name
-// as the opts are, so it is checked rather than assumed: the token drivers are
-// pinned as the only place a TMS-scoped provider is built, and every production
-// call site listed for a constructor must still contain that call. Removing the
-// wrapper, or moving a call site, therefore fails here instead of quietly
-// renaming twenty-one metrics.
+// as the opts are, so it is checked rather than assumed, from three directions:
+// the token drivers are pinned as the only place a TMS-scoped provider is built,
+// the container's own provider is required to reach nothing but that wrapper, and
+// every production call site listed for a constructor must still contain that
+// call. Removing the wrapper, routing the plain provider past it, or moving a
+// call site therefore fails here instead of quietly renaming twenty-one
+// metrics.
 package metricsdoc

--- a/token/services/metricsdoc/reference_test.go
+++ b/token/services/metricsdoc/reference_test.go
@@ -175,6 +175,9 @@ var groups = []group{
 		wiring: []wiringSite{
 			{file: "token/core/fabtoken/v1/driver/ws.go", call: "identity.NewMetrics(metricsProvider)"},
 			{file: "token/core/zkatdlog/nogh/v1/driver/ws.go", call: "identity.NewMetrics(metricsProvider)"},
+			// the hop that carries the TMS-scoped provider into the wallet service
+			{file: "token/core/fabtoken/v1/driver/driver.go", call: "ws, err := d.newWalletService("},
+			{file: "token/core/zkatdlog/nogh/v1/driver/driver.go", call: "ws, err := d.NewWalletService("},
 		},
 		build: func(p metrics.Provider) { identity.NewMetrics(p) },
 	},
@@ -422,6 +425,29 @@ func TestTMSScopedProviderWiringIsIntact(t *testing.T) {
 	}
 }
 
+// plainProviderRef is how a token driver names the provider it receives from the
+// dependency-injection container.
+const plainProviderRef = "d.metricsProvider"
+
+// TestPlainProviderDoesNotBypassTheWrapper closes the gap that pinning the
+// wrapper alone leaves open. TestTMSScopedProviderWiringIsIntact establishes that
+// a TMS-scoped provider is *built* in the token drivers and nowhere else, which is
+// not the same as the tmsScoped groups actually *receiving* it: handing
+// d.metricsProvider to the wallet service instead would export the six identity
+// and cache metrics under their own package prefixes, blank six dashboard panels,
+// and leave every other check in this package green. The container's provider is
+// therefore required to appear exactly once per driver - as the argument to
+// NewTMSProvider - so any second use of it fails here.
+func TestPlainProviderDoesNotBypassTheWrapper(t *testing.T) {
+	for _, driver := range tokenDrivers {
+		assert.Equal(t, 1, strings.Count(readRepoFile(t, driver), plainProviderRef),
+			"%s uses %s more than once. The container's provider must reach nothing but %s, "+
+				"otherwise the metrics created from what it is handed to are exported under their "+
+				"own package prefixes instead of %q, and those names in %s are wrong.",
+			driver, plainProviderRef, tmsProviderCall, tmsWrapperPrefix, referenceDoc)
+	}
+}
+
 // TestWiringSitesArePresent checks that every call site listed in a group's
 // wiring still exists and still builds that group's metrics, so the pointers a
 // reviewer follows stay honest.
@@ -609,12 +635,14 @@ func (p *recordingProvider) NewCounter(o metrics.CounterOpts) metrics.Counter {
 	return p.inner.NewCounter(o)
 }
 
+//nolint:ireturn // implements metrics.Provider; the interface fixes the return type
 func (p *recordingProvider) NewGauge(o metrics.GaugeOpts) metrics.Gauge {
 	p.record("gauge", o.Name, o.Help, o.LabelNames)
 
 	return p.inner.NewGauge(o)
 }
 
+//nolint:ireturn // implements metrics.Provider; the interface fixes the return type
 func (p *recordingProvider) NewHistogram(o metrics.HistogramOpts) metrics.Histogram {
 	p.record("histogram", o.Name, o.Help, o.LabelNames)
 
@@ -663,13 +691,24 @@ func newCapturingRegisterer(t *testing.T) *capturingRegisterer {
 }
 
 func (c *capturingRegisterer) Register(collector prom.Collector) error {
+	// Describe is driven from this goroutine and the channel drained by the
+	// helper, so the pair always terminates. Draining here instead - with
+	// Describe in a goroutine - would leave that goroutine blocked on send
+	// forever if one of the assertions below aborted the test mid-loop.
 	descs := make(chan *prom.Desc, 1)
+	var collected []*prom.Desc
+	drained := make(chan struct{})
 	go func() {
-		defer close(descs)
-		collector.Describe(descs)
+		defer close(drained)
+		for desc := range descs {
+			collected = append(collected, desc)
+		}
 	}()
+	collector.Describe(descs)
+	close(descs)
+	<-drained
 
-	for desc := range descs {
+	for _, desc := range collected {
 		match := fqNamePattern.FindStringSubmatch(desc.String())
 		require.Len(c.t, match, 2, "cannot read the metric name out of %s", desc)
 		c.names = append(c.names, match[1])


### PR DESCRIPTION
Fixes #2309

## Problem

The shipped Grafana overview dashboard renders **No data** on a healthy node in its default state:

```text
$network / $channel / $namespace / $method
  |
  +- all four sourced from panurus_core_common_metrics_transfer_service_operations_total
  |     -> no series until this node's first transfer
  +- includeAll: true, but NO allValue
        -> "All" (the shipped default) interpolates to ""
        -> network=~"" matches only series with an absent label -> nothing

$method, even on a node that has transferred:
  populated from the transfer service only  -> "All" = (DeserializeTransferAction|Transfer|VerifyTransfer)
  applied as method=~"$method" to issue / tokens / auditor / upgrade series
  whose label values are disjoint            -> 4 of 5 series empty by construction, in 3 panels
```

The guard in `token/services/metricsdoc` cannot see this: `dashboard_test.go` validates label *names* against the registered metrics, not label *values*, so a query filtering on values that can never match still passes.

## Change

**Dashboard (`docs/monitoring/grafana/panurus.json`)**

- `allValue: ".*"` on all four query variables, so the default "All" no longer interpolates to the empty string.
- `$method` now unions all five driver services via a `__name__` matcher instead of reading only the transfer service.
- Per-series `fieldConfig.overrides` on panels 402, 501, 601, 602 and 701, which previously mixed seconds, rates and bytes on one axis under a single `unit` (panel 501 rendered an append-error rate of 0.5/s as "500 ms").
- Hardcoded `[5m]` → `[$__rate_interval]` at 18 sites, matching every counter panel and keeping the p95 panels populated on deployments whose scrape interval exceeds 2.5 minutes.
- Duplicate `"panurus"` tag removed; panel 702 legends no longer print raw metric names.

**Guard (`token/services/metricsdoc`)**

- New `TestPlainProviderDoesNotBypassTheWrapper` closes the circular assertion `doc.go` claimed to make. It requires `d.metricsProvider` to appear exactly once per token driver, so it can reach nothing but `NewTMSProvider`. Verified to catch the regression it exists for: routing the plain provider into `NewWalletService` fails with `expected: 1, actual: 2`, where previously that silently invalidated six documented metric names with every test green.
- `dashboard_test.go` now skips bare namespace prefixes (names ending in `_`) as `extractMetricNames` already does. Also required by the new `__name__` matcher.
- `capturingRegisterer.Register` drives `Describe` on the test goroutine, so a failing assertion can no longer leave a sender blocked on a capacity-1 channel forever.
- The `newWalletService` / `NewWalletService` hop is added to the identity group's wiring list.

**Lint (`.golangci.yml`)**

- Reverts the repo-wide `ireturn` allow-list widening, which had added FSC's `metrics.Gauge` and `metrics.Histogram` to accommodate two methods in one test file. Replaced with two scoped `//nolint:ireturn`, the pattern already used for `assertFileContains` in the same file.

**Docs**

- `docs/monitoring/grafana/README.md` and `docs/development/metrics.md` describe the new variable sourcing; `README.md`'s previous claim that "the unfiltered panels still work" understated the breakage, since 10 of the 19 panels carry the TMS filters. `doc.go` documents the third leg of the wiring guard.
- Two links in `docs/development/metrics.md` read "Coverage gaps" while pointing at the `#metric-hygiene` anchor; the link text now matches the section it targets.

## Verification

- `go test ./token/services/metricsdoc/...` passes.
- `go vet` clean; `golangci-lint` 0 issues on all four touched packages; `gofmt` clean.
- The dashboard round-trips as byte-identical JSON formatting.
- Rebuilt on current `main` rather than replaying an earlier patch: `main` had drifted, including two new metrics (`cache_provision_failures_total`, `recipient_data_provision_failures_total`) and 41 new dashboard lines, so a cherry-pick would have been wrong.

