### PR TITLE
identity: areMe converts storage errors into false-negative ownership answers

### DIFF
--- a/token/services/storage/db/kvs/hashicorp/identitydb_test.go
+++ b/token/services/storage/db/kvs/hashicorp/identitydb_test.go
@@ -32,13 +32,9 @@ func TestIdentityDBWithHashicorpVault(t *testing.T) {
 			Namespace: "strawberries",
 		})
 		t.Run(c.Name, func(xt *testing.T) {
-			// The KVS-backed identity store returns composite storage keys from
-			// GetExistingSignerInfo instead of the identity hashes the interface
-			// contract requires. Tracked in #1892; skip until the KVS backend
-			// is brought in line with the SQL implementation.
-			if c.Name == "GetExistingSignerInfo" {
-				xt.Skip("KVS GetExistingSignerInfo returns composite keys, not identity hashes")
-			}
+			// GetExistingSignerInfo now translates the internal composite storage keys
+			// back to identity hashes, in line with the SQL backend and the driver
+			// contract (#1892), so the shared case runs against the KVS backend too.
 			c.Fn(xt, db)
 		})
 	}

--- a/token/services/storage/db/kvs/hashicorp/vault_kvs.go
+++ b/token/services/storage/db/kvs/hashicorp/vault_kvs.go
@@ -68,42 +68,57 @@ func (v *KVS) deNormalizeID(id string) string {
 	return normilzedId
 }
 
