### PR TITLE
docs: OpenSSF Compliance badge point to out of date badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202-blue" alt="License"></a>
-  <a href="https://www.bestpractices.dev/projects/7176"><img src="https://www.bestpractices.dev/projects/7176/badge" alt="OpenSSF Best Practices"></a>
+  <a href="https://www.bestpractices.dev/projects/14554"><img src="https://www.bestpractices.dev/projects/14554/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://goreportcard.com/badge/github.com/LFDT-Panurus/panurus"><img src="https://goreportcard.com/badge/github.com/LFDT-Panurus/panurus" alt="Go Report Card"></a>
   <a href="https://github.com/LFDT-Panurus/panurus/actions/workflows/tests.yml"><img src="https://github.com/LFDT-Panurus/panurus/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests"></a>
   <a href="https://github.com/LFDT-Panurus/panurus/actions/workflows/codeql-analysis.yml"><img src="https://github.com/LFDT-Panurus/panurus/actions/workflows/codeql-analysis.yml/badge.svg?branch=main" alt="CodeQL"></a>

--- a/docs/openssf/README.md
+++ b/docs/openssf/README.md
@@ -40,7 +40,7 @@ and only the first one is assessed here.
 | Program | Identifiers | Levels | Used here |
 |---------|-------------|--------|-----------|
 | [OSPS Baseline](https://baseline.openssf.org) | `OSPS-<CATEGORY>-<NN>.<NN>` | Level 1, Level 2, Level 3 | Yes — the pages below |
-| [Best Practices Badge](https://www.bestpractices.dev) | free-form criteria | passing, silver, gold | No — tracked separately in the project's [badge entry](https://www.bestpractices.dev/en/projects/7176) |
+| [Best Practices Badge](https://www.bestpractices.dev) | free-form criteria | passing, silver, gold | No — tracked separately in the project's [badge entry](https://www.bestpractices.dev/en/projects/14554) |
 
 The OSPS Baseline levels are *not* named "passing", "silver" or "gold" — those are Best Practices
 Badge tiers. Baseline levels are scoped by project size instead:
@@ -141,7 +141,7 @@ The assessment converges on a small number of themes rather than 20 unrelated it
 5. Open a GitHub issue for every control that moves to, or stays at, **Not Met**, and reference the
    control identifier in the issue so progress stays traceable.
 6. If the project also wants credit on the Best Practices Badge, update
-   [project 7176](https://www.bestpractices.dev/en/projects/7176) separately — the two programs do
+   [project 14554](https://www.bestpractices.dev/en/projects/14554) separately — the two programs do
    not share data.
 
 ## Related documentation


### PR DESCRIPTION
Fixes #2350

_Related to https://github.com/LFDT-Panurus/panurus/issues/1626_

The `README.md` points to old OpenSSF compliance badge:  https://www.bestpractices.dev/projects/7176/badge

This is a `fabric-token-sdk` badge from march. 

## Fix 
point it to https://www.bestpractices.dev/en/projects/14554