### PR TITLE
fix(identity): isolate idempotent identity registration inserts in savepoints

### DIFF
--- a/docs/services/storage.md
+++ b/docs/services/storage.md
@@ -60,6 +60,21 @@ Manages the cryptographic identities and logical wallet groupings used by the no
 *   **IdentityInfo**: Stores sensitive identity-related data, including audit information and PII required for transaction processing.
 *   **IdentitySigners**: Tracks which identities have locally available signing keys and their associated metadata.
 
+#### Idempotent identity registration
+
+`RegisterIdentityDescriptor` writes up to four rows in a single transaction: the signer info and
+the audit info of the identity, plus the same two for its alias. The operation is **idempotent and
+safe to retry**. Registering the same descriptor twice succeeds without error, and a registration
+that was only partially persisted — for example because a previous attempt was interrupted by a
+crash — is completed by the retry rather than rejected.
+
+Each of those inserts is individually idempotent (a duplicate key means "already registered"), but
+they share one transaction, so each one is isolated by its own `SAVEPOINT`. Without it, the first
+duplicate key would abort the whole transaction on PostgreSQL and every following statement would
+fail with a generic `current transaction is aborted` error (`SQLSTATE 25P02`) that no longer
+identifies itself as a unique-key violation. Rolling back to the savepoint clears that state, so
+the rows that are still missing are written and only genuine errors abort the registration.
+
 ### Generic Store
 *   **KeyStore**: A secure, generic key-value store used for persisting various cryptographic materials and small sensitive states. The keystore uses identifiers that are expected to be the hexadecimal representation of the key's Subject Key Identifier (SKI). This convention is relied upon by other packages, particularly for operations like keystore cleanup where SKIs are derived from owner identities to locate and manage keys.
 

