### PR TITLE
fix(identity): close assorted robustness defects across the identity stack

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -141,6 +141,12 @@ jobs:
           - name: identity-role-register-recipient
             pkg: ./token/services/identity/role
             func: FuzzLongTermOwnerWalletRegisterRecipientNoPanic
+          - name: identity-htlc-verify-owner
+            pkg: ./token/services/identity/interop/htlc
+            func: FuzzVerifyOwnerNoPanic
+          - name: identity-htlc-metadata-claim-key-check
+            pkg: ./token/services/identity/interop/htlc
+            func: FuzzMetadataClaimKeyCheckNoPanic
 
     steps:
       - name: Checkout code

--- a/docs/services/identity.md
+++ b/docs/services/identity.md
@@ -98,6 +98,15 @@ The `LocalMembership` component (`token/services/identity/membership`) plays a p
     each returned `KeyManager` must either be independently owned by the caller or safe for concurrent `EnrollmentID` calls — and the results
     are committed to the in-memory indices sequentially in the original store order, so identity ordering (e.g. fallback default selection,
     same-name tie-breaks) is deterministic.
+*   **Reloading replaces, it does not merge**: `Load` may be called more than once on the same `LocalMembership`, and each call is a full
+    replacement of the in-memory view. It resets **all four** indices — `localIdentities`, `localIdentitiesByName`,
+    `localIdentitiesByConfig` and `localIdentitiesByIdentity` — plus the cached default identifier, so an identity that was present only in an
+    earlier `Load` no longer resolves. `localIdentitiesByIdentity` is the map consulted after a miss on `localIdentitiesByName` (by both
+    `lookup` and `getLocalIdentity`, reached from `GetIdentifier` and `GetIdentityInfo`); leaving it unreset was the stale-read fixed for
+    [#2073](https://github.com/LFDT-Panurus/panurus/issues/2073). Anything added to `LocalMembership` that indexes identities must be reset
+    there too.
+*   **Teardown**: `Close` releases every `KeyManager` this membership loaded (those implementing `Close`), unregisters its own `conf_id`s from
+    the `SignerRouter` (see below), and unsubscribes from the identity-store notifier. It is idempotent.
 
 ### Example: Wiring Services
 
@@ -148,6 +157,11 @@ func (d *Base) NewWalletService(...) (*wallet.Service, error) {
 *   **Wiring**: a driver builds a `SignerRouter` with `identity.NewSignerRouter(m *Metrics)`, registers `KeyManager`s against their `conf_id` with `Register`, sets a `ConfIDResolver` with `SetConfIDResolver`, and attaches it to the `Provider` with `Provider.SetSignerRouter`. See `token/core/fabtoken/v1/driver/ws.go` and the zkatdlog equivalent.
 *   **Fallback semantics**: `Resolve` returns `ok=false` (never an error) whenever routing cannot be attempted (no resolver set, no `conf_id` mapping, no `KeyManager` registered for it) or the routed `KeyManager` itself fails — callers always fall back to the probing deserializer in that case, never treating it as a hard failure.
 *   **Probe-free deserialization**: when the registered `KeyManager` also implements `idriver.ProbeFreeSignerDeserializer`, `Resolve` calls `DeserializeSignerNoProbe` directly, skipping the cryptographic probe that the fallback path relies on to catch a mismatched `KeyManager`. This is only safe because the `conf_id` already pins the identity to exactly one `KeyManager`.
+*   **Teardown**: a registration pins its `KeyManager` — and, for idemix, the BCCSP instance and `IdentityCache` behind it — for as long as the entry lives, so registrations have an explicit lifecycle:
+    *   `Unregister(confIDs ...string)` drops specific entries. `LocalMembership.Close` calls it with the `conf_id`s of its own local identities right after closing their `KeyManager`s, so a released `KeyManager` is never left routable with the probe skipped. Because `conf_id` is derived from `(ID, Type, URL)` with `Type` being the membership's identity type, one role's teardown cannot unpin another's entries.
+    *   `Close()` drops every entry, for tearing down a whole router. It does not close the `KeyManager`s themselves — the router borrows them; `LocalMembership` owns them. The router stays usable afterwards.
+    *   `Len()` reports how many bindings are currently held.
+    *   Both are idempotent, and unregistering an unknown `conf_id` is a no-op. After either, `Resolve` reports `ok=false` for the affected identities and callers fall back to the probing deserializer — correct, just without the fast path.
 
 #### conf_id must be collision-free
 
@@ -404,6 +418,22 @@ flows), so both `crypto.AuditInfo.FromBytes`
 (`token/services/identity/idemixnym/nym/audit.go`) treat their input as untrusted and reject
 malformed payloads with an error.
 
+Both decode through the project's strict JSON wrapper
+(`token/core/common/encoding/json`, which sets `DisallowUnknownFields`) — the same logical type
+must not be parsed more leniently just because it arrived through a different entry point.
+`nym.AuditInfo` additionally rejects a payload that carries none of the promoted
+`crypto.AuditInfo` fields: `encoding/json` leaves the embedded pointer nil in that case, and
+`FromBytes` returning success there would hand the caller a value whose promoted methods and
+fields nil-dereference. Both strictness gaps were closed for
+[#2073](https://github.com/LFDT-Panurus/panurus/issues/2073).
+
+`crypto.AuditInfo.Validate` guarantees only the four `Attributes` entries the default schema
+needs, while the schema string travels in the same payload and selects the positions
+`schema.DefaultManager` indexes — up to `Attributes[27]` for `w3c-v0.0.1`. `EidNymAuditOpts` and
+`RhNymAuditOpts` therefore bounds-check before indexing and return an error for an
+attribute-count/schema mismatch, rather than relying on callers to overwrite `Schema` with a
+trusted value first (which `idemixnym.KeyManager.DeserializeAuditInfo` does do today).
+
 `EidNymAuditData` and `RhNymAuditData` embed `mathlib` curve elements, which JSON-encode as
 a curve ID plus the raw element bytes:
 
@@ -469,6 +499,7 @@ Located in `token/services/identity/boolpolicy`.
     - `TypedIdentity` payload: ASN.1 DER.
     - Audit Info: JSON.
 *   **Signature Representation**: An ASN.1 `PolicySignature` (`SEQUENCE OF OCTET STRING`) where each slot corresponds to one component identity. A slot may be nil/empty when that component does not need to sign (valid for OR branches).
+*   **Verification**: `PolicyVerifier.Verify` rejects a `PolicySignature` whose slot count differs from `len(Verifiers)`, then walks the AST memoising each `$N`'s outcome so a repeated reference verifies at most once. Every `$N` is additionally bounds-checked against the signature slots, the memo and `Verifiers` at the point each is indexed, and a nil `Verifiers` entry fails the reference: an out-of-range or unset slot is an unsatisfied reference, never a panic, independently of the length check in `Verify`.
 *   **Implementation**: `token/services/identity/boolpolicy`.
 
 #### HTLC (Hashed Time Lock Contract)
@@ -486,6 +517,8 @@ Located in `token/services/identity/interop/htlc`.
     - `TypedIdentity` payload: JSON.
     - Audit Info: JSON.
 *   **Behavior**: Validation involves satisfying the script conditions (e.g., providing the hash preimage).
+*   **Parsing strictness**: the `Script` in a `TypedIdentity`, the `ScriptInfo` audit info and the `ClaimSignature` are all parsed with the strict JSON wrapper (`DisallowUnknownFields`), in `validator.go` and `info.go` as well as in `deserializer.go` — the validator must not accept a payload the deserializer would reject.
+*   **Preimage comparison**: `MetadataClaimKeyCheck` compares the claim's preimage against the action's metadata entry with `subtle.ConstantTimeCompare`. Not a practical timing oracle today (the same transaction reveals the preimage in the clear), but the property costs nothing to keep.
 
 ## Extending the Identity Service
 

--- a/plan.md
+++ b/plan.md
@@ -1,134 +1,70 @@
-# Plan: Bump fabric-smart-client to v0.18.0
+# Plan — issue #2073 ✅ COMPLETE: identity assorted robustness defects
 
 ## Goal
-Update Panurus's `github.com/hyperledger-labs/fabric-smart-client` dependency from
-v0.17.0 to the tagged release **v0.18.0** across every Go module, absorb the two
-breaking API changes in that release, align pinned infra versions, and get
-`make checks` / `make unit-tests` green. Do not push or open a PR without explicit
-user go-ahead (per AGENTS.md).
 
-Already on branch `fsc-v0-18-0` (== `main`, no commits yet) — no new branch needed.
-
-## Upstream changes (v0.17.0...v0.18.0)
-Two PRs are marked breaking (`fix!:` / explicit "Breaking changes" section):
-
-1. **PR #1649** — `view.Session.Send`/`SendError` become ctx-first; `SendWithContext`/
-   `SendErrorWithContext` are removed (merged into `Send`/`SendError`).
-2. **PR #1644** — leading `context.Context` added to `NewBatchExecutor`,
-   `NewBatchRunner`, `NewTimeoutCache`, `NewTimeoutEviction`, `NewListenerManager`,
-   `NewSequentialListenerManager`, `NewDeliveryFLM`, `chaincode.NewChaincode`,
-   `chaincode.NewManager`, and the package-level `view.RunView`.
-
-Grep-confirmed blast radius in Panurus:
-- Panurus never calls FSC's package-level `view.RunView` (it has its own
-  independent `token/services/utils/view.RunView` wrapper) — no changes needed there.
-- Panurus doesn't call `NewBatchExecutor`/`NewBatchRunner`/`NewTimeoutCache`/
-  `NewTimeoutEviction`/`NewDeliveryFLM`/`chaincode.NewChaincode`/`chaincode.NewManager`
-  directly — no changes needed.
-- `events.NewListenerManager[TxInfo]` (`token/services/network/fabric/finality/deliveryflm.go:165`)
-  and `events.NewSequentialListenerManager[KeyInfo]` (`token/services/network/fabric/lookup/deliveryllm.go:146`)
-  ARE called directly and need a leading ctx. No ctx flows through their callers
-  (`ListenerManagerProvider.NewManager(network, channel string)`). FSC's own
-  `channelprovider.go` hit the identical situation ("channel has no higher-level
-  context to derive from today") and used `context.WithCancel(context.Background())`
-  — mirror that: pass `context.Background()` at both call sites (no `Close()` hook
-  exists on `deliveryBasedFLM`/`deliveryBasedLLM` to wire a cancel into, matching
-  upstream's own constraint).
-- `view.Session` implementers needing the Send/SendError merge:
-  - `token/services/ttx/session.go` (`localSession`) — hand-written, real implementer.
-  - `token/services/ttx/cleanupsessions_test.go` (`countingSession`) — test double.
-  - `token/services/ttx/dep/mock/session.go`, `token/services/ttx/deps/mock/session.go`,
-    `token/services/utils/session/mock/session.go` — counterfeiter mocks, regenerate.
-  - `token/services/utils/session/session.go` (`S`, `type Session = view.Session`
-    alias): internal calls `j.s.SendWithContext(...)` / `j.s.SendErrorWithContext(...)`
-    must rename to `j.s.Send(...)` / `j.s.SendError(...)`. `S`'s own public API
-    (`Send(state any)`, `SendWithContext`, `SendError(err string)`,
-    `SendErrorWithContext`) is a distinct signature (not the FSC interface) and
-    stays as-is — not in scope.
-  - `token/services/utils/json/session/envelope.go` calls `s.SendWithContext(ctx, env)`
-    where `s` is Panurus's own `*session.S` wrapper (not the FSC interface directly)
-    — unaffected, no change.
-  - `token/services/ttx/session_test.go` — update to the renamed methods it exercises.
-- Sub-modules `platform/fabric/services/state/cc/query` and
-  `platform/view/services/comm/host/libp2p` stay pinned at v0.16.0 (FSC's own
-  root go.mod doesn't reference them — independently tagged; only bump if a build
-  error demands it).
+Close the bundle of robustness defects reported in
+[#2073](https://github.com/LFDT-Panurus/panurus/issues/2073) across the identity stack. The one
+item with real correctness impact is the stale `localIdentitiesByIdentity` map after a second
+`LocalMembership.Load`; everything else is latent fragility or defense-in-depth.
 
 ## Steps
-- [x] 1. `make update-dep DEP=github.com/hyperledger-labs/fabric-smart-client VER=v0.18.0` — done.
-- [x] 2. `make update-dep DEP=github.com/hyperledger-labs/fabric-smart-client/integration VER=v0.18.0` — done
-      (first attempt hit a transient proxy hiccup on the hashicorp module; retried clean).
-- [x] 3. Diff FSC's Makefile pinned infra versions against Panurus's `Makefile`/`fabricx.mk`.
-      `FABRIC_VERSION`/`FABRIC_TWO_DIGIT_VERSION`/`FABRIC_X_TOOLS_VERSION`/`FABRIC_X_COMMITTER_VERSION`
-      already matched (3.1.4 / v1.0.1 / 1.0.4). Docker image refs HAD drifted: FSC now
-      pulls `fabric-baseos`/`fabric-ccenv`/`fabric-x-committer-test-node` from
-      `ghcr.io/hyperledger/...` and tags to the plain `hyperledger/...` name; Panurus's
-      `Makefile` (`fabric-docker-images`) and `fabricx.mk` (`fabricx-docker-images`) were
-      still pulling straight from Docker Hub. Fixed both to match FSC's ghcr.io source.
-- [x] 4. Fix `view.Session` Send/SendError merge (files listed above), including all
-      `SendWithContext*`/`SendErrorWithContext*` counterfeiter-mock call sites
-      (`*Stub`, `*Returns`, `*ReturnsOnCall`, `*CallCount`, `*ArgsForCall`) surfaced by
-      `go vet -all ./...` across `token/services/ttx/{,boolpolicy,multisig}/*_test.go`,
-      `token/services/utils/json/session/envelope_test.go`,
-      `token/services/utils/session/session_test.go`.
-- [x] 5. Add `context.Background()` to the two `events.New*ListenerManager` call sites.
-- [x] 6. `go generate ./...` to regenerate counterfeiter mocks — see Notes & Decisions
-      for the scope-narrowing this required.
-- [x] 7. `go build ./... && go vet -all ./...` in every `GO_MODULES` dir — all clean.
-- [x] 8. `make lint-auto-fix && make checks-no-tidy` — clean (see Notes & Decisions on
-      why `checks-no-tidy` instead of `checks`). `make tidy` run once to refresh
-      go.mod/go.sum for the new FSC version.
-- [x] 9. `make unit-tests` — all green, zero failures, across every package in the
-      root module and the `hashicorp` kvs module. `unit-tests-race` not run (not
-      requested; standard suite already gives full confidence in the Send/SendError
-      merge and ctx-propagation changes).
-- [x] 10. One signed-off commit (`b228a15b1`, `git commit -s`). Waiting for user
-      go-ahead before push/PR.
 
-✅ COMPLETE (pending user go-ahead for push/PR)
+1. `token/services/identity/membership/lm.go` — `Load` must reset `localIdentitiesByIdentity`
+   alongside the other three `localIdentitiesBy*` maps, so `lookup`/`getLocalIdentity` cannot
+   return pre-reload entries.
+2. `token/services/identity/boolpolicy/sig.go` — `evalRef` bounds-checks `i` against `len(sigs)`
+   but then indexes `v.Verifiers[i]`. Add an explicit `i >= len(v.Verifiers)` guard at the point of
+   use so it no longer depends on `Verify`'s earlier length-equality check being kept in sync.
+3. `token/services/identity/idemixnym/nym/audit.go` — `FromBytes` uses stdlib `encoding/json` while
+   the same logical type is parsed with the project's strict `DisallowUnknownFields` wrapper
+   everywhere else. Switch to the strict wrapper and add the nil-embedded-pointer guard that
+   `crypto.DeserializeAuditInfo` has, so a payload carrying no `crypto.AuditInfo` fields is rejected
+   in `FromBytes` rather than panicking in a promoted method.
+4. `token/services/identity/interop/htlc/validator.go` and `info.go` — switch to the strict JSON
+   wrapper already used by `deserializer.go` for the same wire types (`htlc.Script`, `ScriptInfo`).
+5. `token/services/identity/interop/htlc/validator.go` — compare the HTLC preimage against the
+   metadata entry in constant time.
+6. `token/services/identity/role/cache.go` — `time.Since(start)` is evaluated eagerly even though
+   `start` is only assigned under a debug-level check; move the formatting behind the same check and
+   consolidate the four package-level `logger` calls onto the instance `c.Logger`.
+7. `token/services/identity/idemix/schema/schema.go` — `EidNymAuditOpts`/`RhNymAuditOpts` index
+   `attrs` at schema-dependent positions (up to `attrs[27]` for `w3c-v0.0.1`) with no bounds check,
+   so an audit info that passes `crypto.AuditInfo.Validate`'s `len(Attributes) >= 4` check but
+   declares the w3c schema panics. Bounds-check before indexing.
+8. `token/services/identity/signer_router.go` — add teardown for `byConfID`
+   (`Unregister`/`Close`) and unregister a `LocalMembership`'s own conf_ids from
+   `LocalMembership.Close`, so released KeyManagers are not left routable.
+   (`role.Registry.Wallets` already has the teardown hook the issue asks for: `Registry.Done`.)
+9. Unit tests for each behavioural change; `docs/` update where user-visible.
+10. `make checks` / `make lint-auto-fix` / `make unit-tests` clean.
+
+## Implementation Progress
+
+- [x] Done — 1. `Load` resets `localIdentitiesByIdentity` — reset alongside the other three maps in `Load`; regression test verified to fail without it
+- [x] Done — 2. `boolpolicy` verifier bounds guard — `evalRef` now bounds-checks `i` against `sigs`, `memo` and `Verifiers`, and rejects a nil `Verifiers` entry
+- [x] Done — 3. `nym.AuditInfo.FromBytes` strict JSON + nil guard — switched to `token/core/common/encoding/json`; nil embedded `crypto.AuditInfo` rejected in `FromBytes`
+- [x] Done — 4. htlc validator/info strict JSON — `validator.go` and `info.go` now use the strict wrapper `deserializer.go` already used
+- [x] Done — 5. htlc preimage constant-time compare — `subtle.ConstantTimeCompare` in `MetadataClaimKeyCheck`
+- [x] Done — 6. `role/cache.go` debug-guard + single logger — `time.Since` reads moved behind the debug check; package-level `logger` removed, everything on `c.Logger`
+- [x] Done — 7. idemix schema audit-opts bounds checks — `attributeAt` guards `Eid`/`RhNymAuditOpts`; schema names and indices are now named constants
+- [x] Done — 8. `SignerRouter` teardown — `Unregister`/`Close`/`Len` added; `LocalMembership.Close` unregisters its own conf_ids after releasing their KeyManagers
+- [x] Done — 9. Tests — unit tests per item, plus `FuzzVerifyOwnerNoPanic` and `FuzzMetadataClaimKeyCheckNoPanic` wired into `nightly-fuzz.yml`
+- [x] Done — 10. Checks green — `make checks`, `make lint-auto-fix`, `make unit-tests` and `-race` clean; only pre-existing `TestTranslatePath` fails (asserts the checkout dir is named `panurus`)
 
 ## Notes & Decisions
-- Target is the tagged release `v0.18.0`, not latest `main` HEAD — runbook adapted
-  accordingly (VER=v0.18.0 instead of a commit SHA; no new branch).
-- `token/services/ttx/dep/mock/session.go` has no owning `//go:generate` directive
-  anywhere in the current codebase (orphaned — likely left behind by a past
-  refactor), so `go generate ./...` silently skips it. Hand-fixed by copying the
-  freshly-regenerated, structurally-identical sibling `token/services/ttx/deps/mock/session.go`
-  over it (both mock the same `ttx.Session` = `view.Session` alias). Not fixing the
-  missing directive itself — out of scope for this bump.
-- `token/services/utils/json/session/json.go:8` has a pre-existing broken
-  `//go:generate counterfeiter ... . JsonSession` directive — no `JsonSession`
-  interface exists anywhere in that package, so `go generate ./...` errors on it
-  (`cannot find package with target: JsonSession`). Confirmed via git diff/ls that
-  this predates this session and is unrelated to the FSC bump. Left unfixed —
-  out of scope.
-- Running `go generate ./...` unscoped regenerated ~15 mock files that have nothing
-  to do with the FSC Session API change (a newer locally-installed `counterfeiter`
-  version adds `var _ <pkg>.<Interface> = new(<Mock>)` assertion lines and other
-  formatting churn project-wide) and created 3 new untracked mock artifacts that
-  never existed in git. This violates the "minimal, surgical changes" rule and, as
-  a side effect, introduced a genuine new import cycle in
-  `token/services/identity/multisig` (a `package multisig` test file importing
-  `multisig/mock`, which the new assertion line made import `multisig` right back).
-  Fixed by reverting all 15 unrelated files via `git checkout --` and removing the
-  3 new untracked artifacts, leaving only the 3 intentional Session mock
-  regenerations (`ttx/dep/mock`, `ttx/deps/mock`, `utils/session/mock`) modified.
-- `make checks`'s `tidy-check` sub-target diffs `go.mod`/`go.sum` against `HEAD` and
-  will always flag them after a legitimate dependency-version bump + `make tidy`.
-  The Makefile already anticipates this with a `checks-no-tidy` target
-  ("for use after a workflow step that already rewrote go.mod/go.sum to a new
-  dependency version and ran 'make tidy' itself") — used that instead of `checks`.
-  `make tidy` itself was still run once, and its output (go.mod/go.sum updates
-  across all 9 Go modules) is expected/desired.
-- `make lint-auto-fix` (and standalone `golangci-lint`) reports 17 pre-existing
-  `revive: unhandled-error` findings (unchecked `strings.Builder.Write*`,
-  `fmt.Fprintf`/`fmt.Print` return values) in `cmd/profiler/*`,
-  `token/core/zkatdlog/nogh/v1/crypto/common/array*.go`, `token/driver/wallet*.go`,
-  `token/services/benchmark/runner.go`, `token/services/storage/db/sql/**`. Confirmed
-  via `git status`/`git diff` that none of these files were touched by this session —
-  pre-existing lint debt, unrelated to the FSC bump, left as-is.
-- `token/services/ttx/cleanupsessions_test.go`'s `countingSession` fake dropped from
-  7 methods to 5 (merging `Send`/`SendWithContext` and `SendError`/`SendErrorWithContext`
-  into ctx-first `Send`/`SendError`) — `gofmt -s` then re-aligned the trailing-comment
-  columns on the remaining method one-liners; ran `gofmt -l -s -w` on just that file
-  to pick this up (it's what `make checks`'s `gofmt` sub-target itself was flagging).
+
+- The issue also notes that `crypto.AuditInfo.Validate` never validates `Schema` against a known
+  set. A whitelist inside `Validate` would hardcode `DefaultManager`'s two schemas into a type whose
+  `SchemaManager` is an interface, breaking any custom manager that supports other schemas. The
+  reachable consequence of an unvalidated `Schema` is the unchecked `attrs[...]` indexing in
+  `DefaultManager`, so step 7 guards there instead — an unsupported schema already returns an error
+  from those methods.
+
+- `role.Registry.Wallets` already had the teardown hook the issue asks for (`Registry.Done`, which
+  closes wallets implementing `Close` and drops the map), so only `SignerRouter.byConfID` needed one.
+- Consolidating `role/cache.go` onto `c.Logger` left the package-level `logger` unused (every other
+  reference in the package is a shadowing parameter), so it was removed rather than kept dead —
+  which is also what "one logical component, one logger" means here.
+- `docs/services/identity.md` updated: reload-replaces-not-merges under LocalMembership, the
+  SignerRouter teardown API, the audit-info JSON strictness and schema/attribute-count coupling, the
+  boolpolicy verification bounds guarantees, and the HTLC parsing/comparison notes.

--- a/token/services/identity/boolpolicy/sig.go
+++ b/token/services/identity/boolpolicy/sig.go
@@ -123,8 +123,17 @@ func (v *PolicyVerifier) evalNode(node Node, msg []byte, sigs [][]byte, memo []r
 
 // evalRef verifies the component identity at index i, reusing a previously
 // computed result for the same index when one is available.
+//
+// i is bounds-checked against sigs, memo and Verifiers independently. Verify already rejects a
+// signature whose slot count differs from len(Verifiers), which makes the three lengths equal
+// today, but that is an invariant held by convention in a different function: checking each slice
+// at the point it is indexed keeps an out-of-range index a rejected reference rather than a panic
+// if that equality check is ever loosened.
 func (v *PolicyVerifier) evalRef(i int, msg []byte, sigs [][]byte, memo []refResult) bool {
-	if i < 0 || i >= len(sigs) || len(sigs[i]) == 0 {
+	if i < 0 || i >= len(sigs) || i >= len(memo) || i >= len(v.Verifiers) {
+		return false
+	}
+	if len(sigs[i]) == 0 || v.Verifiers[i] == nil {
 		return false
 	}
 	if memo[i] != refUnknown {

--- a/token/services/identity/boolpolicy/sig_test.go
+++ b/token/services/identity/boolpolicy/sig_test.go
@@ -234,3 +234,61 @@ func TestPolicyVerify_Memoisation_FailingRefVerifiedOnce(t *testing.T) {
 	require.Error(t, pv.Verify([]byte(testMsg), buildPolicySig(t, "wrong")))
 	assert.Equal(t, 1, counter.calls, "failing verifier for $0 must be invoked exactly once")
 }
+
+// ---------------------------------------------------------------------------
+// Bounds checks at the point of use (issue #2073)
+// ---------------------------------------------------------------------------
+
+// TestEvalRef_ShorterVerifiersThanSignatures calls the AST evaluation directly with more signature
+// slots than Verifiers. Verify rejects that mismatch before evalNode ever runs, so this exercises
+// evalRef's own guard: a reference past the end of Verifiers must evaluate to false rather than
+// panic with an index-out-of-range.
+func TestEvalRef_ShorterVerifiersThanSignatures(t *testing.T) {
+	stubs := makeVerifiers(testMsg, "s0")
+
+	node, err := Parse("$0 OR $1")
+	require.NoError(t, err)
+	pv := &PolicyVerifier{
+		Policy: node,
+		// Two signature slots below, only one Verifier here.
+		Verifiers: []tdriver.Verifier{stubs[0]},
+	}
+
+	sigs := [][]byte{[]byte("s0"), []byte("s1")}
+	memo := make([]refResult, len(sigs))
+
+	// $0 is in range and its signature verifies, so the OR is satisfied without reaching $1.
+	assert.True(t, pv.evalNode(pv.Policy, []byte(testMsg), sigs, memo))
+
+	// $1 alone is out of range for Verifiers and must simply not be satisfied.
+	node, err = Parse("$1")
+	require.NoError(t, err)
+	pv.Policy = node
+	memo = make([]refResult, len(sigs))
+	assert.False(t, pv.evalNode(pv.Policy, []byte(testMsg), sigs, memo))
+}
+
+// TestEvalRef_ShorterMemoThanSignatures exercises the memo bounds check: memo is documented to have
+// one entry per signature slot, and a shorter one must not panic.
+func TestEvalRef_ShorterMemoThanSignatures(t *testing.T) {
+	stubs := makeVerifiers(testMsg, "s0", "s1")
+
+	node, err := Parse("$1")
+	require.NoError(t, err)
+	pv := &PolicyVerifier{Policy: node, Verifiers: []tdriver.Verifier{stubs[0], stubs[1]}}
+
+	sigs := [][]byte{[]byte("s0"), []byte("s1")}
+	assert.False(t, pv.evalNode(pv.Policy, []byte(testMsg), sigs, make([]refResult, 1)))
+}
+
+// TestEvalRef_NilVerifier covers a Verifiers slot left nil: the reference must fail instead of
+// nil-dereferencing on Verify.
+func TestEvalRef_NilVerifier(t *testing.T) {
+	node, err := Parse("$0")
+	require.NoError(t, err)
+	pv := &PolicyVerifier{Policy: node, Verifiers: []tdriver.Verifier{nil}}
+
+	sigs := [][]byte{[]byte("s0")}
+	assert.False(t, pv.evalNode(pv.Policy, []byte(testMsg), sigs, make([]refResult, 1)))
+	require.Error(t, pv.Verify([]byte(testMsg), buildPolicySig(t, "s0")))
+}

--- a/token/services/identity/idemix/schema/schema.go
+++ b/token/services/identity/idemix/schema/schema.go
@@ -32,8 +32,31 @@ const (
 	rhIdx  = 3
 	skIdx  = 0
 
+	// w3cEidIdx and w3cRhIdx are the enrollment-id and revocation-handle positions in the
+	// W3CSchema attribute list (see attributeNames, offset by one for the hidden usk attribute
+	// PublicKeyImportOpts prepends).
+	w3cEidIdx = 26
+	w3cRhIdx  = 27
+	w3cSkIdx  = 24
+
 	DefaultSchema = ""
+	// W3CSchema is the identifier of the W3C Verifiable Credentials schema.
+	W3CSchema = "w3c-v0.0.1"
 )
+
+// attributeAt returns attrs[i], or an error when attrs is too short for the schema that selected
+// that index. The audit-opts builders index attrs at positions fixed by the schema name, and the
+// schema travels alongside the attributes in a serialized AuditInfo: nothing in the wire format
+// makes the two consistent, and callers (crypto.AuditInfo.Validate) only guarantee the four
+// entries the default schema needs. Returning an error keeps a mismatched pair a rejected audit
+// info instead of an index-out-of-range panic.
+func attributeAt(schema string, attrs [][]byte, i int) ([]byte, error) {
+	if i < 0 || i >= len(attrs) {
+		return nil, errors.Errorf("schema '%s' requires at least %d attributes, got %d", schema, i+1, len(attrs))
+	}
+
+	return attrs[i], nil
+}
 
 // attributeNames are the attribute names for the `w3c` schema
 var attributeNames = []string{
@@ -87,11 +110,11 @@ func NewDefaultManager() *DefaultManager {
 // Returns the options for signing with pseudonyms
 func (*DefaultManager) NymSignerOpts(schema string) (*bccsp.IdemixNymSignerOpts, error) {
 	switch schema {
-	case "":
+	case DefaultSchema:
 		return &bccsp.IdemixNymSignerOpts{}, nil
-	case "w3c-v0.0.1":
+	case W3CSchema:
 		return &bccsp.IdemixNymSignerOpts{
-			SKIndex: 24,
+			SKIndex: w3cSkIdx,
 		}, nil
 	}
 
@@ -101,7 +124,7 @@ func (*DefaultManager) NymSignerOpts(schema string) (*bccsp.IdemixNymSignerOpts,
 // Returns the options for importing issuer public keys (with the attribute names)
 func (*DefaultManager) PublicKeyImportOpts(schema string) (*bccsp.IdemixIssuerPublicKeyImportOpts, error) {
 	switch schema {
-	case "":
+	case DefaultSchema:
 		return &bccsp.IdemixIssuerPublicKeyImportOpts{
 			Temporary: true,
 			AttributeNames: []string{
@@ -111,7 +134,7 @@ func (*DefaultManager) PublicKeyImportOpts(schema string) (*bccsp.IdemixIssuerPu
 				msp.AttributeNameRevocationHandle,
 			},
 		}, nil
-	case "w3c-v0.0.1":
+	case W3CSchema:
 		return &bccsp.IdemixIssuerPublicKeyImportOpts{
 			Temporary:      true,
 			AttributeNames: append([]string{""}, attributeNames...),
@@ -124,7 +147,7 @@ func (*DefaultManager) PublicKeyImportOpts(schema string) (*bccsp.IdemixIssuerPu
 // Returns the options for creating signatures/proofs (specifying which attributes are hidden)
 func (*DefaultManager) SignerOpts(schema string) (*bccsp.IdemixSignerOpts, error) {
 	switch schema {
-	case "":
+	case DefaultSchema:
 		return &bccsp.IdemixSignerOpts{
 			Attributes: []bccsp.IdemixAttribute{
 				{Type: bccsp.IdemixHiddenAttribute},
@@ -135,7 +158,7 @@ func (*DefaultManager) SignerOpts(schema string) (*bccsp.IdemixSignerOpts, error
 			RhIndex:  rhIdx,
 			EidIndex: eidIdx,
 		}, nil
-	case "w3c-v0.0.1":
+	case W3CSchema:
 		var idemixAttrs []bccsp.IdemixAttribute
 		for i := range attributeNames {
 			switch i {
@@ -156,9 +179,9 @@ func (*DefaultManager) SignerOpts(schema string) (*bccsp.IdemixSignerOpts, error
 
 		return &bccsp.IdemixSignerOpts{
 			Attributes:       idemixAttrs,
-			RhIndex:          27,
-			EidIndex:         26,
-			SKIndex:          24,
+			RhIndex:          w3cRhIdx,
+			EidIndex:         w3cEidIdx,
+			SKIndex:          w3cSkIdx,
 			VerificationType: bccsp.ExpectEidNymRhNym,
 		}, nil
 	}
@@ -169,17 +192,27 @@ func (*DefaultManager) SignerOpts(schema string) (*bccsp.IdemixSignerOpts, error
 // Returns the options for auditing revocation handle pseudonyms
 func (*DefaultManager) RhNymAuditOpts(schema string, attrs [][]byte) (*bccsp.RhNymAuditOpts, error) {
 	switch schema {
-	case "":
+	case DefaultSchema:
+		rh, err := attributeAt(schema, attrs, rhIdx)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot build RhNymAuditOpts")
+		}
+
 		return &bccsp.RhNymAuditOpts{
 			RhIndex:          rhIdx,
 			SKIndex:          skIdx,
-			RevocationHandle: string(attrs[rhIdx]),
+			RevocationHandle: string(rh),
 		}, nil
-	case "w3c-v0.0.1":
+	case W3CSchema:
+		rh, err := attributeAt(schema, attrs, w3cRhIdx)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot build RhNymAuditOpts")
+		}
+
 		return &bccsp.RhNymAuditOpts{
-			RhIndex:          27,
-			SKIndex:          24,
-			RevocationHandle: string(attrs[27]),
+			RhIndex:          w3cRhIdx,
+			SKIndex:          w3cSkIdx,
+			RevocationHandle: string(rh),
 		}, nil
 	}
 
@@ -189,17 +222,27 @@ func (*DefaultManager) RhNymAuditOpts(schema string, attrs [][]byte) (*bccsp.RhN
 // Returns options for auditing enrollment ID pseudonyms
 func (*DefaultManager) EidNymAuditOpts(schema string, attrs [][]byte) (*bccsp.EidNymAuditOpts, error) {
 	switch schema {
-	case "":
+	case DefaultSchema:
+		eid, err := attributeAt(schema, attrs, eidIdx)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot build EidNymAuditOpts")
+		}
+
 		return &bccsp.EidNymAuditOpts{
 			EidIndex:     eidIdx,
 			SKIndex:      skIdx,
-			EnrollmentID: string(attrs[eidIdx]),
+			EnrollmentID: string(eid),
 		}, nil
-	case "w3c-v0.0.1":
+	case W3CSchema:
+		eid, err := attributeAt(schema, attrs, w3cEidIdx)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot build EidNymAuditOpts")
+		}
+
 		return &bccsp.EidNymAuditOpts{
-			EidIndex:     26,
-			SKIndex:      24,
-			EnrollmentID: string(attrs[26]),
+			EidIndex:     w3cEidIdx,
+			SKIndex:      w3cSkIdx,
+			EnrollmentID: string(eid),
 		}, nil
 	}
 

--- a/token/services/identity/idemix/schema/schema_test.go
+++ b/token/services/identity/idemix/schema/schema_test.go
@@ -383,3 +383,87 @@ func TestAttributeNames(t *testing.T) {
 	assert.Contains(t, attributeNames[25], "cbdccard:4_eid")
 	assert.Contains(t, attributeNames[26], "cbdccard:5_rh")
 }
+
+// TestAuditOpts_ShortAttributesRejected covers the unchecked attribute indexing reported in issue
+// #2073. The audit-opts builders index attrs at positions fixed by the schema name - up to
+// attrs[27] for W3CSchema - while crypto.AuditInfo.Validate only guarantees the four entries the
+// default schema needs, and the schema string travels alongside the attributes in the serialized
+// audit info with nothing making the two consistent. A short slice must therefore come back as an
+// error rather than an index-out-of-range panic.
+func TestAuditOpts_ShortAttributesRejected(t *testing.T) {
+	manager := NewDefaultManager()
+
+	fourAttrs := [][]byte{[]byte("ou"), []byte("role"), []byte("eid"), []byte("rh")}
+
+	for _, tc := range []struct {
+		name   string
+		schema string
+		attrs  [][]byte
+	}{
+		{"default schema, nil attributes", DefaultSchema, nil},
+		{"default schema, empty attributes", DefaultSchema, [][]byte{}},
+		{"default schema, two attributes", DefaultSchema, fourAttrs[:2]},
+		// The pairing an unvalidated Schema makes reachable: enough attributes for the default
+		// schema, but the payload declares the w3c one, which indexes far past the end.
+		{"w3c schema, default-schema attribute count", W3CSchema, fourAttrs},
+		{"w3c schema, nil attributes", W3CSchema, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eidOpts, err := manager.EidNymAuditOpts(tc.schema, tc.attrs)
+			require.Error(t, err)
+			assert.Nil(t, eidOpts)
+			assert.Contains(t, err.Error(), "requires at least")
+
+			rhOpts, err := manager.RhNymAuditOpts(tc.schema, tc.attrs)
+			require.Error(t, err)
+			assert.Nil(t, rhOpts)
+			assert.Contains(t, err.Error(), "requires at least")
+		})
+	}
+}
+
+// TestRhNymAuditOpts_ThreeAttributesRejected covers the boundary case where the enrollment-id index
+// is in range but the revocation-handle index is one past the end.
+func TestRhNymAuditOpts_ThreeAttributesRejected(t *testing.T) {
+	manager := NewDefaultManager()
+	attrs := [][]byte{[]byte("ou"), []byte("role"), []byte("eid")}
+
+	eidOpts, err := manager.EidNymAuditOpts(DefaultSchema, attrs)
+	require.NoError(t, err)
+	assert.Equal(t, "eid", eidOpts.EnrollmentID)
+
+	rhOpts, err := manager.RhNymAuditOpts(DefaultSchema, attrs)
+	require.Error(t, err)
+	assert.Nil(t, rhOpts)
+	assert.Contains(t, err.Error(), "requires at least")
+}
+
+// TestAuditOpts_SufficientAttributesAccepted pins that the bounds checks do not reject the
+// attribute counts each schema actually expects.
+func TestAuditOpts_SufficientAttributesAccepted(t *testing.T) {
+	manager := NewDefaultManager()
+
+	defaultAttrs := [][]byte{[]byte("ou"), []byte("role"), []byte("eid"), []byte("rh")}
+	eidOpts, err := manager.EidNymAuditOpts(DefaultSchema, defaultAttrs)
+	require.NoError(t, err)
+	assert.Equal(t, "eid", eidOpts.EnrollmentID)
+	rhOpts, err := manager.RhNymAuditOpts(DefaultSchema, defaultAttrs)
+	require.NoError(t, err)
+	assert.Equal(t, "rh", rhOpts.RevocationHandle)
+
+	// W3CSchema: one entry per attribute name plus the hidden usk attribute prepended by
+	// PublicKeyImportOpts.
+	w3cAttrs := make([][]byte, len(attributeNames)+1)
+	for i := range w3cAttrs {
+		w3cAttrs[i] = []byte("attr")
+	}
+	w3cAttrs[w3cEidIdx] = []byte("w3c-eid")
+	w3cAttrs[w3cRhIdx] = []byte("w3c-rh")
+
+	eidOpts, err = manager.EidNymAuditOpts(W3CSchema, w3cAttrs)
+	require.NoError(t, err)
+	assert.Equal(t, "w3c-eid", eidOpts.EnrollmentID)
+	rhOpts, err = manager.RhNymAuditOpts(W3CSchema, w3cAttrs)
+	require.NoError(t, err)
+	assert.Equal(t, "w3c-rh", rhOpts.RevocationHandle)
+}

--- a/token/services/identity/idemixnym/nym/audit.go
+++ b/token/services/identity/idemixnym/nym/audit.go
@@ -8,9 +8,9 @@ package nym
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/IBM/idemix/bccsp/types"
+	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/json"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/idemix/crypto"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
@@ -21,13 +21,27 @@ type AuditInfo struct {
 }
 
 // FromBytes deserializes the AuditInfo from JSON format.
+//
+// The decode is strict (unknown fields rejected), matching how the embedded crypto.AuditInfo is
+// parsed on every other entry point: the same logical type must not be laxer here just because it
+// arrived through the nym wrapper.
 func (a *AuditInfo) FromBytes(raw []byte) error {
 	// The embedded crypto.AuditInfo's fields are inlined into this struct's JSON,
 	// so this decode reaches the panicking mathlib curve elements itself rather
 	// than going through crypto.AuditInfo.FromBytes. Guard it here too.
-	return crypto.UnmarshalAuditInfo(func() error {
+	if err := crypto.UnmarshalAuditInfo(func() error {
 		return json.Unmarshal(raw, a)
-	})
+	}); err != nil {
+		return err
+	}
+	// The embedded pointer is only allocated if the payload carried at least one of the promoted
+	// crypto.AuditInfo fields. Reject it here rather than leaving a nil embedded pointer for the
+	// caller to dereference through a promoted method or field.
+	if a.AuditInfo == nil {
+		return errors.New("failed to unmarshal, no audit info found")
+	}
+
+	return nil
 }
 
 func (a *AuditInfo) Match(ctx context.Context, id []byte) error {
@@ -65,9 +79,7 @@ func DeserializeAuditInfo(raw []byte) (*AuditInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	if auditInfo.AuditInfo == nil {
-		return nil, errors.Errorf("failed to unmarshal, no audit info found")
-	}
+	// FromBytes already rejects a nil embedded AuditInfo.
 	if err := auditInfo.Validate(); err != nil {
 		return nil, err
 	}

--- a/token/services/identity/idemixnym/nym/audit_strict_test.go
+++ b/token/services/identity/idemixnym/nym/audit_strict_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package nym
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/services/identity/idemix/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFromBytes_RejectsUnknownFields covers the JSON strictness asymmetry reported in issue #2073:
+// FromBytes used stdlib encoding/json while the embedded crypto.AuditInfo is parsed with the
+// project's DisallowUnknownFields wrapper on every other entry point, so the same logical type was
+// laxer when it arrived through the nym wrapper.
+func TestFromBytes_RejectsUnknownFields(t *testing.T) {
+	_, err := DeserializeAuditInfo([]byte(`{"Attributes":[],"NotAField":1}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field")
+
+	err = (&AuditInfo{}).FromBytes([]byte(`{"IdemixSignature":"AAAA","NotAField":1}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field")
+}
+
+// TestFromBytes_RejectsNilEmbeddedAuditInfo covers the missing nil-embedded-pointer guard reported
+// in issue #2073: a payload that carries none of the promoted crypto.AuditInfo fields left the
+// embedded pointer nil, and the exported FromBytes returned success, so any caller dereferencing it
+// through a promoted method or field panicked.
+func TestFromBytes_RejectsNilEmbeddedAuditInfo(t *testing.T) {
+	// Nothing but the nym-level field: encoding/json never allocates the embedded pointer.
+	raw, err := json.Marshal(map[string]any{"IdemixSignature": []byte("sig")})
+	require.NoError(t, err)
+
+	ai := &AuditInfo{}
+	err = ai.FromBytes(raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no audit info found")
+
+	// The same payload through DeserializeAuditInfo, which is where the guard already existed.
+	result, err := DeserializeAuditInfo(raw)
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+// TestFromBytes_PopulatesEmbeddedAuditInfo pins the accepted shape: as soon as the payload carries a
+// promoted crypto.AuditInfo field, the embedded pointer is allocated and FromBytes succeeds.
+func TestFromBytes_PopulatesEmbeddedAuditInfo(t *testing.T) {
+	original := &AuditInfo{
+		AuditInfo: &crypto.AuditInfo{
+			Attributes: [][]byte{[]byte("a0"), []byte("a1"), []byte("eid"), []byte("rh")},
+			Schema:     "",
+		},
+		IdemixSignature: []byte("sig"),
+	}
+	raw, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	ai := &AuditInfo{}
+	require.NoError(t, ai.FromBytes(raw))
+	require.NotNil(t, ai.AuditInfo)
+	assert.Equal(t, "eid", ai.EnrollmentID())
+	assert.Equal(t, []byte("sig"), ai.IdemixSignature)
+}

--- a/token/services/identity/interop/htlc/info.go
+++ b/token/services/identity/interop/htlc/info.go
@@ -8,8 +8,8 @@ package htlc
 
 import (
 	"context"
-	"encoding/json"
 
+	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/json"
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
 )
@@ -41,6 +41,9 @@ func (si *ScriptInfo) Marshal() ([]byte, error) {
 }
 
 // Unmarshal populates the ScriptInfo from the provided JSON-encoded bytes.
+//
+// The decode is strict (unknown fields rejected), matching how deserializer.go parses the same
+// wire type.
 func (si *ScriptInfo) Unmarshal(raw []byte) error {
 	return json.Unmarshal(raw, si)
 }

--- a/token/services/identity/interop/htlc/strict_test.go
+++ b/token/services/identity/interop/htlc/strict_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package htlc_test
+
+import (
+	"crypto"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	ihtlc "github.com/LFDT-Panurus/panurus/token/services/identity/interop/htlc"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/interop/htlc/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/interop/encoding"
+	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScriptInfo_UnmarshalRejectsUnknownFields covers the strictness asymmetry reported in issue
+// #2073: info.go parsed ScriptInfo with stdlib encoding/json while deserializer.go parses the same
+// wire type with the project's DisallowUnknownFields wrapper.
+func TestScriptInfo_UnmarshalRejectsUnknownFields(t *testing.T) {
+	si := &ihtlc.ScriptInfo{}
+	err := si.Unmarshal([]byte(`{"Sender":"cw==","Recipient":"cg==","Extra":1}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field")
+
+	// The well-formed payload still round-trips.
+	raw, err := (&ihtlc.ScriptInfo{Sender: []byte("s"), Recipient: []byte("r")}).Marshal()
+	require.NoError(t, err)
+	require.NoError(t, si.Unmarshal(raw))
+	assert.Equal(t, []byte("s"), si.Sender)
+	assert.Equal(t, []byte("r"), si.Recipient)
+}
+
+// TestVerifyOwner_RejectsUnknownScriptFields covers the same asymmetry on the validator side: the
+// htlc.Script carried by a TypedIdentity must be parsed as strictly here as in deserializer.go, so
+// the validator cannot accept an identity payload the deserializer would reject.
+func TestVerifyOwner_RejectsUnknownScriptFields(t *testing.T) {
+	deadline := time.Now().Add(time.Hour)
+	script := &htlc.Script{Sender: []byte("s"), Recipient: []byte("r"), Deadline: deadline}
+	raw, err := json.Marshal(script)
+	require.NoError(t, err)
+
+	// Splice an extra field into the serialized script.
+	var asMap map[string]any
+	require.NoError(t, json.Unmarshal(raw, &asMap))
+	asMap["NotAField"] = 1
+	tampered, err := json.Marshal(asMap)
+	require.NoError(t, err)
+
+	typed, err := identity.WrapWithType(ihtlc.ScriptType, tampered)
+	require.NoError(t, err)
+
+	_, _, err = ihtlc.VerifyOwner(typed, []byte("r"), time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field")
+
+	// The untampered script is still accepted.
+	typed, err = identity.WrapWithType(ihtlc.ScriptType, raw)
+	require.NoError(t, err)
+	parsed, op, err := ihtlc.VerifyOwner(typed, []byte("r"), time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, ihtlc.Claim, op)
+	assert.Equal(t, script.Recipient, parsed.Recipient)
+}
+
+// TestMetadataClaimKeyCheck_RejectsUnknownClaimSignatureFields covers the ClaimSignature decode in
+// the validator, which shares the strictness change.
+func TestMetadataClaimKeyCheck_RejectsUnknownClaimSignatureFields(t *testing.T) {
+	script := &htlc.Script{Sender: []byte("s"), Recipient: []byte("r"), HashInfo: htlc.HashInfo{Hash: []byte("h")}}
+	act := &mock.Action{}
+	act.GetMetadataReturns(map[string][]byte{})
+
+	_, err := ihtlc.MetadataClaimKeyCheck(act, script, ihtlc.Claim,
+		[]byte(`{"RecipientSignature":"c2ln","Preimage":"cHJl","NotAField":1}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field")
+}
+
+// TestMetadataClaimKeyCheck_PreimageComparison pins the behaviour of the constant-time preimage
+// comparison: an exact match is accepted, and any difference - including a same-length one - is
+// rejected.
+func TestMetadataClaimKeyCheck_PreimageComparison(t *testing.T) {
+	script := &htlc.Script{
+		Sender:    []byte("s"),
+		Recipient: []byte("r"),
+		HashInfo: htlc.HashInfo{
+			Hash:         []byte("h"),
+			HashFunc:     crypto.SHA256,
+			HashEncoding: encoding.Base64,
+		},
+	}
+	pre := []byte("preimage")
+	image, err := script.HashInfo.Image(pre)
+	require.NoError(t, err)
+	key := htlc.ClaimKey(image)
+
+	sig, err := json.Marshal(&htlc.ClaimSignature{RecipientSignature: []byte("sig"), Preimage: pre})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name  string
+		value []byte
+		ok    bool
+	}{
+		{"exact match", []byte("preimage"), true},
+		{"same length, last byte differs", []byte("preimagf"), false},
+		{"same length, first byte differs", []byte("Preimage"), false},
+		{"prefix only", []byte("pre"), false},
+		{"longer", []byte("preimage!"), false},
+		{"empty", []byte{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			act := &mock.Action{}
+			act.GetMetadataReturns(map[string][]byte{key: tc.value})
+			k, err := ihtlc.MetadataClaimKeyCheck(act, script, ihtlc.Claim, sig)
+			if tc.ok {
+				require.NoError(t, err)
+				assert.Equal(t, key, k)
+
+				return
+			}
+			require.Error(t, err)
+		})
+	}
+}

--- a/token/services/identity/interop/htlc/validator.go
+++ b/token/services/identity/interop/htlc/validator.go
@@ -8,9 +8,10 @@ package htlc
 
 import (
 	"bytes"
-	"encoding/json"
+	"crypto/subtle"
 	"time"
 
+	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/json"
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
 	"github.com/LFDT-Panurus/panurus/token/services/utils"
@@ -109,7 +110,10 @@ func MetadataClaimKeyCheck(action Action, script *htlc.Script, op OperationType,
 	if !ok {
 		return "", errors.New("cannot find htlc pre-image, missing metadata entry")
 	}
-	if !bytes.Equal(value, claim.Preimage) {
+	// Constant-time: the preimage is a secret until the claim reveals it, and this comparison is
+	// the only place a candidate is checked against it. Not a practical oracle today - the same
+	// transaction carries claim.Preimage in the clear - but the property is free to keep.
+	if subtle.ConstantTimeCompare(value, claim.Preimage) != 1 {
 		return "", errors.Errorf("invalid action, cannot match htlc pre-image with metadata [%x]!=[%x]", value, claim.Preimage)
 	}
 

--- a/token/services/identity/interop/htlc/validator_fuzz_test.go
+++ b/token/services/identity/interop/htlc/validator_fuzz_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package htlc_test
+
+import (
+	"crypto"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	ihtlc "github.com/LFDT-Panurus/panurus/token/services/identity/interop/htlc"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/interop/htlc/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/interop/encoding"
+	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
+	"github.com/stretchr/testify/require"
+)
+
+const maxFuzzHTLCBytes = 64 << 10
+
+// fuzzScript is the reference HTLC script the seed corpus is built from.
+func fuzzScript() *htlc.Script {
+	return &htlc.Script{
+		Sender:    []byte("sender"),
+		Recipient: []byte("recipient"),
+		Deadline:  time.Unix(1_700_000_000, 0).UTC(),
+		HashInfo: htlc.HashInfo{
+			Hash:         []byte("hash"),
+			HashFunc:     crypto.SHA256,
+			HashEncoding: encoding.Base64,
+		},
+	}
+}
+
+// FuzzVerifyOwnerNoPanic hunts for owner bytes that panic VerifyOwner instead of returning an error.
+// senderRawOwner is the raw owner field of a token being spent, so it is fully attacker-controlled
+// and reaches both the TypedIdentity unmarshaller and the JSON decode of the embedded htlc.Script
+// ahead of any signature check.
+func FuzzVerifyOwnerNoPanic(f *testing.F) {
+	scriptRaw, err := json.Marshal(fuzzScript())
+	require.NoError(f, err)
+	typed, err := identity.WrapWithType(ihtlc.ScriptType, scriptRaw)
+	require.NoError(f, err)
+
+	seeds := [][]byte{
+		nil,
+		{},
+		[]byte("not a typed identity"),
+		typed,
+		scriptRaw,
+	}
+	// A typed identity of the right type wrapping garbage, and one of the wrong type.
+	if wrapped, err := identity.WrapWithType(ihtlc.ScriptType, []byte("{")); err == nil {
+		seeds = append(seeds, wrapped)
+	}
+	if wrapped, err := identity.WrapWithType(ihtlc.ScriptType+1, scriptRaw); err == nil {
+		seeds = append(seeds, wrapped)
+	}
+	for _, seed := range seeds {
+		f.Add(seed, []byte("recipient"))
+	}
+
+	f.Fuzz(func(t *testing.T, sender, out []byte) {
+		if len(sender) > maxFuzzHTLCBytes || len(out) > maxFuzzHTLCBytes {
+			t.Skip("input beyond the size any owner field can reach in practice")
+		}
+		require.NotPanics(t, func() {
+			// Both sides of the deadline, so the claim and the reclaim branch are both reached.
+			_, _, _ = ihtlc.VerifyOwner(sender, out, time.Unix(1, 0).UTC())
+			_, _, _ = ihtlc.VerifyOwner(sender, out, time.Unix(2_000_000_000, 0).UTC())
+		})
+	})
+}
+
+// FuzzMetadataClaimKeyCheckNoPanic hunts for claim signature bytes that panic MetadataClaimKeyCheck.
+// sig is the signature an unlocking party supplies, decoded into an htlc.ClaimSignature before its
+// preimage is ever checked against the action metadata.
+func FuzzMetadataClaimKeyCheckNoPanic(f *testing.F) {
+	script := fuzzScript()
+	preimage := []byte("preimage")
+	claim, err := json.Marshal(&htlc.ClaimSignature{RecipientSignature: []byte("sig"), Preimage: preimage})
+	require.NoError(f, err)
+
+	for _, seed := range [][]byte{
+		nil,
+		{},
+		[]byte("{"),
+		[]byte(`{}`),
+		[]byte(`{"Preimage":null,"RecipientSignature":null}`),
+		[]byte(`{"Preimage":"cHJl"}`),
+		[]byte(`{"Preimage":"cHJl","RecipientSignature":"c2ln","NotAField":1}`),
+		claim,
+	} {
+		f.Add(seed, preimage)
+	}
+
+	f.Fuzz(func(t *testing.T, sig, metadataValue []byte) {
+		if len(sig) > maxFuzzHTLCBytes || len(metadataValue) > maxFuzzHTLCBytes {
+			t.Skip("input beyond the size any claim signature can reach in practice")
+		}
+		image, err := script.HashInfo.Image(preimage)
+		require.NoError(t, err)
+
+		action := &mock.Action{}
+		action.GetMetadataReturns(map[string][]byte{htlc.ClaimKey(image): metadataValue})
+
+		require.NotPanics(t, func() {
+			_, _ = ihtlc.MetadataClaimKeyCheck(action, script, ihtlc.Claim, sig)
+			_, _ = ihtlc.MetadataClaimKeyCheck(action, script, ihtlc.Reclaim, sig)
+		})
+	})
+}

--- a/token/services/identity/membership/lm.go
+++ b/token/services/identity/membership/lm.go
@@ -270,11 +270,29 @@ func (l *LocalMembership) Close() {
 		l.localIdentitiesMutex.Lock()
 		keyManagers := l.keyManagers
 		l.keyManagers = nil
+		// The conf_ids this membership registered with the router. conf_id is derived from
+		// (ID, Type, URL) with Type being this membership's IdentityType, so these are only ever
+		// this membership's own entries - closing one role's membership cannot unpin another's.
+		var confIDs []string
+		if l.signerRouter != nil {
+			confIDs = make([]string, 0, len(l.localIdentities))
+			for _, li := range l.localIdentities {
+				if len(li.ConfigurationID) != 0 {
+					confIDs = append(confIDs, li.ConfigurationID)
+				}
+			}
+		}
 		l.localIdentitiesMutex.Unlock()
 		for _, keyManager := range keyManagers {
 			if c, ok := keyManager.(closer); ok {
 				c.Close()
 			}
+		}
+		// Drop the routes to the key managers just closed: byConfID otherwise keeps them
+		// reachable - and alive - for the lifetime of the router, and Resolve would hand out
+		// signers from a closed key manager with the cryptographic probe skipped.
+		if l.signerRouter != nil {
+			l.signerRouter.Unregister(confIDs...)
 		}
 
 		notifier, err := l.identityDB.Notifier()
@@ -391,6 +409,10 @@ func (l *LocalMembership) Load(ctx context.Context, identities []idriver.Configu
 	l.cachedDefaultIdentifier = ""
 	l.localIdentitiesByName = make(map[string][]LocalIdentityWithPriority, 0)
 	l.localIdentitiesByConfig = make(map[string]*LocalIdentity, 0)
+	// localIdentitiesByIdentity must be reset with the other three: it is the map both lookup
+	// and getLocalIdentity consult after a miss on localIdentitiesByName, so an entry left over
+	// from a previous Load would be served as if it were part of the set just loaded.
+	l.localIdentitiesByIdentity = make(map[string]*LocalIdentity, 0)
 
 	// prepare all identity configurations
 	identityConfigurations, defaults, err := l.toIdentityConfiguration(identities)

--- a/token/services/identity/membership/lm_reload_test.go
+++ b/token/services/identity/membership/lm_reload_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package membership_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	idriver "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/membership"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/membership/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/token/services/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const reloadIdentityType = identity.Type(99)
+
+// newReloadableMembership builds a LocalMembership whose KeyManager resolves whatever raw identity
+// bytes currentIdentity currently points at, so a test can Load twice with a different identity set
+// each time.
+func newReloadableMembership(t *testing.T, currentIdentity *[]byte) *membership.LocalMembership {
+	t.Helper()
+
+	ip := &mock.IdentityProvider{}
+	ip.BindReturns(nil)
+
+	iss := &mock.IdentityStoreService{}
+	iss.ConfigurationExistsReturns(false, nil)
+	iss.AddConfigurationReturns(nil)
+	iss.IteratorConfigurationsReturns(&mock.IdentityConfigurationIterator{}, nil)
+	iss.NotifierReturns(nil, storage.ErrNotSupported)
+
+	km := &mock.KeyManager{}
+	km.EnrollmentIDReturns("e1")
+	km.AnonymousReturns(false)
+	km.IsRemoteReturns(false)
+	km.IdentityTypeReturns(reloadIdentityType)
+	km.IdentityStub = func(context.Context, []byte) (*idriver.IdentityDescriptor, error) {
+		return &idriver.IdentityDescriptor{Identity: *currentIdentity, AuditInfo: []byte("ai")}, nil
+	}
+
+	kmp := &mock.KeyManagerProvider{}
+	kmp.GetReturns(km, nil)
+
+	return membership.NewLocalMembership(
+		logging.MustGetLogger("test"),
+		&mock.Config{},
+		[]byte("netid"),
+		&mock.SignerDeserializerManager{},
+		iss,
+		"testType",
+		false,
+		ip,
+		kmp,
+	)
+}
+
+// wrappedIdentity returns the identity bytes LocalMembership actually indexes for a KeyManager
+// reporting reloadIdentityType, i.e. the raw bytes wrapped with the type tag.
+func wrappedIdentity(t *testing.T, raw string) []byte {
+	t.Helper()
+	wrapped, err := identity.WrapWithType(reloadIdentityType, []byte(raw))
+	require.NoError(t, err)
+
+	return wrapped
+}
+
+// TestLoad_ResetsIdentityMap covers the stale-read reported in issue #2073: Load used to reset
+// localIdentitiesByName, localIdentitiesByConfig and localIdentities but not
+// localIdentitiesByIdentity, so an identity present only in an earlier Load kept resolving through
+// that fourth map as if it were part of the set just loaded.
+func TestLoad_ResetsIdentityMap(t *testing.T) {
+	ctx := t.Context()
+
+	raw := []byte("id-alice")
+	lm := newReloadableMembership(t, &raw)
+
+	require.NoError(t, lm.Load(ctx, []idriver.ConfiguredIdentity{
+		{ID: "alice", Path: "/tmp/alice", Default: true},
+	}, nil))
+
+	alice := wrappedIdentity(t, "id-alice")
+	label, err := lm.GetIdentifier(ctx, alice)
+	require.NoError(t, err)
+	assert.Equal(t, "alice", label)
+
+	// Second Load with a disjoint identity set.
+	raw = []byte("id-bob")
+	require.NoError(t, lm.Load(ctx, []idriver.ConfiguredIdentity{
+		{ID: "bob", Path: "/tmp/bob", Default: true},
+	}, nil))
+
+	bob := wrappedIdentity(t, "id-bob")
+	label, err = lm.GetIdentifier(ctx, bob)
+	require.NoError(t, err)
+	assert.Equal(t, "bob", label)
+
+	// alice was only in the first load: resolving it must fail rather than return the pre-reload
+	// entry from localIdentitiesByIdentity.
+	_, err = lm.GetIdentifier(ctx, alice)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identifier not found")
+}
+
+// TestLoad_ReloadKeepsSameIdentityResolvable guards the other direction: resetting the map must not
+// drop an identity that the second Load registers again.
+func TestLoad_ReloadKeepsSameIdentityResolvable(t *testing.T) {
+	ctx := t.Context()
+
+	raw := []byte("id-alice")
+	lm := newReloadableMembership(t, &raw)
+
+	configured := []idriver.ConfiguredIdentity{{ID: "alice", Path: "/tmp/alice", Default: true}}
+	require.NoError(t, lm.Load(ctx, configured, nil))
+	require.NoError(t, lm.Load(ctx, configured, nil))
+
+	label, err := lm.GetIdentifier(ctx, wrappedIdentity(t, "id-alice"))
+	require.NoError(t, err)
+	assert.Equal(t, "alice", label)
+}
+
+// TestClose_UnregistersOwnConfIDsFromSignerRouter covers the byConfID teardown reported in issue
+// #2073: Close releases the KeyManagers it loaded, so the routes pinning them must go with them
+// instead of keeping closed KeyManagers reachable - and alive - for the router's lifetime.
+func TestClose_UnregistersOwnConfIDsFromSignerRouter(t *testing.T) {
+	ctx := t.Context()
+
+	raw := []byte("id-alice")
+	lm := newReloadableMembership(t, &raw)
+
+	router := identity.NewSignerRouter(nil)
+	lm.SetSignerRouter(router)
+
+	require.NoError(t, lm.Load(ctx, []idriver.ConfiguredIdentity{
+		{ID: "alice", Path: "/tmp/alice", Default: true},
+	}, nil))
+	require.Equal(t, 1, router.Len(), "the loaded identity must have pinned its KeyManager")
+
+	lm.Close()
+	assert.Equal(t, 0, router.Len(), "Close must drop the routes to the KeyManagers it released")
+}

--- a/token/services/identity/role/cache.go
+++ b/token/services/identity/role/cache.go
@@ -17,8 +17,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-var logger = logging.MustGetLogger()
-
 // provisionRetryDelay is how long the background provisioning loop waits after a
 // backend failure before trying again. Without it, a persistently failing identity
 // backend would turn the loop into a busy spin.
@@ -81,8 +79,12 @@ func (c *RecipientDataCache) RecipientData(ctx context.Context) (*driver.Recipie
 		}
 	})
 
+	// start is only meaningful when the timing is actually going to be logged, so every read of
+	// it is guarded by the same check that sets it: time.Since and the argument boxing it feeds
+	// are evaluated eagerly, before Debugf gets to decide whether to format anything.
+	debug := c.Logger.IsEnabledFor(zapcore.DebugLevel)
 	var start time.Time
-	if c.Logger.IsEnabledFor(zapcore.DebugLevel) {
+	if debug {
 		start = time.Now()
 	}
 	timeout := time.NewTimer(c.cacheTimeout)
@@ -90,24 +92,27 @@ func (c *RecipientDataCache) RecipientData(ctx context.Context) (*driver.Recipie
 
 	var identity *driver.RecipientData
 	var err error
-	logger.DebugfContext(ctx, "fetching wallet recipient data")
+	c.Logger.DebugfContext(ctx, "fetching wallet recipient data")
 	select {
 	case entry := <-c.cache:
 		c.metrics.CacheLevelGauge.Add(-1)
-		logger.DebugfContext(ctx, "fetched wallet recipient data from cache")
 		identity = entry
-		c.Logger.DebugfContext(ctx, "fetching wallet identity from cache [%s] took [%v]", identity, time.Since(start))
+		if debug {
+			c.Logger.DebugfContext(ctx, "fetched wallet recipient data from cache [%s], took [%v]", identity, time.Since(start))
+		}
 	case <-timeout.C:
-		logger.DebugfContext(ctx, "generating wallet recipient data on the spot")
+		c.Logger.DebugfContext(ctx, "generating wallet recipient data on the spot")
 		identity, err = c.backed(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed fetching wallet identity")
 		}
-		c.Logger.DebugfContext(ctx, "fetching wallet identity from backend after a timeout [%s] took [%v]", identity, time.Since(start))
+		if debug {
+			c.Logger.DebugfContext(ctx, "fetching wallet identity from backend after a timeout [%s] took [%v]", identity, time.Since(start))
+		}
 	case <-ctx.Done():
 		return nil, errors.New("context is done")
 	}
-	logger.DebugfContext(ctx, "fetching wallet recipient data done")
+	c.Logger.DebugfContext(ctx, "fetching wallet recipient data done")
 
 	return identity, nil
 }

--- a/token/services/identity/signer_router.go
+++ b/token/services/identity/signer_router.go
@@ -67,6 +67,40 @@ func (r *SignerRouter) Register(confID string, deserializer idriver.SignerDeseri
 	r.metrics.SignerRouterRegistrations.Add(1)
 }
 
+// Unregister drops the entries for the given conf_ids. Callers releasing the KeyManagers behind
+// those conf_ids (LocalMembership.Close) must unregister them: a released KeyManager left in the
+// map stays routable, and Resolve would dispatch to it with the cryptographic probe skipped.
+// conf_ids that were never registered are ignored.
+func (r *SignerRouter) Unregister(confIDs ...string) {
+	if len(confIDs) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, confID := range confIDs {
+		delete(r.byConfID, confID)
+	}
+}
+
+// Close drops every registration, so the router pins no KeyManager and Resolve reports ok=false
+// for every identity until KeyManagers are registered again. It is the teardown counterpart of
+// Register for a whole router, where Unregister covers a single membership's share of it, and is
+// idempotent. Close does not close the KeyManagers themselves: the router borrows them, their
+// owner (LocalMembership) releases them.
+func (r *SignerRouter) Close() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.byConfID = map[string]idriver.SignerDeserializer{}
+}
+
+// Len returns the number of conf_id->KeyManager bindings currently held.
+func (r *SignerRouter) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return len(r.byConfID)
+}
+
 // Resolve attempts to reconstruct a Signer for id via conf_id-based routing. ok is false, with a
 // nil error, whenever routing cannot be attempted (no resolver set, no conf_id mapping, no
 // KeyManager registered for that conf_id) or the routed KeyManager itself fails to reconstruct

--- a/token/services/identity/signer_router_teardown_test.go
+++ b/token/services/identity/signer_router_teardown_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package identity_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/idemix"
+	idmock "github.com/LFDT-Panurus/panurus/token/services/identity/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubSigner is a driver.Signer that does nothing; tests only need a non-nil value.
+type stubSigner struct{}
+
+func (stubSigner) Sign([]byte) ([]byte, error) { return []byte("sig"), nil }
+
+// stubProbeFreeDeserializer is a ProbeFreeSignerDeserializer that always succeeds, so a test can
+// tell a successful route from one that was torn down.
+type stubProbeFreeDeserializer struct{}
+
+func (stubProbeFreeDeserializer) DeserializeSigner(_ context.Context, _ []byte) (driver.Signer, error) {
+	return stubSigner{}, nil
+}
+
+func (stubProbeFreeDeserializer) DeserializeSignerNoProbe(_ context.Context, _ []byte) (driver.Signer, error) {
+	return stubSigner{}, nil
+}
+
+// TestSignerRouter_Unregister covers the byConfID teardown reported in issue #2073: byConfID had no
+// eviction or teardown hook, so every registered conf_id pinned its KeyManager - and everything that
+// KeyManager owns - for the lifetime of the router.
+func TestSignerRouter_Unregister(t *testing.T) {
+	router := identity.NewSignerRouter(nil)
+	router.Register("conf-id-1", erroringProbeFreeDeserializer{})
+	router.Register("conf-id-2", erroringProbeFreeDeserializer{})
+	require.Equal(t, 2, router.Len())
+
+	router.Unregister("conf-id-1")
+	assert.Equal(t, 1, router.Len())
+
+	// Unknown and repeated conf_ids are ignored.
+	router.Unregister("conf-id-1", "never-registered")
+	assert.Equal(t, 1, router.Len())
+
+	// No conf_ids at all is a no-op, not a full wipe.
+	router.Unregister()
+	assert.Equal(t, 1, router.Len())
+
+	router.Unregister("conf-id-2")
+	assert.Equal(t, 0, router.Len())
+}
+
+// TestSignerRouter_UnregisteredConfIDStopsRouting proves the behavioural consequence: once a conf_id
+// is unregistered, Resolve reports ok=false for its identities so callers fall back to the probing
+// deserializer instead of being handed a signer from a released KeyManager.
+func TestSignerRouter_UnregisteredConfIDStopsRouting(t *testing.T) {
+	router := identity.NewSignerRouter(nil)
+	router.Register("conf-id-1", stubProbeFreeDeserializer{})
+
+	wrapped, err := identity.WrapWithType(idemix.IdentityType, []byte("raw"))
+	require.NoError(t, err)
+
+	resolver := &idmock.ConfIDResolver{}
+	resolver.GetConfIDReturns("conf-id-1", nil)
+	router.SetConfIDResolver(resolver)
+
+	signer, ok := router.Resolve(t.Context(), wrapped)
+	require.True(t, ok)
+	require.NotNil(t, signer)
+
+	router.Unregister("conf-id-1")
+
+	signer, ok = router.Resolve(t.Context(), wrapped)
+	assert.False(t, ok)
+	assert.Nil(t, signer)
+}
+
+// TestSignerRouter_Close drops every registration and is idempotent.
+func TestSignerRouter_Close(t *testing.T) {
+	router := identity.NewSignerRouter(nil)
+	router.Register("conf-id-1", erroringProbeFreeDeserializer{})
+	router.Register("conf-id-2", erroringProbeFreeDeserializer{})
+	require.Equal(t, 2, router.Len())
+
+	router.Close()
+	assert.Equal(t, 0, router.Len())
+
+	router.Close()
+	assert.Equal(t, 0, router.Len())
+
+	// The router is reusable after Close: it holds no other state that Close invalidates.
+	router.Register("conf-id-3", erroringProbeFreeDeserializer{})
+	assert.Equal(t, 1, router.Len())
+}


### PR DESCRIPTION
Fixes #2073

## The one real bug

`LocalMembership.Load` (`token/services/identity/membership/lm.go`) resets three of its four
identity indices — `localIdentities`, `localIdentitiesByName`, `localIdentitiesByConfig` — but not
`localIdentitiesByIdentity`. That fourth map is what both `lookup` and `getLocalIdentity` consult
after a miss on the by-name map, so a second `Load` left entries from the first one being served as
current: `GetIdentifier` and `GetIdentityInfo` returned pre-reload identity data. It is now reset
with the others, so a reload is the full replacement it reads as.

## The rest of the bundle

Latent fragility and defense-in-depth, none independently reachable today:

- **`boolpolicy/sig.go`** — `evalRef` bounds-checked its index against the signature slots and then
  indexed `Verifiers`, safe only because `Verify` enforces the two lengths equal before the
  traversal starts: an invariant held by convention in a different function. `sigs`, `memo` and
  `Verifiers` are now each checked where they are indexed, and a nil `Verifiers` entry is an
  unsatisfied reference rather than a nil dereference.

- **`idemixnym/nym/audit.go`** — `FromBytes` parsed with stdlib `encoding/json` while the embedded
  `crypto.AuditInfo` goes through the project's `DisallowUnknownFields` wrapper on every other entry
  point, and it lacked the nil-embedded-pointer guard `crypto.DeserializeAuditInfo` has, so a
  payload carrying none of the promoted fields returned success with a nil embedded pointer for the
  caller to dereference. Now strict, and the nil embedded pointer is rejected in `FromBytes` itself.

- **`interop/htlc/{validator,info}.go`** — parsed `htlc.Script`, `ScriptInfo` and `ClaimSignature`
  with stdlib `encoding/json` while `deserializer.go` parses the same wire types strictly; the
  validator must not accept what the deserializer rejects. The claim preimage is also now compared
  against the metadata entry with `subtle.ConstantTimeCompare`.

- **`role/cache.go`** — `start` was assigned only under a debug-level check but `time.Since(start)`
  was evaluated unconditionally, and a package-level logger was mixed with the instance one for the
  same component. Both reads are behind the same check now, and everything is on `c.Logger`; the
  package-level logger had no other user (every other reference in the package is a shadowing
  parameter) and was removed rather than left dead.

- **`idemix/schema/schema.go`** — `EidNymAuditOpts`/`RhNymAuditOpts` index `attrs` at positions fixed
  by the schema name (up to `attrs[27]` for `w3c-v0.0.1`) while `crypto.AuditInfo.Validate` only
  guarantees the four entries the default schema needs, and the schema string travels in the same
  payload with nothing making the two consistent. Bounds-checked, so a mismatched pair is a rejected
  audit info rather than an index-out-of-range panic.

- **`signer_router.go`** — `byConfID` had no eviction or teardown hook, so each entry pinned its
  `KeyManager` (and for idemix a BCCSP instance plus an `IdentityCache` backed by a live goroutine)
  for the router's lifetime. Adds `Unregister`, `Close` and `Len`, and `LocalMembership.Close` now
  unregisters its own conf_ids right after releasing their `KeyManager`s — which also stops the
  router handing out signers from a closed `KeyManager` with the cryptographic probe skipped.
  `conf_id` is derived from `(ID, Type, URL)` with `Type` being the membership's identity type, so
  one role's teardown cannot unpin another's.

## Deviations from the issue's suggested fix

- The issue suggests validating `Schema` against a known set inside `crypto.AuditInfo.Validate`. A
  whitelist there would hardcode `DefaultManager`'s two schemas into a type whose `SchemaManager` is
  an interface, breaking any custom manager supporting other schemas. The reachable consequence of an
  unvalidated `Schema` is exactly the unchecked `attrs[...]` indexing in `DefaultManager`, so the
  guard went there; an unsupported schema already errors from those methods.
- `role.Registry.Wallets`, the second unbounded cache named in the issue, already has the teardown
  hook it asks for in `Registry.Done` (closes wallets implementing `Close`, drops the map), so only
  `byConfID` needed one.

## Testing

- Unit tests for each behavioural change. The `Load` regression test and the boolpolicy bounds tests
  were both confirmed to fail against the unfixed code — the latter with the actual
  `index out of range [1] with length 1` panic.
- New `FuzzVerifyOwnerNoPanic` and `FuzzMetadataClaimKeyCheckNoPanic` over the HTLC owner and
  claim-signature parsers (both touched here), each clean at `-fuzztime=20s`, and wired into the
  `nightly-fuzz.yml` matrix. The pre-existing audit-info fuzz targets were re-run against the strict
  decode.
- `make checks`, `make lint-auto-fix`, `make unit-tests` and `go test -race` on the identity and
  interop trees are clean. One unrelated pre-existing failure: `TestTranslatePath` asserts the
  absolute checkout path contains `"panurus"`, which does not hold in a worktree named otherwise.

## Docs

`docs/services/identity.md`: reload-replaces-not-merges and the `Close` contract under
`LocalMembership`, the `SignerRouter` teardown API, the audit-info JSON strictness plus the
schema/attribute-count coupling, the boolpolicy verification bounds guarantees, and the HTLC parsing
and preimage-comparison notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)