### PR TITLE
fix(zkatdlog): populate OutputAuditInfo in BenchmarkAuditorServiceCheck setup

### DIFF
--- a/token/core/zkatdlog/nogh/v1/benchmark/auditor_setup.go
+++ b/token/core/zkatdlog/nogh/v1/benchmark/auditor_setup.go
@@ -84,7 +84,8 @@ func NewAuditCheckSetup(conf *SetupConfiguration) (*AuditCheckSetup, error) {
 					},
 					Outputs: []*driver.IssueOutputMetadata{
 						{
-							OutputMetadata: metaBytes,
+							OutputMetadata:  metaBytes,
+							OutputAuditInfo: conf.OwnerIdentity.AuditInfo,
 							Receivers: []*driver.AuditableIdentity{
 								{
 									Identity:  conf.OwnerIdentity.ID,


### PR DESCRIPTION
## Summary

- `NewAuditCheckSetup` (`token/core/zkatdlog/nogh/v1/benchmark/auditor_setup.go`) only set
  `Receivers[0].AuditInfo` on the issue output metadata it builds. `AuditorService.AuditorCheck`
  reads a *separate* field, `IssueOutputMetadata.OutputAuditInfo`
  (`token/core/zkatdlog/nogh/v1/audit/auditor.go::validateIssueOutputs` /
  `InspectOutput` / `InspectIdentity`), which was left nil.
- Every call to `BenchmarkAuditorServiceCheck`/`TestParallelBenchmarkAuditorServiceCheck` therefore
  failed with `failed to inspect identity at index [0]: audit info is nil` — the benchmark never
  produced a usable measurement.
- Fix: also set `OutputAuditInfo` on the constructed `IssueOutputMetadata`, matching what
  production issue flows populate.
- Verified locally (targeted benchmark run + full package `go test`) and end-to-end via PerfLab's
  real Tier-1 pipeline on `dectrust22`, which is what surfaced this bug during PerfLab host
  verification.

Closes #2330

## Test plan

- [x] `go test ./token/core/zkatdlog/nogh/v1 -bench=^BenchmarkAuditorServiceCheck$ -benchmem -count=1 -cpu=1 -timeout 0 -run=^$`
- [x] `go test ./token/core/zkatdlog/nogh/v1/... -count=1 -timeout=180s` (full package, no regressions)
- [x] Confirmed via PerfLab Tier-1 run against this commit on `dectrust22` — benchmark completes and reports real timings