-func (v *KVS) GetExisting(ctx context.Context, ids ...string) []string {
+func (v *KVS) GetExisting(ctx context.Context, ids ...string) ([]string, error) {
 	results := make([]string, 0)
 
 	for _, id := range ids {
-		if v.Exists(ctx, id) {
+		ok, err := v.existsE(ctx, id)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed checking existence of id [%s]", id)
+		}
+		if ok {
 			results = append(results, id)
 		}
 	}
 
-	return results
+	return results, nil
 }
 
-func (v *KVS) Exists(_ context.Context, id string) bool {
+// existsE reports whether id holds a value, distinguishing a genuine vault read
+// failure (returned as an error) from a confirmed absence (false, nil). A read
+// error must not be reported as "absent": callers such as Provider.areMe would
+// otherwise treat an owned identity as not-owned (see #2066).
+func (v *KVS) existsE(_ context.Context, id string) (bool, error) {
 	id = v.NormalizeID(id)
 
 	secret, err := v.client.Logical().Read(id)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to read state of id [%s]", id)
+	}
+
+	if secret == nil || secret.Data == nil {
+		return false, nil
+	}
+
+	data, ok := secret.Data[Data].(map[string]any)
+	if !ok || len(data) == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// Exists reports whether id holds a value, treating an unreachable store as
+// "absent". Prefer GetExisting where a store failure must be observable.
+func (v *KVS) Exists(ctx context.Context, id string) bool {
+	ok, err := v.existsE(ctx, id)
 	if err != nil {
 		logger.Debugf("failed to check existence of id [%s]: %v", id, err)
 
 		return false
 	}
 
-	if secret == nil || secret.Data == nil {
-		logger.Debugf("state of id [%s] does not exist", id)
-
-		return false
-	}
-
-	data, ok := secret.Data[Data].(map[string]any)
-	if !ok || len(data) == 0 {
-		logger.Debugf("state of id [%s] does not exist", id)
-
-		return false
-	}
-
-	return true
+	return ok
 }
 
 func (v *KVS) Delete(_ context.Context, id string) error {

--- a/token/services/storage/db/kvs/hashicorp/vault_kvs_test.go
+++ b/token/services/storage/db/kvs/hashicorp/vault_kvs_test.go
@@ -70,7 +70,8 @@ func testRound(t *testing.T, client *vault.Client) {
 	require.NoError(t, err)
 	assert.Equal(t, &stuff{"claws", 2}, val)
 
-	results := kvstore.GetExisting(ctx, k1, k2)
+	results, err := kvstore.GetExisting(ctx, k1, k2)
+	require.NoError(t, err)
 	assert.Len(t, results, 2)
 
 	it, err := kvstore.GetByPartialCompositeID(ctx, "k", []string{})
@@ -96,7 +97,8 @@ func testRound(t *testing.T, client *vault.Client) {
 	require.NoError(t, kvstore.Delete(t.Context(), k2))
 	assert.False(t, kvstore.Exists(ctx, k2))
 
-	results = kvstore.GetExisting(ctx, k1, k2)
+	results, err = kvstore.GetExisting(ctx, k1, k2)
+	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, results[0], k1)
 
@@ -152,7 +154,8 @@ func testRound(t *testing.T, client *vault.Client) {
 	require.NoError(t, kvstore.Get(ctx, k, val2))
 	assert.Equal(t, val, val2)
 
-	results = kvstore.GetExisting(ctx, k)
+	results, err = kvstore.GetExisting(ctx, k)
+	require.NoError(t, err)
 	assert.Len(t, results, 1)
 
 	it, err = kvstore.GetByPartialCompositeID(ctx, k, []string{})
@@ -208,7 +211,8 @@ func testRound(t *testing.T, client *vault.Client) {
 	k4, _ := kvs.CreateCompositeKey("k", []string{"4"})
 	require.NoError(t, kvstore.Delete(t.Context(), k4))
 
-	results = kvstore.GetExisting(ctx)
+	results, err = kvstore.GetExisting(ctx)
+	require.NoError(t, err)
 	assert.Empty(t, results)
 }
 
@@ -355,7 +359,10 @@ func testWithVaultDown(t *testing.T, client *vault.Client) {
 
 	assert.False(t, kvstore.Exists(ctx, k2))
 
-	results := kvstore.GetExisting(ctx, k1, k2)
+	// With the store down, existence cannot be determined: GetExisting must surface the
+	// error rather than fold the unreachable ids into an empty "none exist" slice (#2066).
+	results, err := kvstore.GetExisting(ctx, k1, k2)
+	assert.Error(t, err)
 	assert.Empty(t, results)
 
 	assert.Error(t, kvstore.Delete(t.Context(), k1))

--- a/token/services/storage/db/kvs/identitydb.go
+++ b/token/services/storage/db/kvs/identitydb.go
@@ -294,22 +294,38 @@ func (s *IdentityStore) StoreSignerInfo(ctx context.Context, id tdriver.Identity
 
 func (s *IdentityStore) GetExistingSignerInfo(ctx context.Context, identities ...tdriver.Identity) ([]string, error) {
 	keys := make([]string, len(identities))
+	// The driver contract (and the SQL backend) reports existence by identity hash,
+	// not by the internal composite key, so keep a key -> hash mapping to translate
+	// GetExisting's result back.
+	keyToHash := make(map[string]string, len(identities))
 	for i, id := range identities {
+		idHash := id.UniqueID()
 		k, err := kvs.CreateCompositeKey(
 			IdentityDBPrefix,
 			[]string{
 				IdentityDBSigner,
 				s.tmsID.String(),
-				id.UniqueID(),
+				idHash,
 			},
 		)
 		if err != nil {
 			return nil, err
 		}
 		keys[i] = k
+		keyToHash[k] = idHash
 	}
 
-	return s.kvs.GetExisting(ctx, keys...), nil
+	existingKeys, err := s.kvs.GetExisting(ctx, keys...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed checking existing signer info")
+	}
+
+	result := make([]string, 0, len(existingKeys))
+	for _, k := range existingKeys {
+		result = append(result, keyToHash[k])
+	}
+
+	return result, nil
 }
 
 func (s *IdentityStore) SignerInfoExists(ctx context.Context, id []byte) (bool, error) {

--- a/token/services/storage/db/kvs/identitydb_test.go
+++ b/token/services/storage/db/kvs/identitydb_test.go
@@ -7,10 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package kvs
 
 import (
+	"context"
 	"testing"
 
 	"github.com/LFDT-Panurus/panurus/token"
+	tdriver "github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/storage"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -95,4 +98,55 @@ func TestIdentityStoreGetConfigurationID(t *testing.T) {
 	all, err := db.ConfigurationsByID(ctx, first.ID, first.Type)
 	require.NoError(t, err)
 	assert.Equal(t, []storage.IdentityConfiguration{first}, all)
+}
+
+// errKVS wraps a real KVS but forces GetExisting to fail, standing in for a briefly
+// unavailable backing store.
+type errKVS struct {
+	KVS
+	err error
+}
+
+func (e *errKVS) GetExisting(context.Context, ...string) ([]string, error) {
+	return nil, e.err
+}
+
+// TestIdentityStore_GetExistingSignerInfo_ReturnsHashesNotKeys pins the driver contract for the
+// KVS backend: existence is reported by identity hash (as the SQL backend does), not by the
+// internal composite key. Before the key -> hash mapping fix, GetExisting's composite keys
+// leaked out and Provider.areMe could never match them against an identity's UniqueID.
+func TestIdentityStore_GetExistingSignerInfo_ReturnsHashesNotKeys(t *testing.T) {
+	backend, err := NewInMemory()
+	require.NoError(t, err)
+	tmsID := token.TMSID{Network: "apple", Channel: "pears", Namespace: "strawberries"}
+	db := NewIdentityStore(backend, tmsID)
+	ctx := t.Context()
+
+	id := tdriver.Identity("owned-identity")
+	require.NoError(t, db.StoreSignerInfo(ctx, id, []byte("signer-info")))
+
+	existing, err := db.GetExistingSignerInfo(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, []string{id.UniqueID()}, existing,
+		"GetExistingSignerInfo must report the identity hash, not the internal composite key")
+
+	// an unknown identity is a confirmed absence, not an error
+	missing, err := db.GetExistingSignerInfo(ctx, tdriver.Identity("unknown"))
+	require.NoError(t, err)
+	assert.Empty(t, missing)
+}
+
+// TestIdentityStore_GetExistingSignerInfo_PropagatesStoreError is a regression test for the
+// KVS-backed half of issue #2066: a backing-store failure while checking signer existence must be
+// surfaced, not flattened into a shorter/empty slice that Provider.areMe would read as "not mine"
+// for an owned identity.
+func TestIdentityStore_GetExistingSignerInfo_PropagatesStoreError(t *testing.T) {
+	backend, err := NewInMemory()
+	require.NoError(t, err)
+	tmsID := token.TMSID{Network: "apple", Channel: "pears", Namespace: "strawberries"}
+	db := NewIdentityStore(&errKVS{KVS: backend, err: errors.New("boom")}, tmsID)
+
+	existing, err := db.GetExistingSignerInfo(t.Context(), tdriver.Identity("owned-but-unreachable"))
+	require.Error(t, err, "a store failure must be propagated, not reported as a confident 'not mine'")
+	assert.Nil(t, existing, "no slice may be returned when existence could not be determined")
 }

--- a/token/services/storage/db/kvs/kvs.go
+++ b/token/services/storage/db/kvs/kvs.go
@@ -14,7 +14,12 @@ import (
 
 type KVS interface {
 	Exists(ctx context.Context, id string) bool
-	GetExisting(ctx context.Context, ids ...string) []string
+	// GetExisting returns the subset of ids that currently hold a value. A non-nil
+	// error means existence could not be determined against the backing store; the
+	// returned slice is then not authoritative and must not be read as "only these
+	// exist" (see Provider.areMe / #2066). Implementations must not fold a store
+	// failure into a shorter slice with a nil error.
+	GetExisting(ctx context.Context, ids ...string) ([]string, error)
 	Put(ctx context.Context, id string, state any) error
 	Get(ctx context.Context, id string, state any) error
 	GetByPartialCompositeID(ctx context.Context, prefix string, attrs []string) (kvs.Iterator, error)

--- a/token/services/storage/db/kvs/memory.go
+++ b/token/services/storage/db/kvs/memory.go
@@ -8,7 +8,10 @@ package kvs
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 	mem "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/memory"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/kvs"
@@ -55,4 +58,38 @@ func (k *fscKVS) Close() error {
 	k.Stop()
 
 	return nil
+}
+
+// notFoundMarker is the substring FSC's KVS.Get uses to report that a key holds
+// no value (kvs.KVS.Get -> "state [ns,id] does not exist"). It is the only signal
+// available to tell "confirmed absent" from a real backing-store failure, since
+// both are returned as untyped errors.
+const notFoundMarker = "does not exist"
+
+// GetExisting returns the subset of ids that currently hold a value.
+//
+// The embedded FSC kvs.KVS.GetExisting swallows a backing-store failure and
+// returns a partial (or empty) list with no error, which lets a transient store
+// outage after a cold-cache restart be mistaken for "not mine" (see
+// Provider.areMe / #2066). This override probes each id with the error-returning
+// kvs.KVS.Get instead: a nil error means present, a "does not exist" error means
+// confirmed absent, and any other error is propagated so callers do not treat an
+// unchecked id as absent.
+func (k *fscKVS) GetExisting(ctx context.Context, ids ...string) ([]string, error) {
+	result := make([]string, 0, len(ids))
+	for _, id := range ids {
+		var raw json.RawMessage
+		// k.Get is the embedded kvs.KVS.Get (fscKVS defines no Get of its own).
+		err := k.Get(ctx, id, &raw)
+		switch {
+		case err == nil:
+			result = append(result, id)
+		case strings.Contains(err.Error(), notFoundMarker):
+			// confirmed absent, skip
+		default:
+			return nil, errors.Wrapf(err, "failed checking existence of [%s]", id)
+		}
+	}
+
+	return result, nil
 }

--- a/token/services/ttx/collectendorsements.go
+++ b/token/services/ttx/collectendorsements.go
@@ -455,11 +455,15 @@ func (c *CollectEndorsementsView) requestAudit(context view.Context) ([]view.Ide
 
 	if !c.tx.Opts.Auditor.IsNone() {
 		logger.DebugfContext(context.Context(), "ask auditing to [%s]", c.tx.Opts.Auditor)
-		sigService, err := sig.GetService(context)
+		// Resolve auditor locality through the token SigService, whose IsMe propagates
+		// errors, rather than FSC's sig.Service, whose AreMe logs and discards a
+		// FilterExistingSigners failure. A swallowed error would yield local=false and
+		// route a self-audit through startRemote -> GetSession to self, which FSC does
+		// not support (see startLocal in auditor.go), stalling until the receive timeout.
+		local, err := c.tx.TokenService().SigService().IsMe(context.Context(), c.tx.Opts.Auditor)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed getting sig service for [%s]", c.tx.Opts.Auditor)
+			return nil, errors.Wrapf(err, "failed determining whether auditor [%s] is local", c.tx.Opts.Auditor)
 		}
-		local := sigService.IsMe(context.Context(), c.tx.Opts.Auditor)
 		sessionBoxed, err := context.RunView(newAuditingViewInitiator(c.tx, local, c.Opts.SkipAuditorSignatureVerification))
 		if err != nil {
 			return nil, errors.WithMessagef(err, "failed requesting auditing from [%s]", c.tx.Opts.Auditor.String())


### PR DESCRIPTION
Fixes  #2319

### Part 2 
(Part 1: https://github.com/LFDT-Panurus/panurus/pull/2172 (Issue https://github.com/LFDT-Panurus/panurus/issues/2066) ) 

Here we implements this suggestion in review [comment](https://github.com/LFDT-Panurus/panurus/pull/2172#issuecomment-5422289741_ ):  

Two more findings, on code that isn't in this diff but is directly in scope for the bug being fixed:

**1. `token/services/storage/db/kvs/identitydb.go:312` — the fix doesn't hold for the KVS-backed identity store, so #2066 is only closed for the SQL backend.**

`return s.kvs.GetExisting(ctx, keys...), nil` can never report an error, and FSC's `KVS.GetExisting` (fabric-smart-client v0.18.0, `platform/view/services/storage/kvs/kvs.go:109-111`) does:

```go
it, err := o.store.GetStateSetIterator(...)
if err != nil {
    return result
}
```

i.e. it swallows the store failure and returns the partial/empty list. So: node restarts (in-memory `p.signers` cache cold), backing store is briefly unavailable, `Provider.areMe` receives a short slice with `err == nil` and still answers "not mine" for an owned identity — exactly the false negative this PR is meant to eliminate.

The error-less signature is baked into the `KVS` interface at `token/services/storage/db/kvs/kvs.go:17`, so fixing it needs an interface change or a `Get`-based existence check.

**2. `token/services/ttx/collectendorsements.go:462` — the auditor-locality decision in a file this PR edits is still fail-open.**

`local := sigService.IsMe(context.Context(), c.tx.Opts.Auditor)` uses FSC's `sig.Service`, whose `AreMe` logs and discards a `FilterExistingSigners` error (`platform/view/services/sig/service.go:182-184`).

Scenario: a self-auditing issuer restarts (cold signer cache) and the signer store errors → `local=false` → `AuditingViewInitiator.Call` takes `startRemote` → `context.GetSession(a, <own identity>)`, which FSC explicitly does not support for self (see the comment on `startLocal` in `token/services/ttx/auditor.go`) → the auditing session fails or blocks until the one-minute `ReceiveTypedWithTimeout`.

Worth resolving locality through `c.tx.TokenService().SigService().IsMe(...)` (now error-returning) or FSC's `SignerInfoExists`.



