### PR TITLE
network-driver: ListenerManagerConfig getters inconsistently treat a literal 0 as unset

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,23 +71,28 @@ token:
     #   c) The transaction reached finality long ago, so we query the whole ledger for this specific transaction. If the query returns no result, we proceed to step d.
     #   d) The transaction will reach finality at some point beyond the timeout or never, so we return Unknown. Then it is up to the client to either append another listener or accept that the transaction will never reach finality.  
     delivery:
-      # mapperParallelism is the number of goroutines that process incoming transactions in parallel. Defaults to 1.
+      # mapperParallelism is the number of goroutines that process incoming transactions in parallel.
+      # A non-positive or unset value falls back to the default (10).
       mapperParallelism: 10
       # blockProcessParallelism is the number of blocks we can process in parallel when they arrive from the delivery service.
-      # If the value is <= 1, then blocks are processed sequentially.
-      # This is the suggested configuration if we are not sure about the dependencies between blocks.
+      # Set it to 1 (and only 1) to process blocks sequentially; this is the suggested
+      # configuration if we are not sure about the dependencies between blocks.
+      # A non-positive or unset value falls back to the default (10), NOT sequential mode.
       # The total go routines processing transactions will be blockProcessParallelism * mapperParallelism.
       blockProcessParallelism: 1
       # lruSize detects how many transactions we should guarantee to keep in our recent cache.
       # If the transaction is not among these elements, we proceed to step b, as described above.
-      # If lruSize and lruBuffer are not set, then we will never evict past transactions (the cache will grow infinitely).
+      # Set it to 0 to disable the bound and never evict past transactions (the cache grows without limit).
+      # An unset or negative value falls back to the default (30).
       lruSize: 30
       # eviction will happen when the cache size exceeds lruSize + lruBuffer.
+      # Set it to 0 to disable the bound and never evict (same effect as lruSize: 0).
+      # An unset or negative value falls back to the default (15).
       lruBuffer: 15
       # listenerTimeout is the duration to listen when we can't find a transaction in the cache (most probably it is about to become final).
       # We will listen for this amount of time and then we will query the whole ledger, as described in step c.
-      # If the timeout is not set, then the listener will never be evicted and we will never proceed to step c.
-      # We will wait forever for the transaction to return (as is done for the 'committer' type).
+      # Set it to 0 to disable the timeout and wait forever for the transaction (as is done for the 'committer' type).
+      # An unset or negative value falls back to the default (10s).
       listenerTimeout: 10s
     # Only applicable for fabricx networks
     # notification: The manager is notified about finality events via a notification service (e.g. for FabricX).

--- a/token/services/network/fabric/config/config.go
+++ b/token/services/network/fabric/config/config.go
@@ -64,60 +64,57 @@ type serviceListenerManagerConfig struct {
 	c driver.ConfigService
 }
 
