### PR TITLE
zkatdlog benchmark harness panics for -num_inputs > 2: prepareRedeemRequest hardcodes a 2-element owners slice

### DIFF
--- a/token/core/zkatdlog/nogh/v1/testutils/env.go
+++ b/token/core/zkatdlog/nogh/v1/testutils/env.go
@@ -704,11 +704,16 @@ func prepareRedeemRequest(
 		NumInputs:  benchCase.NumInputs,
 		NumOutputs: 2,
 	}
-	owners := make([][]byte, 2)
-	for i := range benchCase.NumInputs {
+	// owners holds the output owners: prepareTransferWithOpts consumes it indexed
+	// by NumOutputs (not NumInputs), so it must be sized by benchCaseRedeem.NumOutputs.
+	// The first output is the redeemed (nil-owner) output.
+	owners := make([][]byte, benchCaseRedeem.NumOutputs)
+	for i := range benchCaseRedeem.NumOutputs {
 		owners[i] = setupConfig.OwnerIdentity.ID
 	}
-	owners[0] = nil
+	if len(owners) > 0 {
+		owners[0] = nil
+	}
 
 	issuer := issue2.NewIssuer("ABC", setupConfig.IssuerSigner, pp)
 	issuerIdentity, err := setupConfig.IssuerSigner.Serialize()
@@ -755,11 +760,17 @@ func prepareOpenPolicyRedeemRequest(
 		NumInputs:  benchCase.NumInputs,
 		NumOutputs: 2,
 	}
-	owners := make([][]byte, 2)
-	for i := range benchCase.NumInputs {
+	// owners holds the output owners: prepareTransferWithOpts consumes it indexed
+	// by NumOutputs (not NumInputs), so it must be sized by benchCaseRedeem.NumOutputs.
+	// The first output is the redeemed (nil-owner) output.
+	owners := make([][]byte, benchCaseRedeem.NumOutputs)
+	for i := range benchCaseRedeem.NumOutputs {
 		owners[i] = setupConfig.OwnerIdentity.ID
 	}
-	owners[0] = nil
+
+	if len(owners) > 0 { // defensive
+		owners[0] = nil
+	}
 
 	return prepareTransfer(
 		benchCaseRedeem,

--- a/token/core/zkatdlog/nogh/v1/testutils/env_test.go
+++ b/token/core/zkatdlog/nogh/v1/testutils/env_test.go
@@ -74,6 +74,30 @@ func TestNewEnv(t *testing.T) {
 	}
 }
 
+// TestNewEnvManyInputs is a regression guard for issue #2024: prepareRedeemRequest
+// (built unconditionally by NewEnv) used to allocate a fixed 2-element owners slice
+// and index it by NumInputs, panicking for NumInputs > 2. The default benchmark
+// configuration pins NumInputs=2, so the standard run never exercised this. Here we
+// deliberately construct NewEnv with a 4-input case, which panics before the fix.
+func TestNewEnvManyInputs(t *testing.T) {
+	bits, err := sbenchmark.Bits(32)
+	require.NoError(t, err)
+	curves := sbenchmark.Curves(math.BN254)
+	configurations, err := benchmark.NewSetupConfigurations("./../testdata", bits, curves, idemixnym.IdentityType)
+	require.NoError(t, err)
+
+	for _, configuration := range configurations.Configurations {
+		_, err := NewEnv(&sbenchmark.Case{
+			Bits:       configuration.Bits,
+			CurveID:    configuration.CurveID,
+			NumInputs:  4,
+			NumOutputs: 1,
+		}, configurations)
+		require.NoError(t, err, "NewEnv must not panic or error for NumInputs > 2 [bits=%d,curveID=%d]",
+			configuration.Bits, configuration.CurveID)
+	}
+}
+
 func TestSaveTransferToFile(t *testing.T) {
 	metadata := &driver.TokenRequestMetadata{
 		Actions: []*driver.ActionMetadataEntry{


### PR DESCRIPTION
Fixes #2024

## Summary

`prepareRedeemRequest` allocates a fixed 2-element slice but indexes it by `NumInputs` (`token/core/zkatdlog/nogh/v1/testutils/env.go:698-702`):

```go
owners := make([][]byte, 2)
for i := range benchCase.NumInputs {
    owners[i] = setupConfig.OwnerIdentity.ID
}
owners[0] = nil
```

For `NumInputs > 2` this panics. `prepareRedeemRequest` is called unconditionally from `NewEnv` (`env.go:187`), so **every** benchmark built on that environment fails, not just redeem-focused ones.

## Reproduction

```
go test ./token/core/zkatdlog/nogh/v1/validator/ -run='^$' \
  -bench='BenchmarkValidatorTransfer' -benchtime=2x \
  -num_inputs=4 -num_outputs=1 -bits=64 -curves=BN254 -workers=1
```

```
panic: runtime error: index out of range [2] with length 2

goroutine 42 [running]:
.../testutils.prepareRedeemRequest(...)
	.../token/core/zkatdlog/nogh/v1/testutils/env.go:700 +0x1b4
.../testutils.NewEnv(...)
	.../token/core/zkatdlog/nogh/v1/testutils/env.go:187 +0x3f8
.../validator_test.BenchmarkValidatorTransfer.func1(...)
	.../token/core/zkatdlog/nogh/v1/validator/validator_test.go:122 +0x20
```

`-num_inputs=1,2` runs fine, which is why the default configuration never hits it: `GenerateCasesWithDefaults` (`token/services/benchmark/test.go:26`) pins `NumInputs(2)` and `NumOutputs(2)`, so the standard benchmark run only ever exercises the 2-input case.

Note the intent of the surrounding code is that `owners` is sized by input count (each input gets the owner identity, with `owners[0] = nil` marking the redeemed input), so the literal `2` looks like it was meant to track `NumInputs` — it coincidentally matches the hardcoded default. `NumOutputs` is separately pinned to `2` on the redeem case just above (`env.go:696`), which is deliberate and unrelated.

## Consequences

Per-input cost cannot be measured on the validation path. This matters because `TransferSignatureValidate` (`token/core/zkatdlog/nogh/v1/validator/validator_transfer.go:43-113`) performs one full Idemix signature verification **per input** on every endorser and validator, so validation cost is expected to scale linearly with input count. That scaling is currently unmeasurable beyond 2 inputs; the only available data point is the 2-input/2-output baseline at 14.29 ms/op (BN254, 32 bits).

The proving-side sweep works fine (`BenchmarkTransferProofGeneration` accepts `-num_inputs=1,2,3` without issue), so the gap is specific to benchmarks routed through `NewEnv`.

## Suggested direction

Size the slice by `benchCase.NumInputs`, and guard against `NumInputs == 0` before `owners[0] = nil`. A cheap regression guard would be running one benchmark case with `NumInputs > 2` in CI, or adding a unit test that constructs `NewEnv` with a 4-input case.

Related: #2017.