### PR TITLE
network-driver: empty candidate-set entry silently "succeeds" with zero endorsers in SelectEndorsersForMSPSets

### DIFF
--- a/token/services/network/fabric/endorsement/fsc/selection.go
+++ b/token/services/network/fabric/endorsement/fsc/selection.go
@@ -33,9 +33,18 @@ import (
 //
 // It returns an error if none of the candidate sets can be fully covered by distinct
 // configured endorsers. The error names the first MSP that blocked each candidate set.
+//
+// An empty (but present) candidate set — one requiring no MSP at all — is rejected as
+// malformed policy input rather than treated as vacuously satisfied: a policy satisfiable
+// by zero endorsers would let a transaction be endorsed by nobody, so it must fail loudly.
 func SelectEndorsersForMSPSets(configured []view.Identity, mspOf func(view.Identity) (string, error), candidates [][]string) ([]view.Identity, error) {
 	if len(candidates) == 0 {
 		return nil, errors.Errorf("no candidate MSP set to satisfy the namespace endorsement policy")
+	}
+	for _, candidate := range candidates {
+		if len(candidate) == 0 {
+			return nil, errors.Errorf("malformed endorsement policy: a candidate MSP set requires no endorser, which would be satisfied by an empty selection")
+		}
 	}
 	var skipped []error
 	byMSP := make(map[string][]view.Identity)

--- a/token/services/network/fabric/endorsement/fsc/selection_test.go
+++ b/token/services/network/fabric/endorsement/fsc/selection_test.go
@@ -101,6 +101,24 @@ func TestSelectEndorsersForMSPSets(t *testing.T) {
 		assert.Contains(t, err.Error(), "no candidate MSP set")
 	})
 
+	t.Run("empty candidate set is rejected as malformed, not vacuously satisfied", func(t *testing.T) {
+		selected, err := fsc.SelectEndorsersForMSPSets([]view.Identity{org1Endorser1}, mspOf, [][]string{{}})
+
+		require.Error(t, err)
+		assert.Nil(t, selected)
+		assert.Contains(t, err.Error(), "requires no endorser")
+	})
+
+	t.Run("empty candidate set alongside a satisfiable one is still rejected", func(t *testing.T) {
+		configured := []view.Identity{org1Endorser1}
+
+		selected, err := fsc.SelectEndorsersForMSPSets(configured, mspOf, [][]string{{"Org1MSP"}, {}})
+
+		require.Error(t, err)
+		assert.Nil(t, selected)
+		assert.Contains(t, err.Error(), "requires no endorser")
+	})
+
 	t.Run("unsatisfiable - stale endorser check", func(t *testing.T) {
 		configured := []view.Identity{org1Endorser1, staleEndorser}
 		_, err := fsc.SelectEndorsersForMSPSets(configured, mspOf, [][]string{{"Org1MSP", "Org2MSP"}})


### PR DESCRIPTION
Fixes #2049

### Summary

A candidate-set entry that is present but lists zero required MSPs (an empty, non-nil `[]string`) is vacuously "satisfied" by `SelectEndorsersForMSPSets`: the inner loop over `requiredMSPIDs` never executes, so `satisfied` stays `true`, and the function returns success with zero selected endorsers and no error.

### Where

`token/services/network/fabric/endorsement/fsc/selection.go:39-53`

### Impact

If a degenerate/empty candidate set is ever produced upstream (a policy-evaluation bug, or a namespace with a misconfigured/empty endorsement policy), this function reports success without selecting any endorser — a transaction could proceed to be sent for endorsement to nobody, silently, rather than failing loudly on the malformed policy input.

### Reproduction

Reproduced locally with a unit test (not yet committed):

```go
candidates := [][]string{{}}
selected, err := fsc.SelectEndorsersForMSPSets([]view.Identity{org1Endorser1}, mspOf, candidates)
require.NoError(t, err)
assert.Len(t, selected, 0)
```

Happy to include this regression test in the fix PR.

### Suggested fix

Treat an empty (but present) candidate-set entry as invalid input and return an error, rather than vacuous success with zero endorsers.

### Severity

LOW