### PR TITLE
CI: run linter in parallel with integration tests (keep fail-fast) to cut critical-path latency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,36 @@ jobs:
       - name: Run checks
         run: make checks
 
+  # Style linting (golangci-lint) is independent of correctness, so it runs as
+  # its own job in parallel with utest/itest/bench-check rather than sitting on
+  # their critical path. Nothing depends on it: the compile-heavy linter no
+  # longer delays the start of the ~70-job integration matrix.
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: "go.mod"
+          cache-dependency-path: "**/*.sum"
+
+      - name: Replace FSC dep
+        run: |
+          if [ -n "${{ github.event.inputs.fsc-version }}" ]; then
+            echo "Replace FSC dependency"
+            go mod edit -replace=github.com/hyperledger-labs/fabric-smart-client=${{ github.event.inputs.fsc-version }}
+            go mod tidy || true
+          else
+            echo "Skipping FSC dependency replacement"
+          fi
+
+      - name: Set up tools
+        run: make install-tools
+
       - name: Run linter
         run: make lint
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,12 +47,13 @@ jobs:
         run: make install-tools
 
       - name: Run checks
-        run: make checks
+        run: make checks-fast
 
-  # Style linting (golangci-lint) is independent of correctness, so it runs as
-  # its own job in parallel with utest/itest/bench-check rather than sitting on
-  # their critical path. Nothing depends on it: the compile-heavy linter no
-  # longer delays the start of the ~70-job integration matrix.
+  # Compile-heavy analysis (staticcheck, go vet, go fix, golangci-lint) is
+  # independent of correctness, so it runs as its own job in parallel with
+  # utest/itest/bench-check rather than sitting on their critical path. Nothing
+  # depends on it: these ~5m of type-checking no longer delay the start of the
+  # ~70-job integration matrix, which now gates only on the fast textual checks.
   lint:
     runs-on: ubuntu-latest
 
@@ -78,6 +79,9 @@ jobs:
 
       - name: Set up tools
         run: make install-tools
+
+      - name: Run heavy checks
+        run: make checks-heavy
 
       - name: Run linter
         run: make lint

--- a/checks.mk
+++ b/checks.mk
@@ -1,5 +1,16 @@
 .PHONY: checks
-checks: licensecheck gofmt goimports govet gofix misspell ineffassign staticcheck protos-lint buf-format tidy-check
+checks: checks-fast checks-heavy
+
+.PHONY: checks-fast
+# fast, purely textual checks (no compilation) — cheap enough to gate the
+# integration-test matrix on. Run in CI's 'checks' job.
+checks-fast: licensecheck gofmt goimports misspell ineffassign protos-lint buf-format tidy-check
+
+.PHONY: checks-heavy
+# compile-heavy static analysis (invokes the Go type-checker across all
+# modules). Kept off the integration-test critical path — run in CI's parallel
+# 'lint' job alongside golangci-lint.
+checks-heavy: govet gofix staticcheck
 
 .PHONY: checks-no-tidy
 # same as 'checks' but without tidy-check; for use after a workflow step that


### PR DESCRIPTION
Fixes #2342

### Problem

In `.github/workflows/tests.yml`, a single `checks` job runs **both** `make checks` (license, gofmt, goimports, govet, gofix, misspell, ineffassign, `staticcheck`, protos-lint, buf-format, tidy-check) **and** `make lint` (`golangci-lint --timeout=4m` across 9 Go modules) sequentially. `utest`, `itest`, and `bench-check` all declare `needs: checks`.

As a result, the compile-heavy linters (`staticcheck`, `golangci-lint`) sit on the **critical path**: the entire lint duration is paid as pure latency *before* the ~70-job `itest` matrix can start, even though lint (style) and integration tests (correctness) are independent concerns.

### Impact

- Every CI run — including the common case where nothing is wrong — pays the full lint duration up front before any integration test begins.
- Estimated ~3–6 min (~10–17%) of the ~35-min pipeline is this serial gate latency (to be confirmed by timing the `make lint` vs `make checks` steps).

### Desired outcome / acceptance criteria

- Slow, compile-dependent lint runs **in parallel** with the integration tests rather than gating them, so the itest matrix starts after only a fast, second-scale gate (gofmt/goimports/license/misspell/buf-format/tidy-check).
- A **fail-fast** mechanism is preserved so a lint failure does not let the full ~70-job matrix run to completion and waste runner-minutes (e.g. a canceller keyed on lint failure, or a cheap compile gate kept ahead of itest).
- The tradeoff between happy-path latency saved and runner-minutes spent on lint-failing PRs is considered and documented in the workflow.
- Independently: the `golangci-lint` binary (currently curl-installed per run) and its analysis cache are cached.