### PR TITLE
token-validation-benchmark.yml references a companion comment workflow that does not exist

### DIFF
--- a/.github/workflows/token-validation-benchmark.yml
+++ b/.github/workflows/token-validation-benchmark.yml
@@ -32,11 +32,11 @@ on:
   # code, so this workflow runs on `pull_request`, NOT `pull_request_target`:
   # fork PRs run in the fork's untrusted context with a read-only GITHUB_TOKEN
   # and no access to secrets, and `actions/checkout` pulls the fork's PR code
-  # directly (no `allow-unsafe-pr-checkout` needed). This workflow only produces
-  # artifacts; posting the PR comment happens in the companion
-  # `token-validation-benchmark-comment.yml`, which runs on `workflow_run` in the
-  # trusted base-repo context and therefore has `pull-requests: write` even for
-  # fork PRs.
+  # directly (no `allow-unsafe-pr-checkout` needed). For same-repo PRs the
+  # compare job posts the PR comment itself (it runs trusted base-repo code with
+  # a write-capable token). For fork PRs the token is read-only, so no comment
+  # can be posted: the compare job's comment step fails harmlessly and the
+  # benchmark report is only available in the job log.
   pull_request:
   workflow_dispatch:
 
@@ -44,8 +44,8 @@ on:
 # have a write-capable token. pull-requests: write is scoped per-job on the
 # compare job (below). Under `pull_request` that write scope is effective only
 # for same-repo PRs; for fork PRs the token stays read-only, so the compare
-# job's comment step fails harmlessly (it is continue-on-error) and the
-# companion workflow_run workflow posts the comment from the trusted context.
+# job's comment step fails harmlessly (it is continue-on-error) and no comment
+# is posted — the report is available only in the compare job's log.
 permissions:
   contents: read
 
@@ -199,9 +199,10 @@ jobs:
     # trusted base-repo code (it never checks out or executes PR head code). The
     # benchmark job keeps the read-only default token. On fork PRs the token is
     # read-only regardless, so the comment step below cannot post — that is why
-    # the comment step itself is continue-on-error and the companion workflow_run
-    # workflow handles commenting for forks. The job as a whole is NOT
-    # continue-on-error: a detected regression fails it (see the final step).
+    # the comment step itself is continue-on-error; no comment is posted for fork
+    # PRs and the report is available only in this job's log. The job as a whole
+    # is NOT continue-on-error: a detected regression fails it (see the final
+    # step).
     permissions:
       contents: read
       pull-requests: write
@@ -252,8 +253,8 @@ jobs:
           esac
 
       # Only comment when there is a regression to report. On fork PRs the token
-      # is read-only and this step cannot post, so it is continue-on-error; the
-      # companion workflow_run workflow handles commenting for forks.
+      # is read-only and this step cannot post, so it is continue-on-error; no
+      # comment is posted for fork PRs (the report stays in this job's log).
       - name: Post comparison comment
         if: steps.report.outputs.degraded == 'true'
         continue-on-error: true


### PR DESCRIPTION
Fixes #2303

## Problem

`token-validation-benchmark.yml` runs the token-validation benchmark on every `pull_request` and compares HEAD against the base branch. For a same-repo PR, the compare job posts the percentage-diff comment itself via `gh pr comment` (scoped `pull-requests: write`). For a fork PR, that token is read-only, so the workflow's own comments (lines 36-38, 44-48, 201-203, 254-256) say a companion workflow — `token-validation-benchmark-comment.yml`, running on `workflow_run` in the trusted base-repo context with write access — posts the comment instead.

That companion workflow file does not exist anywhere in `.github/workflows/`.

## Impact

Fork PRs are the common contribution path for this repo (external contributors, e.g. `Built-by-Sign`, `atharrva01`). On a fork PR, the benchmark job still runs and still fails the job outright if it detects a regression, but the informational PR comment step is `continue-on-error` and its token is read-only — so on a fork PR today, no comment is ever posted, regardless of whether a regression was detected. A reviewer relying on "no PR comment = no regression" draws the wrong conclusion; the actual result is only visible by opening the job's own log/artifact directly, which is easy to miss since the workflow's own docs describe a comment that should have appeared.