--- a/token/services/identity/driver/storage.go
+++ b/token/services/identity/driver/storage.go
@@ -194,7 +194,9 @@ type IdentityStoreService interface {
 	SignerInfoExists(ctx context.Context, id []byte) (bool, error)
 	// GetSignerInfo returns the signer info bound to the given identity
 	GetSignerInfo(ctx context.Context, id []byte) ([]byte, error)
-	// RegisterIdentityDescriptor registers a descriptor for an identity and associates it with an alias
+	// RegisterIdentityDescriptor registers a descriptor for an identity and associates it with an alias.
+	// The operation is idempotent and safe to retry: registering the same descriptor again succeeds
+	// without error, and a registration that was only partially persisted is completed by the retry.
 	RegisterIdentityDescriptor(ctx context.Context, descriptor *IdentityDescriptor, alias driver.Identity) error
 	// IterateSigners returns a page of SignerEntry values from the Signers table ordered by
 	// identity_hash, starting at the given offset and returning at most limit entries.

--- a/token/services/storage/db/dbtest/identity.go
+++ b/token/services/storage/db/dbtest/identity.go
@@ -66,6 +66,9 @@ var IdentityCases = []struct {
 	{"SignerInfoConcurrent", TSignerInfoConcurrent},
 	{"GetExistingSignerInfo", TGetExistingSignerInfo},
 	{"RegisterIdentityDescriptor", TRegisterIdentityDescriptor},
+	// Keep the name short: it is used as a SQL table prefix and PostgreSQL truncates
+	// identifiers at 63 characters, which would collide the store's tables.
+	{"RegisterPartialConflict", TRegisterIdentityDescriptorPartialConflict},
 }
 
 var IdentityNotificationCases = []struct {
@@ -338,7 +341,83 @@ func TRegisterIdentityDescriptor(t *testing.T, db driver.IdentityStore) {
 		Verifier:   verifier,
 	}
 	require.NoError(t, db.RegisterIdentityDescriptor(ctx, descriptor, aliasID))
+	assertIdentityDescriptorRegistered(t, db, id, aliasID, SignerInfo, auditInfo)
+
+	// registering the very same descriptor again must be a no-op success
 	require.NoError(t, db.RegisterIdentityDescriptor(ctx, descriptor, aliasID))
+	assertIdentityDescriptorRegistered(t, db, id, aliasID, SignerInfo, auditInfo)
+}
+
+// TRegisterIdentityDescriptorPartialConflict covers the retry-after-partial-write scenarios: only
+// some of the rows a descriptor registration writes are already present, as would be left behind by
+// a crash in the middle of a previous attempt. All those writes share one transaction, so a
+// duplicate key on any of them must neither fail the registration nor stop the still-missing rows
+// from being written.
+func TRegisterIdentityDescriptorPartialConflict(t *testing.T, db driver.IdentityStore) {
+	t.Helper()
+	ctx := t.Context()
+	auditInfo := []byte("audit_info")
+	signerInfo := []byte("signer_info")
+
+	descriptorFor := func(id []byte) *idriver.IdentityDescriptor {
+		return &idriver.IdentityDescriptor{
+			Identity:   id,
+			AuditInfo:  auditInfo,
+			Signer:     &mock.Signer{},
+			SignerInfo: signerInfo,
+			Verifier:   &mock.Verifier{},
+		}
+	}
+
+	// The audit info of the identity is already there, everything else is missing. On PostgreSQL
+	// this is the case where the duplicate key aborts the shared transaction and, unless it is
+	// isolated, makes the following alias writes fail with a generic error.
+	id, alias := []byte("bob"), []byte("banana")
+	require.NoError(t, db.StoreIdentityData(ctx, id, auditInfo, nil, nil))
+	require.NoError(t, db.RegisterIdentityDescriptor(ctx, descriptorFor(id), alias))
+	assertIdentityDescriptorRegistered(t, db, id, alias, signerInfo, auditInfo)
+
+	// The signer info of the identity is already there, everything else is missing.
+	id, alias = []byte("carol"), []byte("cherry")
+	require.NoError(t, db.StoreSignerInfo(ctx, id, signerInfo))
+	require.NoError(t, db.RegisterIdentityDescriptor(ctx, descriptorFor(id), alias))
+	assertIdentityDescriptorRegistered(t, db, id, alias, signerInfo, auditInfo)
+
+	// Only the alias' rows are already there.
+	id, alias = []byte("dave"), []byte("date")
+	require.NoError(t, db.StoreSignerInfo(ctx, alias, signerInfo))
+	require.NoError(t, db.StoreIdentityData(ctx, alias, auditInfo, nil, nil))
+	require.NoError(t, db.RegisterIdentityDescriptor(ctx, descriptorFor(id), alias))
+	assertIdentityDescriptorRegistered(t, db, id, alias, signerInfo, auditInfo)
+
+	// Both the identity's signer info and the alias' audit info are already there.
+	id, alias = []byte("erin"), []byte("elderberry")
+	require.NoError(t, db.StoreSignerInfo(ctx, id, signerInfo))
+	require.NoError(t, db.StoreIdentityData(ctx, alias, auditInfo, nil, nil))
+	require.NoError(t, db.RegisterIdentityDescriptor(ctx, descriptorFor(id), alias))
+	assertIdentityDescriptorRegistered(t, db, id, alias, signerInfo, auditInfo)
+}
+
+// assertIdentityDescriptorRegistered checks that both the identity and its alias carry the expected
+// signer info and audit info. GetSignerInfo is asserted on as well as SignerInfoExists because the
+// former bypasses the store's in-memory caches, which would otherwise report a row as present even
+// when the registration never wrote it.
+func assertIdentityDescriptorRegistered(t *testing.T, db driver.IdentityStore, id, alias, signerInfo, auditInfo []byte) {
+	t.Helper()
+	ctx := t.Context()
+	for _, identity := range [][]byte{id, alias} {
+		exists, err := db.SignerInfoExists(ctx, identity)
+		require.NoError(t, err)
+		assert.True(t, exists, "signer info missing for [%s]", identity)
+
+		storedSignerInfo, err := db.GetSignerInfo(ctx, identity)
+		require.NoError(t, err, "failed reading signer info for [%s]", identity)
+		assert.Equal(t, signerInfo, storedSignerInfo, "signer info mismatch for [%s]", identity)
+
+		storedAuditInfo, err := db.GetAuditInfo(ctx, identity)
+		require.NoError(t, err)
+		assert.Equal(t, auditInfo, storedAuditInfo, "audit info mismatch for [%s]", identity)
+	}
 }
 
 func TIdentityNotifier(t *testing.T, db driver.IdentityStore) {

--- a/token/services/storage/db/sql/common/identity.go
+++ b/token/services/storage/db/sql/common/identity.go
@@ -42,6 +42,15 @@ type dbTransaction interface {
 	ExecContext(ctx context.Context, query string, args ...common3.Param) (sql.Result, error)
 }
 
+// Savepoint names used by registerIdentityDescriptor to isolate each of its individually
+// idempotent inserts. They are compile-time constants, never derived from caller input.
+const (
+	savepointIdentitySignerInfo = "sp_identity_signer_info"
+	savepointIdentityAuditInfo  = "sp_identity_audit_info"
+	savepointAliasSignerInfo    = "sp_alias_signer_info"
+	savepointAliasAuditInfo     = "sp_alias_audit_info"
+)
+
 type identityTables struct {
 	IdentityConfigurations string
 	IdentityInfo           string
@@ -306,7 +315,9 @@ func (db *IdentityStore) Notifier() (idriver.IdentityConfigurationNotifier, erro
 }
 
 func (db *IdentityStore) StoreIdentityData(ctx context.Context, id []byte, identityAudit []byte, tokenMetadata []byte, tokenMetadataAudit []byte) error {
-	return db.storeIdentityData(ctx, db.writeDB, tdriver.Identity(id).UniqueID(), id, identityAudit, tokenMetadata, tokenMetadataAudit, true)
+	_, err := db.storeIdentityData(ctx, db.writeDB, tdriver.Identity(id).UniqueID(), id, identityAudit, tokenMetadata, tokenMetadataAudit, true)
+
+	return err
 }
 
 func (db *IdentityStore) GetAuditInfo(ctx context.Context, id []byte) ([]byte, error) {
@@ -454,6 +465,11 @@ func (db *IdentityStore) IterateSigners(ctx context.Context, offset, limit int) 
 	return entries, rows.Err()
 }
 
+// RegisterIdentityDescriptor stores the signer info and audit info of the descriptor's identity
+// and of the given alias, and refreshes the corresponding caches. All writes happen in a single
+// transaction. The operation is idempotent and safe to retry: rows that are already present are
+// left untouched and the missing ones are written, so both a full re-registration and the retry
+// of a registration that was only partially persisted succeed.
 func (db *IdentityStore) RegisterIdentityDescriptor(ctx context.Context, descriptor *idriver.IdentityDescriptor, alias tdriver.Identity) error {
 	// store
 	logger.DebugfContext(ctx, "register identity descriptor...")
@@ -505,32 +521,39 @@ func (db *IdentityStore) registerIdentityDescriptor(
 
 	h := descriptor.Identity.UniqueID()
 
-	exists, err := db.storeSignerInfo(ctx, tx, h, descriptor.Identity, descriptor.SignerInfo, false)
-	if err != nil {
+	// Each insert below is individually idempotent, and they all run on the same
+	// transaction, so each one is isolated by its own savepoint. Without it, the first
+	// duplicate key would abort the whole transaction on PostgreSQL and every following
+	// statement would fail with a generic "current transaction is aborted" error that no
+	// longer matches UniqueKeyViolation - turning an idempotent re-registration into a hard
+	// failure. Rolling back to the savepoint clears that state, so a registration that was
+	// only partially written (e.g. interrupted by a crash) is completed by the retry
+	// instead of being rejected.
+	if err := db.insertIdempotently(ctx, tx, savepointIdentitySignerInfo, func() (bool, error) {
+		return db.storeSignerInfo(ctx, tx, h, descriptor.Identity, descriptor.SignerInfo, false)
+	}); err != nil {
 		return errors.Wrapf(err, "failed to store signer info for descriptor's identity")
-	}
-	if exists {
-		// no need to continue
-
-		return nil
 	}
 
 	if len(descriptor.AuditInfo) != 0 {
-		err = db.storeIdentityData(ctx, tx, h, descriptor.Identity, descriptor.AuditInfo, nil, nil, false)
-		if err != nil {
+		if err := db.insertIdempotently(ctx, tx, savepointIdentityAuditInfo, func() (bool, error) {
+			return db.storeIdentityData(ctx, tx, h, descriptor.Identity, descriptor.AuditInfo, nil, nil, false)
+		}); err != nil {
 			return errors.Wrapf(err, "failed to store audit info for descriptor's identity")
 		}
 	}
 
 	if !alias.IsNone() && !descriptor.Identity.Equal(alias) {
-		h = alias.UniqueID()
-		_, err = db.storeSignerInfo(ctx, tx, h, alias, descriptor.SignerInfo, false)
-		if err != nil {
+		aliasHash := alias.UniqueID()
+		if err := db.insertIdempotently(ctx, tx, savepointAliasSignerInfo, func() (bool, error) {
+			return db.storeSignerInfo(ctx, tx, aliasHash, alias, descriptor.SignerInfo, false)
+		}); err != nil {
 			return errors.Wrapf(err, "failed to store signer info for alias")
 		}
 		if len(descriptor.AuditInfo) != 0 {
-			err = db.storeIdentityData(ctx, tx, h, alias, descriptor.AuditInfo, nil, nil, false)
-			if err != nil {
+			if err := db.insertIdempotently(ctx, tx, savepointAliasAuditInfo, func() (bool, error) {
+				return db.storeIdentityData(ctx, tx, aliasHash, alias, descriptor.AuditInfo, nil, nil, false)
+			}); err != nil {
 				return errors.Wrapf(err, "failed to store audit info for alias")
 			}
 		}
@@ -541,6 +564,36 @@ func (db *IdentityStore) registerIdentityDescriptor(
 
 	// no rollback to be performed
 	tx = nil
+
+	return nil
+}
+
+// insertIdempotently runs insert inside a nested savepoint on tx. insert must report whether
+// the row it writes was already present, that is, whether it swallowed a duplicate-key error.
+// When it was - or when insert failed outright - the savepoint is rolled back. On PostgreSQL a
+// duplicate key aborts the enclosing transaction, and rolling back to the savepoint is what
+// clears that state so the remaining statements of the transaction can still be executed. On
+// success the savepoint is released.
+//
+// savepoint must be a fixed identifier, never a value derived from caller input, as it is
+// interpolated into the statement.
+func (db *IdentityStore) insertIdempotently(ctx context.Context, tx dbTransaction, savepoint string, insert func() (bool, error)) error {
+	if _, err := tx.ExecContext(ctx, "SAVEPOINT "+savepoint); err != nil {
+		return errors.Wrapf(err, "failed to set savepoint [%s]", savepoint)
+	}
+
+	exists, insertErr := insert()
+	if insertErr != nil || exists {
+		if _, err := tx.ExecContext(ctx, "ROLLBACK TO SAVEPOINT "+savepoint); err != nil {
+			return errors.Join(insertErr, errors.Wrapf(err, "failed to roll back to savepoint [%s]", savepoint))
+		}
+
+		return insertErr
+	}
+
+	if _, err := tx.ExecContext(ctx, "RELEASE SAVEPOINT "+savepoint); err != nil {
+		return errors.Wrapf(err, "failed to release savepoint [%s]", savepoint)
+	}
 
 	return nil
 }
@@ -587,6 +640,10 @@ func (db *IdentityStore) GetSchema() string {
 	)
 }
 
+// storeSignerInfo inserts the signer info for the identity hashed to h. A duplicate key is
+// not an error: the insert is idempotent and the returned boolean reports whether the row was
+// already there. Callers running on a shared transaction must react to that boolean, see
+// insertIdempotently.
 func (db *IdentityStore) storeSignerInfo(ctx context.Context, tx dbTransaction, h string, id tdriver.Identity, info []byte, updateCache bool) (bool, error) {
 	logger.DebugfContext(ctx, "store signer info for [%s]", h)
 	query, args := q.InsertInto(db.table.Signers).
@@ -613,7 +670,11 @@ func (db *IdentityStore) storeSignerInfo(ctx context.Context, tx dbTransaction, 
 	return exists, nil
 }
 
-func (db *IdentityStore) storeIdentityData(ctx context.Context, tx dbTransaction, h string, id []byte, identityAudit []byte, tokenMetadata []byte, tokenMetadataAudit []byte, updateCache bool) error {
+// storeIdentityData inserts the identity data for the identity hashed to h. A duplicate key
+// is not an error: the insert is idempotent and the returned boolean reports whether the row
+// was already there. Callers running on a shared transaction must react to that boolean, see
+// insertIdempotently.
+func (db *IdentityStore) storeIdentityData(ctx context.Context, tx dbTransaction, h string, id []byte, identityAudit []byte, tokenMetadata []byte, tokenMetadataAudit []byte, updateCache bool) (bool, error) {
 	logger.DebugfContext(ctx, "store identity data for [%s]", h)
 	query, args := q.InsertInto(db.table.IdentityInfo).
 		Fields("identity_hash", "identity", "identity_audit_info", "token_metadata", "token_metadata_audit_info").
@@ -621,12 +682,13 @@ func (db *IdentityStore) storeIdentityData(ctx context.Context, tx dbTransaction
 		Format()
 	logging.Debug(logger, query, args)
 
-	_, err := tx.ExecContext(ctx, query, args...)
-	if err != nil {
+	exists := false
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 		if !errors.Is(db.errorWrapper.WrapError(err), driver2.UniqueKeyViolation) {
-			return err
+			return exists, err
 		}
 		logger.DebugfContext(ctx, "identity data [%s] exists, no error to return", h)
+		exists = true
 	}
 
 	if updateCache {
@@ -636,5 +698,5 @@ func (db *IdentityStore) storeIdentityData(ctx context.Context, tx dbTransaction
 	}
 	logger.DebugfContext(ctx, "store identity data for [%s] done", h)
 
-	return nil
+	return exists, nil
 }


### PR DESCRIPTION
## Problem

When registering an identity, up to 4 rows are written in one database transaction. If any row already existed (e.g. from a previous crashed attempt), PostgreSQL treats that as a hard error and cancels the entire transaction — so the missing rows never get written. The registration fails instead of completing. SQLite had a quieter version of the same bug: it silently stopped after the first existing row and left the others unwritten, with no error reported.

`IdentityStore.registerIdentityDescriptor` writes up to four rows — signer info and audit info, for the identity and for its alias — on a **single** transaction. Each insert individually swallows a duplicate key so that re-registering an identity is an idempotent no-op.

On PostgreSQL that assumption breaks down as soon as more than one insert is involved: the *first* duplicate key aborts the whole transaction, and every following statement then fails with a generic `current transaction is aborted` error (`SQLSTATE 25P02`) that no longer matches `UniqueKeyViolation`. A retry after a partial write — e.g. a registration interrupted by a crash, where some rows already exist — therefore failed hard instead of completing.

There was a second, silent half to the bug: the `if exists { return nil }` short-circuit after the first insert. When only the identity's signer info was already present, the function returned success without ever writing the audit info or anything for the alias, and the in-memory caches were then populated as if it had. Nothing failed, but the rows were missing after a restart.

## Fix

Wrap each of the 4 inserts in its own mini "checkpoint" (SAVEPOINT). If a row already exists, roll back only that one checkpoint — not the whole transaction — and move on. The remaining missing rows are then written normally. A crashed partial registration is now completed on retry instead of failing.

Suggested option (b) from the issue — savepoints:

- New `insertIdempotently` helper wraps each insert in its own `SAVEPOINT`, rolling back to it when the row is already there (or when the insert failed) and releasing it otherwise. Rolling back to the savepoint is what clears PostgreSQL's aborted-transaction state, so the still-missing rows can be written and only genuine errors abort the registration. Savepoint names are package-level constants, never derived from input.
- `storeIdentityData` now reports whether the row already existed (`(bool, error)`), mirroring `storeSignerInfo`, so the wrapper can tell a swallowed duplicate key from a clean insert.
- The `exists` short-circuit is removed, so a half-written registration is completed by the retry.
- The idempotency guarantee is now documented on the `IdentityStoreService` interface method, on the implementation, and in `docs/services/storage.md`.

## Test coverage

`TRegisterIdentityDescriptor` in the shared dbtest suite only ever called `registerIdentityDescriptor` twice with identical arguments, so it never reached the abort cascade. Added:

- `TRegisterIdentityDescriptorPartialConflict` (case name `RegisterPartialConflict`), covering four partial-conflict combinations: pre-existing audit info only, pre-existing signer info only, alias rows only, and a mix of both sides.
- `TRegisterIdentityDescriptor` now also asserts on the stored rows, not just on the absence of an error.

Assertions go through `GetSignerInfo`, which bypasses the store's in-memory caches — the caches were otherwise reporting rows as present even when the registration never wrote them.

Verified the new case actually catches the bug by reverting the fix:

- **PostgreSQL**: `failed to store signer info for alias: ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)` — exactly the reported failure.
- **SQLite**: no error, but `signer info mismatch for [cherry]` / `[elderberry]` — the silent-incompleteness half.

Green with the fix: sqlite, in-memory, PostgreSQL (container) and Hashicorp-Vault KVS identity suites, plus `make lint-auto-fix` (0 issues) and `make checks`.

Fixes #2036
