### PR TITLE
fix(core): run type-gated authorizations before the wallet-based one

### DIFF
--- a/docs/services/identity.md
+++ b/docs/services/identity.md
@@ -640,17 +640,19 @@ func (a *EscrowAuth) Issued(_ context.Context, _ driver.Identity, _ *token.Token
 func (a *EscrowAuth) OwnerType(raw []byte) (driver.IdentityType, []byte, error)        { ... }
 ```
 
-Register it in **both** driver files inside `NewAuthorizationMultiplexer`:
+Register it in `common.NewStandardAuthorization` (`token/core/common/authorization.go`), the chain both drivers use. Order matters: the multiplexer is first-match-wins and `NewTMSAuthorization` resolves *any* identity bound to a wallet — including composite identities — so it would claim the token under the wrong wallet id and drop its ownership entries. Every type-gated authorization must therefore be registered **before** the trailing `NewTMSAuthorization` catch-all (regression: `TestAuthorizationOrder_BoundPolicyIdentity` in `token/services/ttx/boolpolicy/auth_test.go`).
 
 ```go
-// token/core/fabtoken/v1/driver/driver.go  (and the zkatdlog equivalent)
-authorization := common.NewAuthorizationMultiplexer(
-    common.NewTMSAuthorization(...),
-    htlc.NewScriptAuth(ws),
-    multisig.NewEscrowAuth(ws),
-    boolpolicy.NewEscrowAuth(ws),
-    mynew.NewEscrowAuth(ws),   // ← add here
-)
+// token/core/common/authorization.go
+func NewStandardAuthorization(logger logging.Logger, publicParameters driver.PublicParameters, walletService driver.WalletService) *AuthorizationMultiplexer {
+	return NewAuthorizationMultiplexer(
+		htlc.NewScriptAuth(walletService),
+		multisig.NewEscrowAuth(walletService),
+		boolpolicy.NewEscrowAuth(walletService),
+		mynew.NewEscrowAuth(walletService), // ← add here, before the wallet-based catch-all
+		NewTMSAuthorization(logger, publicParameters, walletService),
+	)
+}
 ```
 
 #### Step 6 — Add a wallet wrapper

--- a/token/core/common/authorization.go
+++ b/token/core/common/authorization.go
@@ -12,7 +12,10 @@ import (
 	"github.com/LFDT-Panurus/panurus/token"
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/token/services/ttx/boolpolicy"
+	"github.com/LFDT-Panurus/panurus/token/services/ttx/multisig"
 	token2 "github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
@@ -88,6 +91,19 @@ type AuthorizationMultiplexer struct {
 // NewAuthorizationMultiplexer returns a new AuthorizationMultiplexer for the passed ownership checkers
 func NewAuthorizationMultiplexer(ownerships ...Authorization) *AuthorizationMultiplexer {
 	return &AuthorizationMultiplexer{authorizations: ownerships}
+}
+
+// NewStandardAuthorization returns the authorization chain used by the token
+// drivers. Type-gated authorizations go first: the wallet-based one resolves
+// any identity bound to a wallet, so it would claim escrow-typed tokens under
+// the wrong wallet id and drop their ownership entries.
+func NewStandardAuthorization(logger logging.Logger, publicParameters driver.PublicParameters, walletService driver.WalletService) *AuthorizationMultiplexer {
+	return NewAuthorizationMultiplexer(
+		htlc.NewScriptAuth(walletService),
+		multisig.NewEscrowAuth(walletService),
+		boolpolicy.NewEscrowAuth(walletService),
+		NewTMSAuthorization(logger, publicParameters, walletService),
+	)
 }
 
 // IsMine returns true it there exists an authorization checker that returns true

--- a/token/core/fabtoken/v1/driver/driver.go
+++ b/token/core/fabtoken/v1/driver/driver.go
@@ -15,10 +15,7 @@ import (
 	v1setup "github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/setup"
 	"github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/validator"
 	"github.com/LFDT-Panurus/panurus/token/driver"
-	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
-	"github.com/LFDT-Panurus/panurus/token/services/ttx/boolpolicy"
-	"github.com/LFDT-Panurus/panurus/token/services/ttx/multisig"
 	"github.com/LFDT-Panurus/panurus/token/services/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
@@ -150,12 +147,7 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 	deserializer := ws.Deserializer
 	ip := ws.IdentityProvider
 
-	authorization := common.NewAuthorizationMultiplexer(
-		common.NewTMSAuthorization(logger, publicParamsManager.PublicParams(), ws),
-		htlc.NewScriptAuth(ws),
-		multisig.NewEscrowAuth(ws),
-		boolpolicy.NewEscrowAuth(ws),
-	)
+	authorization := common.NewStandardAuthorization(logger, publicParamsManager.PublicParams(), ws)
 	tokensService, err := v1.NewTokensService(publicParamsManager.PublicParams(), deserializer)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to initialize token service for [%s:%s]", tmsID.Network, tmsID.Namespace)

--- a/token/core/zkatdlog/nogh/v1/driver/driver.go
+++ b/token/core/zkatdlog/nogh/v1/driver/driver.go
@@ -17,10 +17,7 @@ import (
 	v1token "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/validator"
 	"github.com/LFDT-Panurus/panurus/token/driver"
-	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
-	"github.com/LFDT-Panurus/panurus/token/services/ttx/boolpolicy"
-	"github.com/LFDT-Panurus/panurus/token/services/ttx/multisig"
 	"github.com/LFDT-Panurus/panurus/token/services/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
@@ -152,12 +149,7 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 	deserializer := ws.Deserializer
 	ip := ws.IdentityProvider
 
-	authorization := common.NewAuthorizationMultiplexer(
-		common.NewTMSAuthorization(logger, ppm.PublicParams(), ws),
-		htlc.NewScriptAuth(ws),
-		multisig.NewEscrowAuth(ws),
-		boolpolicy.NewEscrowAuth(ws),
-	)
+	authorization := common.NewStandardAuthorization(logger, ppm.PublicParams(), ws)
 
 	tokensService, err := v1token.NewTokensService(logger, ppm, deserializer)
 	if err != nil {

--- a/token/services/ttx/boolpolicy/auth_test.go
+++ b/token/services/ttx/boolpolicy/auth_test.go
@@ -9,17 +9,20 @@ SPDX-License-Identifier: Apache-2.0
 package boolpolicy_test
 
 import (
+	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/core/common"
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	drivermock "github.com/LFDT-Panurus/panurus/token/driver/mock"
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	identityboolpolicy "github.com/LFDT-Panurus/panurus/token/services/identity/boolpolicy"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	"github.com/LFDT-Panurus/panurus/token/services/ttx/boolpolicy"
 	token2 "github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -169,4 +172,55 @@ func TestEscrowAuth_IsMine_AllComponentsMine(t *testing.T) {
 	assert.Contains(t, ids, "policyw1")
 	assert.Contains(t, ids, "policyw2")
 	assert.True(t, isMine)
+}
+
+// ---------------------------------------------------------------------------
+// Authorization order — regression for bound policy identities
+// ---------------------------------------------------------------------------
+
+// TestAuthorizationOrder_BoundPolicyIdentity checks that the drivers' chain
+// (common.NewStandardAuthorization) still attributes a policy token to the
+// member's policy wallet once its composite identity is bound to a wallet.
+func TestAuthorizationOrder_BoundPolicyIdentity(t *testing.T) {
+	tok := makePolicyToken(t, "$0", []byte("alice"))
+
+	memberOW := &drivermock.OwnerWallet{}
+	memberOW.IDReturns("w1")
+	boundOW := &drivermock.OwnerWallet{}
+	boundOW.IDReturns("baseWallet")
+
+	mockWS := &drivermock.WalletService{}
+	mockWS.OwnerWalletCalls(func(_ context.Context, id driver.WalletLookupID) (driver.OwnerWallet, error) {
+		raw, ok := id.([]byte)
+		if !ok {
+			return nil, errors.New("not found")
+		}
+		switch {
+		case string(raw) == "alice":
+			return memberOW, nil
+		case bytes.Equal(raw, tok.Owner):
+			// The bound composite identity resolves to the base wallet.
+			return boundOW, nil
+		}
+
+		return nil, errors.New("not found")
+	})
+
+	pp := &drivermock.PublicParameters{}
+	pp.AuditorsReturns(nil)
+
+	auth := common.NewStandardAuthorization(logging.MustGetLogger(), pp, mockWS)
+
+	walletID, ids, isMine := auth.IsMine(t.Context(), tok)
+	assert.True(t, isMine)
+	assert.Empty(t, walletID)
+	require.Len(t, ids, 1)
+	assert.Equal(t, "policyw1", ids[0])
+
+	// The wallet-based authorization alone would claim the token under the
+	// base wallet id with no ownership ids.
+	walletID, ids, isMine = common.NewTMSAuthorization(logging.MustGetLogger(), pp, mockWS).IsMine(t.Context(), tok)
+	assert.True(t, isMine)
+	assert.Equal(t, "baseWallet", walletID)
+	assert.Empty(t, ids)
 }


### PR DESCRIPTION
## Motivation

`AuthorizationMultiplexer.IsMine` is first-match-wins, and both drivers registered the generic `WalletBasedAuthorization` before the type-gated authorizations. Once a boolpolicy composite identity gets bound to a wallet — `AnonymousOwnerWallet.RegisterRecipient` does this when the rest of a transfer goes back to the wallet's own policy identity — the wallet-based authorization starts resolving that identity and claims every subsequent token first, returning the base wallet id and **no ownership ids**. `StoreToken` writes ownership rows only from the ids slice, so those tokens land in the store without any ownership row, under a wallet id the policy wallet's selector never queries (`<id>` instead of `policy<id>`).

The observable failure in our test environments: an anonymous-identity policy wallet works normally until its first outgoing transfer; from then on every incoming token (rest or deposit) is invisible to the selector, so the balance reports funds while any transfer fails with "insufficient funds". The failure is deterministic — before the bind the very same owner bytes are attributed correctly through `boolpolicy.EscrowAuth`, after the bind they never are. Wallets backed by long-term identities are unaffected because their `RegisterRecipient` accepts the policy rest recipient without binding (#2268).

## Change

Extract the drivers' authorization chain into a single shared constructor, `common.NewStandardAuthorization`, which registers the type-gated authorizations (`htlc.ScriptAuth`, `multisig.EscrowAuth`, `boolpolicy.EscrowAuth`) before `common.NewTMSAuthorization`, and use it from both the fabtoken and zkatdlog drivers, so the ordering has exactly one definition. Each type-gated authorization rejects foreign owner types up front, so the reorder is inert for plain tokens; escrow-typed tokens are always attributed by the authorization that understands their owner type, whether or not the composite identity has been bound to a wallet.

The identity guide's "add a new identity type" registration example taught the generic-first order; it now shows the shared constructor and spells out that the wallet-based catch-all must stay last.

## Testing

- New regression test (`token/services/ttx/boolpolicy/auth_test.go`) exercises the same constructor the drivers use (`common.NewStandardAuthorization`) and replays the failure mode: a policy token whose composite identity resolves to a wallet must still be attributed to the member's policy wallet (`policy<id>` ownership ids), and the test also pins the wrong answer the wallet-based authorization alone would give, which the specific-first order exists to preempt. Reintroducing the generic-first order in the shared constructor turns the test red.
- `gofmt`, `go build ./token/...`, `go vet`, `go test -race` over the touched packages, and golangci-lint (repo config) all pass locally.

Fixes #2328