-func (c *serviceListenerManagerConfig) DeliveryMapperParallelism() int {
-	if v := c.c.GetInt(DeliveryMapperParallelism); v > 0 {
+// positiveOrDefault returns v when it is strictly positive, otherwise def. Use it
+// for knobs with no "disabled" state, where 0 is meaningless and indistinguishable
+// from an unset key: a non-positive or unset value is always the documented default.
+func positiveOrDefault[T int | time.Duration](v, def T) T {
+	if v > 0 {
 		return v
 	}
 
-	return DefaultDeliveryMapperParallelism
+	return def
+}
+
+// configuredOrDefault preserves an explicit, non-negative value the operator wrote
+// — including 0, which the delivery layer reads as "remove this bound" (an unbounded
+// cache, or a listener that never times out). isSet distinguishes a deliberate 0
+// from an absent key, which GetInt/GetDuration also report as 0: only an unset key
+// or a negative typo fall back to def. Contrast positiveOrDefault, which also
+// replaces 0 and so cannot express that disabled mode.
+func configuredOrDefault[T int | time.Duration](isSet bool, v, def T) T {
+	if isSet && v >= 0 {
+		return v // explicit 0 -> disabled mode, positive -> honoured as-is
+	}
+
+	return def // unset key or negative typo -> documented default
+}
+
+func (c *serviceListenerManagerConfig) DeliveryMapperParallelism() int {
+	return positiveOrDefault(c.c.GetInt(DeliveryMapperParallelism), DefaultDeliveryMapperParallelism)
 }
 
 func (c *serviceListenerManagerConfig) DeliveryBlockProcessParallelism() int {
-	if v := c.c.GetInt(DeliveryBlockProcessParallelism); v >= 0 {
-		return v
-	}
-
-	return DefaultDeliveryBlockProcessParallelism
+	return positiveOrDefault(c.c.GetInt(DeliveryBlockProcessParallelism), DefaultDeliveryBlockProcessParallelism)
 }
 
 func (c *serviceListenerManagerConfig) DeliveryLRUSize() int {
-	if v := c.c.GetInt(DeliveryLRUSize); v >= 0 {
-		return v
-	}
-
-	return DefaultDeliveryLRUSize
+	return configuredOrDefault(c.c.IsSet(DeliveryLRUSize), c.c.GetInt(DeliveryLRUSize), DefaultDeliveryLRUSize)
 }
 
 func (c *serviceListenerManagerConfig) DeliveryLRUBuffer() int {
-	if v := c.c.GetInt(DeliveryLRUBuffer); v >= 0 {
-		return v
-	}
-
-	return DefaultDeliveryLRUBuffer
+	return configuredOrDefault(c.c.IsSet(DeliveryLRUBuffer), c.c.GetInt(DeliveryLRUBuffer), DefaultDeliveryLRUBuffer)
 }
 
 func (c *serviceListenerManagerConfig) DeliveryListenerTimeout() time.Duration {
-	if v := c.c.GetDuration(DeliveryListenerTimeout); v >= 0 {
-		return v
-	}
-
-	return DefaultDeliveryListenerTimeout
+	return configuredOrDefault(c.c.IsSet(DeliveryListenerTimeout), c.c.GetDuration(DeliveryListenerTimeout), DefaultDeliveryListenerTimeout)
 }
 
 func (c *serviceListenerManagerConfig) DeliveryLedgerInfoAttempts() int {
-	if v := c.c.GetInt(DeliveryLedgerInfoAttempts); v > 0 {
-		return v
-	}
-
-	return DefaultDeliveryLedgerInfoAttempts
+	return positiveOrDefault(c.c.GetInt(DeliveryLedgerInfoAttempts), DefaultDeliveryLedgerInfoAttempts)
 }
 
 func (c *serviceListenerManagerConfig) DeliveryLedgerInfoRetryDelay() time.Duration {
-	if v := c.c.GetDuration(DeliveryLedgerInfoRetryDelay); v > 0 {
-		return v
-	}
-
-	return DefaultDeliveryLedgerInfoRetryDelay
+	return positiveOrDefault(c.c.GetDuration(DeliveryLedgerInfoRetryDelay), DefaultDeliveryLedgerInfoRetryDelay)
 }
 
 func (c *serviceListenerManagerConfig) String() string {

--- a/token/services/network/fabric/config/config_test.go
+++ b/token/services/network/fabric/config/config_test.go
@@ -27,11 +27,18 @@ func (c *mapConfigService) GetDuration(key string) time.Duration { return c.dura
 func (c *mapConfigService) GetString(string) string              { return "" }
 func (c *mapConfigService) GetBool(string) bool                  { return false }
 func (c *mapConfigService) GetStringSlice(string) []string       { return nil }
-func (c *mapConfigService) IsSet(string) bool                    { return false }
-func (c *mapConfigService) UnmarshalKey(string, any) error       { return nil }
-func (c *mapConfigService) ConfigFileUsed() string               { return "" }
-func (c *mapConfigService) GetPath(string) string                { return "" }
-func (c *mapConfigService) TranslatePath(path string) string     { return path }
+func (c *mapConfigService) IsSet(key string) bool {
+	if _, ok := c.ints[key]; ok {
+		return true
+	}
+	_, ok := c.durations[key]
+
+	return ok
+}
+func (c *mapConfigService) UnmarshalKey(string, any) error   { return nil }
+func (c *mapConfigService) ConfigFileUsed() string           { return "" }
+func (c *mapConfigService) GetPath(string) string            { return "" }
+func (c *mapConfigService) TranslatePath(path string) string { return path }
 
 // TestLedgerInfoRetryDefaults pins the defaults an unconfigured deployment gets.
 // The attempt budget matters beyond taste: nothing retries the block scan, so a
@@ -71,6 +78,86 @@ func TestLedgerInfoRetryRejectsNonPositiveValues(t *testing.T) {
 		c := config.NewListenerManagerConfig(&mapConfigService{durations: map[string]time.Duration{config.DeliveryLedgerInfoRetryDelay: delay}})
 		assert.Equal(t, config.DefaultDeliveryLedgerInfoRetryDelay, c.DeliveryLedgerInfoRetryDelay(), "delay %v must not be honoured", delay)
 	}
+}
+
+// TestDeliveryDefaults pins the defaults an unconfigured deployment gets for the
+// remaining delivery getters. This is the core of #2060: an operator who never sets
+// lruSize/lruBuffer/listenerTimeout gets the documented default, not the silent 0
+// (unbounded cache / instantly-expiring timeout) that GetInt/GetDuration read from a
+// missing key.
+func TestDeliveryDefaults(t *testing.T) {
+	c := config.NewListenerManagerConfig(&mapConfigService{})
+
+	assert.Equal(t, config.DefaultDeliveryMapperParallelism, c.DeliveryMapperParallelism())
+	assert.Equal(t, config.DefaultDeliveryBlockProcessParallelism, c.DeliveryBlockProcessParallelism())
+	assert.Equal(t, config.DefaultDeliveryLRUSize, c.DeliveryLRUSize())
+	assert.Equal(t, config.DefaultDeliveryLRUBuffer, c.DeliveryLRUBuffer())
+	assert.Equal(t, config.DefaultDeliveryListenerTimeout, c.DeliveryListenerTimeout())
+}
+
+// TestDeliveryReadsConfiguredValues confirms a positive configured value is
+// honoured over the default for each getter.
+func TestDeliveryReadsConfiguredValues(t *testing.T) {
+	c := config.NewListenerManagerConfig(&mapConfigService{
+		ints: map[string]int{
+			config.DeliveryMapperParallelism:       3,
+			config.DeliveryBlockProcessParallelism: 4,
+			config.DeliveryLRUSize:                 5,
+			config.DeliveryLRUBuffer:               6,
+		},
+		durations: map[string]time.Duration{config.DeliveryListenerTimeout: 250 * time.Millisecond},
+	})
+
+	assert.Equal(t, 3, c.DeliveryMapperParallelism())
+	assert.Equal(t, 4, c.DeliveryBlockProcessParallelism())
+	assert.Equal(t, 5, c.DeliveryLRUSize())
+	assert.Equal(t, 6, c.DeliveryLRUBuffer())
+	assert.Equal(t, 250*time.Millisecond, c.DeliveryListenerTimeout())
+}
+
+// TestDeliveryRejectsNonPositiveValues covers the getters with no disabled mode:
+// mapperParallelism and blockProcessParallelism have no meaningful 0, so a 0 (the
+// value an absent or explicitly-zeroed YAML key reads as) or a negative value falls
+// back to the documented default. blockProcessParallelism in particular no longer
+// treats 0 as sequential: sequential is reached only with an explicit 1.
+func TestDeliveryRejectsNonPositiveValues(t *testing.T) {
+	for _, v := range []int{0, -1} {
+		c := config.NewListenerManagerConfig(&mapConfigService{ints: map[string]int{
+			config.DeliveryMapperParallelism:       v,
+			config.DeliveryBlockProcessParallelism: v,
+		}})
+
+		assert.Equal(t, config.DefaultDeliveryMapperParallelism, c.DeliveryMapperParallelism(), "mapper %d must not be honoured", v)
+		assert.Equal(t, config.DefaultDeliveryBlockProcessParallelism, c.DeliveryBlockProcessParallelism(), "blockProcess %d must not be honoured", v)
+	}
+}
+
+// TestDeliveryHonoursExplicitZeroDisabledMode guards the capability #2320's review
+// insisted on keeping: lruSize/lruBuffer set to 0 select an unbounded cache and
+// listenerTimeout set to 0 makes the listener wait forever. Only an unset key falls
+// back to the default (see TestDeliveryDefaults), so a deliberate 0 must survive.
+func TestDeliveryHonoursExplicitZeroDisabledMode(t *testing.T) {
+	c := config.NewListenerManagerConfig(&mapConfigService{
+		ints:      map[string]int{config.DeliveryLRUSize: 0, config.DeliveryLRUBuffer: 0},
+		durations: map[string]time.Duration{config.DeliveryListenerTimeout: 0},
+	})
+
+	assert.Equal(t, 0, c.DeliveryLRUSize(), "explicit lruSize: 0 must reach the unbounded cache")
+	assert.Equal(t, 0, c.DeliveryLRUBuffer(), "explicit lruBuffer: 0 must reach the unbounded cache")
+	assert.Equal(t, time.Duration(0), c.DeliveryListenerTimeout(), "explicit listenerTimeout: 0 must disable the timeout")
+}
+
+// TestDeliveryRejectsNegativeDisabledMode confirms a negative value is treated as a
+// typo, not as the disabled mode: unlike an explicit 0, it falls back to the default.
+func TestDeliveryRejectsNegativeDisabledMode(t *testing.T) {
+	c := config.NewListenerManagerConfig(&mapConfigService{
+		ints:      map[string]int{config.DeliveryLRUSize: -1, config.DeliveryLRUBuffer: -1},
+		durations: map[string]time.Duration{config.DeliveryListenerTimeout: -time.Second},
+	})
+
+	assert.Equal(t, config.DefaultDeliveryLRUSize, c.DeliveryLRUSize(), "negative lruSize must fall back to the default")
+	assert.Equal(t, config.DefaultDeliveryLRUBuffer, c.DeliveryLRUBuffer(), "negative lruBuffer must fall back to the default")
+	assert.Equal(t, config.DefaultDeliveryListenerTimeout, c.DeliveryListenerTimeout(), "negative listenerTimeout must fall back to the default")
 }
 
 // TestStringReportsLedgerInfoBudget keeps the startup log line informative: the


### PR DESCRIPTION
Fixes #2060

### Summary

The five config getters on `serviceListenerManagerConfig` use inconsistent zero-handling: one correctly treats a configured `0` as "unset" and substitutes its default, while the other four return a literal `0` unchanged — indistinguishable from an operator who simply never set the key (`GetInt`/`GetDuration` on a missing key also return the zero value).

### Where

`token/services/network/fabric/config/config.go:51-89`:

```go
func (c *serviceListenerManagerConfig) DeliveryMapperParallelism() int {
    if v := c.c.GetInt(DeliveryMapperParallelism); v > 0 { return v }     // 0 falls through to default
    return DefaultDeliveryMapperParallelism
}
func (c *serviceListenerManagerConfig) DeliveryLRUSize() int {
    if v := c.c.GetInt(DeliveryLRUSize); v >= 0 { return v }   // 0 IS returned as-is
    return DefaultDeliveryLRUSize
}
```

`DeliveryMapperParallelism` treats a configured `0` as "unset" and substitutes the default (10), while `DeliveryBlockProcessParallelism`, `DeliveryLRUSize`, `DeliveryLRUBuffer`, and `DeliveryListenerTimeout` all use `>= 0` and therefore return a literal, explicit zero value unchanged when that's what's configured.

### Impact

Because `GetInt`/`GetDuration` on a missing config key return the zero value rather than a distinguishable "not set" sentinel, an operator who simply never sets `token.finality.delivery.lruSize`/`lruBuffer`/`listenerTimeout` (or `blockProcessParallelism`) gets a silent effective value of `0` instead of the documented default of 30/15/10s (or 10) — for the LRU size/buffer, a cache configured to hold zero entries; for the listener timeout, an instantly-expiring timeout. This is a "config typo/omission causes silent degradation to non-functional, not a clear error" class of bug, and the inconsistency between the getters (one clamps 0→default, the rest don't) means the safe behavior exists in the codebase already (in the sibling `DeliveryMapperParallelism` getter) but isn't applied uniformly.

### Reproduction

Reproduced locally with a table-driven unit test (not yet committed) across the three affected getters, each set to an explicit configured `0`, asserting the literal zero is returned rather than the documented default — plus a contrast test showing `DeliveryMapperParallelism`'s correct `> 0` guard does fall back as intended:

```go
fake := &fakeConfigService{ints: map[string]int{config.DeliveryLRUSize: 0}, ...}
cfg := config.NewListenerManagerConfig(fake)
got := cfg.DeliveryLRUSize()
assert.Equal(t, 0, got)                    // BUG: literal 0 returned, not DefaultDeliveryLRUSize (30)
assert.NotEqual(t, config.DefaultDeliveryLRUSize, got)
```

Happy to include this regression test in the fix PR.

### Suggested fix

Make `DeliveryBlockProcessParallelism`, `DeliveryLRUSize`, `DeliveryLRUBuffer`, and `DeliveryListenerTimeout` use the same `> 0` guard as `DeliveryMapperParallelism`, so a configured/defaulted `0` consistently falls back to the documented default across all five getters.

### Severity

MEDIUM — silent degradation to a non-functional cache/timeout on a common config omission, not a clear error.